### PR TITLE
Fix frame holding mechanism

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chaos-master",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "WebGPU based IFS Flame Generator for Artists & Explorers",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
We need this mechanism in order to not over-queue GPU work. However, the previous implementation was wrong as it introduced `async` into the render loop. This time, we use a `Set` to keep track of pending frames while the usual render loop stays sync.