### PR TITLE
Compress undo system preview patches, commit on slider pointer release instead of onChange

### DIFF
--- a/packages/app/src/components/Sliders/ParametricEditors/AngleEditor.module.css
+++ b/packages/app/src/components/Sliders/ParametricEditors/AngleEditor.module.css
@@ -26,6 +26,7 @@
   border: 2px solid rgba(255, 255, 255, 0.2);
   cursor: pointer;
   outline: none;
+  touch-action: none;
 
   /* when scrolling into view on change, how much to over-scroll */
   scroll-margin-block: 8rem;

--- a/packages/app/src/components/Sliders/Slider.tsx
+++ b/packages/app/src/components/Sliders/Slider.tsx
@@ -1,5 +1,6 @@
 import { createMemo, Show } from 'solid-js'
 import { useChangeHistory } from '@/contexts/ChangeHistoryContext'
+import { createDragHandler } from '@/utils/createDragHandler'
 import { scrollIntoViewAndFocusOnChange } from '@/utils/scrollIntoViewOnChange'
 import ui from './Slider.module.css'
 
@@ -30,6 +31,20 @@ export function Slider(props: SliderProps) {
     return ((value() - min()) / range) * 100
   }
 
+  // Dragging the slider handle is handled by the browser,
+  // but we still want to startPreview and commit to history once.
+  const commitHandler = createDragHandler(
+    () => {
+      history.startPreview(`Edit ${props.label}`)
+      return {
+        onDone() {
+          history.commit()
+        },
+      }
+    },
+    { preventDefault: false },
+  )
+
   return (
     <label class={ui.label} classList={{ [props.class ?? '']: true }}>
       <Show when={label()}>
@@ -45,15 +60,9 @@ export function Slider(props: SliderProps) {
         max={max()}
         step={step()}
         value={value()}
+        onPointerDown={commitHandler}
         onInput={(ev) => {
-          if (!history.isPreviewing()) {
-            history.startPreview(`Edit ${props.label}`)
-          }
           props.onInput(ev.target.valueAsNumber)
-        }}
-        onChange={(ev) => {
-          props.onInput(ev.target.valueAsNumber)
-          history.commit()
         }}
         style={{
           '--fill-percent': `${(props.trackFill ?? true) ? fillPercentage() : 0}%`,

--- a/packages/app/src/utils/assertArray.ts
+++ b/packages/app/src/utils/assertArray.ts
@@ -1,0 +1,28 @@
+/**
+ * Type guard to make sure an array has at least one element,
+ * so it can be indexed into using `[0]` or unpacked like:
+ * ```
+ * let array: number[]
+ * if (hasAtLeastOneElement(array)) {
+ *   const [first, ...rest] = array
+ *   // first is number, not number | undefined
+ * }
+ * ```
+ */
+export function hasAtLeastOneElement<T>(array: T[]): array is [T, ...T[]] {
+  return array.length > 0
+}
+/**
+ * Type guard to make sure an array has exactly one element,
+ * so it can be indexed into using `[0]` or unpacked like:
+ * ```
+ * let array: number[]
+ * if (hasExactlyOneElement(array)) {
+ *   const [first] = array
+ *   // first is number, not number | undefined
+ * }
+ * ```
+ */
+export function hasExactlyOneElement<T>(array: T[]): array is [T] {
+  return array.length > 0
+}

--- a/packages/app/src/utils/compressPatches.test.ts
+++ b/packages/app/src/utils/compressPatches.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+import {
+  compressPatches,
+  forwardBackwardPatchPairDoesNothing,
+} from './compressPatches'
+import type { Patch } from 'structurajs'
+
+describe('compressPatches', () => {
+  it('removes repeating replace patches', () => {
+    const patches: Patch[] = [
+      { op: 'replace', path: ['a', 'b', 'c'], value: 5 },
+      { op: 'replace', path: ['a', 'b', 'c'], value: 6 },
+      { op: 'replace', path: ['a', 'b', 'c'], value: 7 },
+      { op: 'replace', path: ['a', 'b', 'c'], value: 8 },
+    ]
+    expect(compressPatches(patches)).toEqual([
+      {
+        op: 'replace',
+        path: ['a', 'b', 'c'],
+        value: 8,
+      },
+    ])
+  })
+
+  it('does nothing for []', () => {
+    expect(compressPatches([])).toEqual([])
+  })
+
+  it('keeps unrelated patches', () => {
+    const patches: Patch[] = [
+      { op: 'replace', path: ['a', 'b', 'b'], value: 0 },
+      { op: 'replace', path: ['a', 'b', 'c'], value: 6 },
+      { op: 'replace', path: ['a', 'b', 'c'], value: 7 },
+      { op: 'replace', path: ['a', 'b', 'c'], value: 8 },
+    ]
+    expect(compressPatches(patches)).toEqual([
+      {
+        op: 'replace',
+        path: ['a', 'b', 'b'],
+        value: 0,
+      },
+      {
+        op: 'replace',
+        path: ['a', 'b', 'c'],
+        value: 8,
+      },
+    ])
+  })
+})
+
+describe('forwardBackwardPatchPairDoesNothing', () => {
+  it('works in the basic case', () => {
+    expect(
+      forwardBackwardPatchPairDoesNothing(
+        [{ op: 'replace', path: ['a'], value: 3 }],
+        [{ op: 'replace', path: ['a'], value: 3 }],
+      ),
+    ).toBe(true)
+    expect(
+      forwardBackwardPatchPairDoesNothing(
+        [{ op: 'replace', path: ['a'], value: 3 }],
+        [{ op: 'replace', path: ['a'], value: 4 }],
+      ),
+    ).toBe(false)
+  })
+
+  it(`ignores changes which are not 'replace'`, () => {
+    expect(
+      forwardBackwardPatchPairDoesNothing(
+        [{ op: 'add', path: ['a'], value: 3 }],
+        [{ op: 'add', path: ['a'], value: 3 }],
+      ),
+    ).toBe(false)
+  })
+})

--- a/packages/app/src/utils/compressPatches.ts
+++ b/packages/app/src/utils/compressPatches.ts
@@ -1,0 +1,60 @@
+import { hasAtLeastOneElement, hasExactlyOneElement } from './assertArray'
+import type { Patch } from 'structurajs'
+
+const { isArray } = Array
+
+/**
+ * Given a list of patches, throws out redundant consecutive `replace` patches
+ * to the same path and keeps the last one.
+ *
+ * This solves the most common case of changing a single value over time
+ * but wanting to store only the last change.
+ */
+export function compressPatches(patches: Patch[]): Patch[] {
+  if (!hasAtLeastOneElement(patches)) {
+    return []
+  }
+  const [first, ...rest] = patches
+  const output = [first]
+  for (const patch of rest) {
+    const last = output.at(-1)!
+    if (
+      patch.op === 'replace' &&
+      last.op === 'replace' &&
+      isArray(patch.path) &&
+      isArray(last.path) &&
+      patch.path.join(',') === last.path.join(',')
+    ) {
+      output[output.length - 1] = patch
+    } else {
+      output.push(patch)
+    }
+  }
+  return output
+}
+
+/**
+ * This only solves the most basic case of changing the same path
+ * from one value to the same value (not changing it).
+ */
+export function forwardBackwardPatchPairDoesNothing(
+  forwardPatches: Patch[],
+  backwardPatches: Patch[],
+) {
+  if (
+    !hasExactlyOneElement(forwardPatches) ||
+    !hasExactlyOneElement(backwardPatches)
+  ) {
+    return false
+  }
+  const [forwardPatch] = forwardPatches
+  const [backwardPatch] = backwardPatches
+  return (
+    forwardPatch.op === 'replace' &&
+    backwardPatch.op === 'replace' &&
+    isArray(forwardPatch.path) &&
+    isArray(backwardPatch.path) &&
+    forwardPatch.path.join(',') === backwardPatch.path.join(',') &&
+    forwardPatch.value === backwardPatch.value
+  )
+}

--- a/packages/app/src/utils/createDragHandler.ts
+++ b/packages/app/src/utils/createDragHandler.ts
@@ -16,7 +16,7 @@ function manhattanDistance(p1: Point, p2: Point) {
 
 type Options = {
   deadZoneRadius?: number
-  setActive?: (active: boolean) => void
+  preventDefault?: boolean
 }
 
 /**
@@ -46,7 +46,7 @@ type Options = {
  */
 export function createDragHandler(
   createHandlers: CreateClickAndDragHandler,
-  { deadZoneRadius = 0, setActive }: Options = {},
+  { deadZoneRadius = 0, preventDefault = true }: Options = {},
 ) {
   const unmountController = new AbortController()
   const unmountSignal = unmountController.signal
@@ -69,22 +69,27 @@ export function createDragHandler(
     const handlers = createHandlers(initEvent)
     if (!handlers) return
 
-    initEvent.preventDefault()
-    initEvent.stopImmediatePropagation()
+    if (preventDefault) {
+      initEvent.preventDefault()
+      initEvent.stopImmediatePropagation()
+    }
+
     if (
       initEvent.target instanceof HTMLElement ||
       initEvent.target instanceof SVGElement
     ) {
       initEvent.target.setPointerCapture(initEvent.pointerId)
     }
-    setActive?.(true)
 
     const { onPointerMove, onDone } = handlers
     let moved = false
 
     function onPointerMove_(event: PointerEvent) {
-      event.preventDefault()
-      event.stopImmediatePropagation()
+      if (preventDefault) {
+        event.preventDefault()
+        event.stopImmediatePropagation()
+      }
+
       if (moved || manhattanDistance(initEvent, event) >= deadZoneRadius) {
         onPointerMove?.(event)
         moved = true
@@ -100,11 +105,10 @@ export function createDragHandler(
       event?.preventDefault()
       event?.stopImmediatePropagation()
       onDone?.()
-      setActive?.(false)
     }
 
     function preventDefaultIfMoved(event: Event) {
-      if (moved) {
+      if (moved && preventDefault) {
         event.preventDefault()
         event.stopImmediatePropagation()
       }


### PR DESCRIPTION
Three behavior changes are implemented:
- we did not compress changes before, so undo / redo commits would contain many redundant patches, namely repeated `replace` patches to the same path. Now they contain only one `Patch` in this case.
- if the change does nothing, we don't commit it to history, i.e. user moves the slider around but ends in the same place as started.
- the slider used `onChange` in order to commit history, however this event is not called when input doesn't actually change, so in some cases the history was never commited, causing `startPreview` to fail next time.

Related to #40 