### PR TITLE
Add valibot validation for import/export

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -44,7 +44,7 @@ export default tseslint.config(
       // this is caught by ts already and eslint doesn't understand @/
       'import-x/no-unresolved': 'off',
 
-      'no-console': ['error', { allow: ['info', 'warn', 'error'] }],
+      'no-console': ['error', { allow: ['info', 'warn', 'error', 'table'] }],
       'no-throw-literal': 'error',
       'no-useless-concat': 'error',
       'prefer-template': 'error',

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chaos-master",
-  "version": "0.6.7",
+  "version": "0.7.0",
   "description": "WebGPU based IFS Flame Generator for Artists & Explorers",
   "type": "module",
   "scripts": {
@@ -16,6 +16,7 @@
     "solid-js": "1.9.7",
     "structurajs": "0.12.6",
     "typegpu": "0.5.8",
+    "valibot": "^1.1.0",
     "wgpu-matrix": "3.4.0"
   }
 }

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -44,6 +44,10 @@ import {
   setQualityPointCountLimit,
 } from './flame/renderStats'
 import {
+  MAX_CAMERA_ZOOM_VALUE,
+  MIN_CAMERA_ZOOM_VALUE,
+} from './flame/schema/flameSchema'
+import {
   generateTransformId,
   generateVariationId,
 } from './flame/transformFunction'
@@ -139,13 +143,17 @@ function App(props: AppProps) {
       setFlameDescriptor((draft) => {
         draft.renderSettings.camera.zoom = clamp(
           value(draft.renderSettings.camera.zoom),
-          0.01,
-          Infinity,
+          MIN_CAMERA_ZOOM_VALUE,
+          MAX_CAMERA_ZOOM_VALUE,
         )
       })
     } else {
       setFlameDescriptor((draft) => {
-        draft.renderSettings.camera.zoom = clamp(value, 0.01, Infinity)
+        draft.renderSettings.camera.zoom = clamp(
+          value,
+          MIN_CAMERA_ZOOM_VALUE,
+          MAX_CAMERA_ZOOM_VALUE,
+        )
       })
     }
     return flameDescriptor.renderSettings.camera.zoom

--- a/packages/app/src/components/LoadFlameModal/LoadFlameModal.tsx
+++ b/packages/app/src/components/LoadFlameModal/LoadFlameModal.tsx
@@ -17,10 +17,6 @@ import type { ChangeHistory } from '@/utils/createStoreHistory'
 
 const CANCEL = 'cancel'
 
-function zoomToFovy(zoom: number, fovyMin = 1, fovyMax = 60): number {
-  return fovyMin + (1 - zoom) * (fovyMax - fovyMin)
-}
-
 function Preview(props: { flameDescriptor: FlameDescriptor }) {
   return (
     <Root adapterOptions={{ powerPreference: 'high-performance' }}>
@@ -29,7 +25,7 @@ function Preview(props: { flameDescriptor: FlameDescriptor }) {
           position={vec2f(
             ...props.flameDescriptor.renderSettings.camera.position,
           )}
-          fovy={zoomToFovy(props.flameDescriptor.renderSettings.camera.zoom)}
+          zoom={props.flameDescriptor.renderSettings.camera.zoom}
         >
           <Flam3
             quality={0.8}
@@ -64,8 +60,12 @@ function LoadFlameModal(props: LoadFlameModalProps) {
     const [fileHandle] = fileHandles
     const file = await fileHandle.getFile()
     const arrBuf = new Uint8Array(await file.arrayBuffer())
-    const newFlameDescriptor = await extractFlameFromPng(arrBuf)
-    props.respond(newFlameDescriptor)
+    try {
+      const flameDescriptor = await extractFlameFromPng(arrBuf)
+      props.respond(flameDescriptor)
+    } catch (_) {
+      alert(`No valid flame found in '${file.name}'.`)
+    }
   }
 
   return (

--- a/packages/app/src/flame/Flam3.tsx
+++ b/packages/app/src/flame/Flam3.tsx
@@ -18,6 +18,10 @@ import {
 } from './colorGrading'
 import { drawModeToImplFn } from './drawMode'
 import { createIFSPipeline } from './ifsPipeline'
+import {
+  backgroundColorDefault,
+  backgroundColorDefaultWhite,
+} from './schema/flameSchema'
 import { Bucket } from './types'
 import type { v4f } from 'typegpu/data'
 import type { FlameDescriptor } from './transformFunction'
@@ -48,8 +52,8 @@ export function Flam3(props: Flam3Props) {
   const backgroundColorFinal = () => {
     if (props.flameDescriptor.renderSettings.backgroundColor === undefined) {
       return props.flameDescriptor.renderSettings.drawMode === 'light'
-        ? vec3f(0)
-        : vec3f(1)
+        ? vec3f(...backgroundColorDefault)
+        : vec3f(...backgroundColorDefaultWhite)
     }
     return vec3f(...props.flameDescriptor.renderSettings.backgroundColor)
   }
@@ -221,7 +225,7 @@ export function Flam3(props: Flam3Props) {
 
     createEffect(() => {
       // redraw when these change
-      const __ = colorGradingPipeline()
+      const _ = colorGradingPipeline()
       rafLoop.redraw()
       forceDrawToScreen = true
     })

--- a/packages/app/src/flame/drawMode.ts
+++ b/packages/app/src/flame/drawMode.ts
@@ -2,6 +2,8 @@ import { tgpu } from 'typegpu'
 import { f32 } from 'typegpu/data'
 import type { TgpuFn } from 'typegpu'
 import type { F32 } from 'typegpu/data'
+import type { InferOutput } from 'valibot'
+import type { DrawModeSchema } from './schema/flameSchema'
 
 export type DrawModeFn = TgpuFn<[F32], F32>
 const drawModeFn = tgpu['~unstable'].fn([f32], f32)
@@ -17,4 +19,5 @@ export const drawModeToImplFn = {
   light: lightMode,
   paint: paintMode,
 }
-export type DrawMode = keyof typeof drawModeToImplFn
+
+export type DrawMode = InferOutput<typeof DrawModeSchema>

--- a/packages/app/src/flame/examples/empty.ts
+++ b/packages/app/src/flame/examples/empty.ts
@@ -1,7 +1,6 @@
-import { tid, vid } from './util'
-import type { FlameDescriptor } from '../transformFunction'
+import { defineExample, tid, vid } from './util'
 
-export const empty: FlameDescriptor = {
+export const empty = defineExample({
   renderSettings: {
     exposure: 0.25,
     skipIters: 20,
@@ -26,4 +25,4 @@ export const empty: FlameDescriptor = {
       },
     },
   },
-}
+})

--- a/packages/app/src/flame/examples/example1.ts
+++ b/packages/app/src/flame/examples/example1.ts
@@ -1,7 +1,11 @@
-import { tid, vid } from './util'
-import type { FlameDescriptor } from '../transformFunction'
+import { latestSchemaVersion } from '../schema/flameSchema'
+import { defineExample, tid, vid } from './util'
 
-export const example1: FlameDescriptor = {
+export const example1 = defineExample({
+  version: latestSchemaVersion,
+  metadata: {
+    author: 'deluksic',
+  },
   renderSettings: {
     exposure: 0.25,
     skipIters: 20,
@@ -74,4 +78,4 @@ export const example1: FlameDescriptor = {
       },
     },
   },
-}
+})

--- a/packages/app/src/flame/examples/example2.ts
+++ b/packages/app/src/flame/examples/example2.ts
@@ -1,7 +1,6 @@
-import { tid, vid } from './util'
-import type { FlameDescriptor } from '../transformFunction'
+import { defineExample, tid, vid } from './util'
 
-export const example2: FlameDescriptor = {
+export const example2 = defineExample({
   renderSettings: {
     exposure: 0.25,
     skipIters: 20,
@@ -53,4 +52,4 @@ export const example2: FlameDescriptor = {
       },
     },
   },
-}
+})

--- a/packages/app/src/flame/examples/example3.ts
+++ b/packages/app/src/flame/examples/example3.ts
@@ -1,15 +1,10 @@
-import { tid, vid } from './util'
-import type { FlameDescriptor } from '../transformFunction'
+import { defineExample, tid, vid } from './util'
 
-export const example3: FlameDescriptor = {
+export const example3 = defineExample({
   renderSettings: {
-    exposure: 0.2,
+    exposure: 0.25,
     skipIters: 20,
     drawMode: 'light',
-    camera: {
-      zoom: 1,
-      position: [0, 0],
-    },
   },
   transforms: {
     [tid('2fa2980e_6df0_4735_8334_052f42d6639d')]: {
@@ -71,4 +66,4 @@ export const example3: FlameDescriptor = {
       },
     },
   },
-}
+})

--- a/packages/app/src/flame/examples/example4.ts
+++ b/packages/app/src/flame/examples/example4.ts
@@ -1,7 +1,6 @@
-import { tid, vid } from './util'
-import type { FlameDescriptor } from '../transformFunction'
+import { defineExample, tid, vid } from './util'
 
-export const example4: FlameDescriptor = {
+export const example4 = defineExample({
   renderSettings: {
     exposure: 0.25,
     skipIters: 20,
@@ -70,4 +69,4 @@ export const example4: FlameDescriptor = {
       },
     },
   },
-}
+})

--- a/packages/app/src/flame/examples/example5.ts
+++ b/packages/app/src/flame/examples/example5.ts
@@ -1,7 +1,6 @@
-import { tid, vid } from './util'
-import type { FlameDescriptor } from '../transformFunction'
+import { defineExample, tid, vid } from './util'
 
-export const example5: FlameDescriptor = {
+export const example5 = defineExample({
   renderSettings: {
     exposure: 0.25,
     skipIters: 20,
@@ -90,4 +89,4 @@ export const example5: FlameDescriptor = {
       },
     },
   },
-}
+})

--- a/packages/app/src/flame/examples/example6.ts
+++ b/packages/app/src/flame/examples/example6.ts
@@ -1,7 +1,6 @@
-import { tid, vid } from './util'
-import type { FlameDescriptor } from '../transformFunction'
+import { defineExample, tid, vid } from './util'
 
-export const example6: FlameDescriptor = {
+export const example6 = defineExample({
   renderSettings: {
     exposure: 0.25,
     skipIters: 20,
@@ -71,4 +70,4 @@ export const example6: FlameDescriptor = {
       },
     },
   },
-}
+})

--- a/packages/app/src/flame/examples/example7.ts
+++ b/packages/app/src/flame/examples/example7.ts
@@ -1,7 +1,6 @@
-import { tid, vid } from './util'
-import type { FlameDescriptor } from '../transformFunction'
+import { defineExample, tid, vid } from './util'
 
-export const example7: FlameDescriptor = {
+export const example7 = defineExample({
   renderSettings: {
     exposure: 0.137,
     skipIters: 30,
@@ -71,4 +70,4 @@ export const example7: FlameDescriptor = {
       },
     },
   },
-}
+})

--- a/packages/app/src/flame/examples/linear1.ts
+++ b/packages/app/src/flame/examples/linear1.ts
@@ -1,29 +1,28 @@
-import { tid, vid } from './util'
-import type { FlameDescriptor } from '../transformFunction'
+import { defineExample, tid, vid } from './util'
 
-export const linear1: FlameDescriptor = {
+export const linear1 = defineExample({
   renderSettings: {
     exposure: 1,
     skipIters: 20,
     drawMode: 'light',
     camera: {
-      zoom: 0.6156769296084323,
-      position: [2.363656845208408, -1.5589096906996596],
+      zoom: 0.9250189643808657,
+      position: [2.2206582672782824, -1.3296191881496164],
     },
   },
   transforms: {
     [tid('5d4334f1_2d86_4790_b1f7_0959ce03486d')]: {
       probability: 1,
       preAffine: {
-        c: 0.41044109612070767,
-        f: -0.6449788653325407,
         a: 1.0540204340811536,
         b: 0.40927217400008875,
+        c: 0.41044109612070767,
         d: -0.40927217400008875,
         e: 1.0540204340811536,
+        f: -0.6449788653325407,
       },
       postAffine: { a: 1, b: 0, c: 0, d: 0, e: 1, f: 0 },
-      color: { x: -0.19059401492657632, y: -0.06663110806042248 },
+      color: { x: -0.24059401492657634, y: -0.1892117532217128 },
       variations: {
         [vid('79b89e92_15a5_478f_ae85_dcd22856f9ea')]: {
           type: 'linear',
@@ -33,16 +32,16 @@ export const linear1: FlameDescriptor = {
     },
     [tid('42316a5a_d01b_4577_8dae_8107f2eecded')]: {
       probability: 0.293,
-      color: { x: -0.031047370799169666, y: 0.0937664949455789 },
       preAffine: {
-        c: 1.9489456440401987,
-        f: 0.17311140256688978,
         a: 1.6053602749419031,
         b: 0.7684904295453283,
+        c: 1.9489456440401987,
         d: -0.3204383880132562,
         e: 0.43973527404023566,
+        f: 0.17311140256688978,
       },
       postAffine: { a: 1, b: 0, c: 0, d: 0, e: 1, f: 0 },
+      color: { x: -0.031047370799169666, y: 0.0937664949455789 },
       variations: {
         [vid('c07f1b17_9072_461e_9dc8_c5ceaaabf71d')]: {
           type: 'linear',
@@ -52,16 +51,16 @@ export const linear1: FlameDescriptor = {
     },
     [tid('2f4887e6_852d_4b71_b4ac_0c9be63d7870')]: {
       probability: 0.293,
-      color: { x: -0.031047370799169666, y: 0.0937664949455789 },
       preAffine: {
-        c: 1.9489456440401987,
-        f: 0.17311140256688978,
         a: 1.6053602749419031,
         b: 0.7684904295453283,
+        c: 1.9489456440401987,
         d: -0.3204383880132562,
         e: 0.43973527404023566,
+        f: 0.17311140256688978,
       },
       postAffine: { a: 1, b: 0, c: 0, d: 0, e: 1, f: 0 },
+      color: { x: -0.031047370799169666, y: 0.0937664949455789 },
       variations: {
         [vid('b2c15c46_4975_4fc6_9571_52189459f503')]: {
           type: 'linear',
@@ -71,16 +70,16 @@ export const linear1: FlameDescriptor = {
     },
     [tid('4d691d7e_bcdd_4275_b743_8a9f7ac7db33')]: {
       probability: 0.293,
-      color: { x: -0.031047370799169666, y: 0.0937664949455789 },
       preAffine: {
-        c: 1.9489456440401987,
-        f: 0.17311140256688978,
         a: 1.6053602749419031,
         b: 0.7684904295453283,
+        c: 1.9489456440401987,
         d: -0.3204383880132562,
         e: 0.43973527404023566,
+        f: 0.17311140256688978,
       },
       postAffine: { a: 1, b: 0, c: 0, d: 0, e: 1, f: 0 },
+      color: { x: 0.007662306620185175, y: 0.12602455946170793 },
       variations: {
         [vid('30af6845_b157_4a01_98de_3f1ee9f93c44')]: {
           type: 'linear',
@@ -89,4 +88,4 @@ export const linear1: FlameDescriptor = {
       },
     },
   },
-}
+})

--- a/packages/app/src/flame/examples/util.ts
+++ b/packages/app/src/flame/examples/util.ts
@@ -1,4 +1,12 @@
-import type { TransformId, VariationId } from '../transformFunction'
+import { flatten, safeParse } from 'valibot'
+import { FlameDescriptorSchema } from '../schema/flameSchema'
+import type { FlatErrors } from 'valibot'
+import type { FlameDescriptorDraft } from '../schema/flameSchema'
+import type {
+  FlameDescriptor,
+  TransformId,
+  VariationId,
+} from '../transformFunction'
 
 export function tid(transformId: string): TransformId {
   return transformId as TransformId
@@ -6,4 +14,45 @@ export function tid(transformId: string): TransformId {
 
 export function vid(variationId: string): VariationId {
   return variationId as VariationId
+}
+
+function prettyPrintValibotErrors(
+  flatErrors: FlatErrors<typeof FlameDescriptorSchema>,
+) {
+  const { root, nested, other } = flatErrors
+
+  if (root !== undefined) {
+    console.warn('Root issues: ')
+    console.table(root)
+  }
+  if (nested !== undefined) {
+    const nestedIssues = Object.fromEntries(
+      Object.entries(nested).map(([key, value]) => [
+        key,
+        value ? value.join(' & ') : 'Unknown Issue',
+      ]),
+    )
+    console.warn('Schema issues: ')
+    console.table(nestedIssues)
+  }
+  if (other !== undefined) {
+    console.warn('Other issues: ')
+    console.table(other)
+  }
+}
+
+export function validateFlame(data: unknown): FlameDescriptor {
+  const result = safeParse(FlameDescriptorSchema, data)
+  if (!result.success) {
+    const flatErrors = flatten<typeof FlameDescriptorSchema>(result.issues)
+    prettyPrintValibotErrors(flatErrors)
+    throw new Error(
+      'This flame cannot be shown, please check console for more info.',
+    )
+  }
+  return result.output
+}
+
+export function defineExample(example: FlameDescriptorDraft) {
+  return validateFlame(example)
 }

--- a/packages/app/src/flame/schema/flameSchema.ts
+++ b/packages/app/src/flame/schema/flameSchema.ts
@@ -1,0 +1,114 @@
+import * as v from 'valibot'
+import { recordKeys } from '@/utils/record'
+import { drawModeToImplFn } from '../drawMode'
+import { TransformVariationSchema } from './variationSchema'
+
+// default values and schema fallbacks
+export const backgroundColorDefault: [number, number, number] = [0, 0, 0]
+export const backgroundColorDefaultWhite: [number, number, number] = [1, 1, 1]
+export const MIN_CAMERA_ZOOM_VALUE: number = 0.01
+export const MAX_CAMERA_ZOOM_VALUE: number = 500
+const cameraDefault: { zoom: number; position: [number, number] } = {
+  zoom: 1,
+  position: [0, 0],
+}
+const MAX_SKIP_ITERS_VALUE = 30
+const MIN_EXPOSURE_VALUE = -4
+const MAX_EXPOSURE_VALUE = 4
+const renderSettingsDefult: v.InferOutput<typeof RenderSettingsSchema> = {
+  exposure: 0.25,
+  skipIters: 20,
+  drawMode: 'light',
+  backgroundColor: backgroundColorDefault,
+  camera: cameraDefault,
+}
+export const latestSchemaVersion = '1.0'
+const MAX_LENGTH_AUTHOR_STRING = 255
+const MAX_LENGTH_VERSION_STRING = 10
+const metadataDefault = {
+  version: latestSchemaVersion,
+  author: 'unknown',
+}
+
+export const TransformIdSchema = v.pipe(v.string(), v.brand('TransformId'))
+export const VariationIdSchema = v.pipe(v.string(), v.brand('VariationId'))
+export const DrawModeSchema = v.picklist(recordKeys(drawModeToImplFn))
+
+export const AffineParamsSchema = v.object({
+  a: v.number(),
+  b: v.number(),
+  c: v.number(),
+  d: v.number(),
+  e: v.number(),
+  f: v.number(),
+})
+
+const VariationRecordSchema = v.record(
+  VariationIdSchema,
+  TransformVariationSchema,
+)
+export const TransformFunctionSchema = v.object({
+  probability: v.number(),
+  preAffine: AffineParamsSchema,
+  postAffine: AffineParamsSchema,
+  color: v.object({
+    x: v.number(),
+    y: v.number(),
+  }),
+  variations: VariationRecordSchema,
+})
+
+const ZoomValueSchema = v.pipe(
+  v.number(),
+  v.minValue(MIN_CAMERA_ZOOM_VALUE),
+  v.maxValue(MAX_CAMERA_ZOOM_VALUE),
+)
+const CameraObjSchema = v.object({
+  zoom: v.optional(ZoomValueSchema, cameraDefault.zoom),
+  position: v.optional(
+    v.tuple([v.number(), v.number()]),
+    cameraDefault.position,
+  ),
+})
+
+const ColorValueSchema = v.pipe(v.number(), v.minValue(0), v.maxValue(1))
+const RenderSettingsSchema = v.object({
+  exposure: v.pipe(
+    v.number(),
+    v.minValue(MIN_EXPOSURE_VALUE),
+    v.maxValue(MAX_EXPOSURE_VALUE),
+  ),
+  skipIters: v.pipe(
+    v.number(),
+    v.integer(),
+    v.minValue(0),
+    v.maxValue(MAX_SKIP_ITERS_VALUE),
+  ),
+  drawMode: v.optional(DrawModeSchema, 'light'),
+  backgroundColor: v.optional(
+    v.tuple([ColorValueSchema, ColorValueSchema, ColorValueSchema]),
+  ),
+  camera: v.optional(CameraObjSchema, cameraDefault),
+})
+
+const FlameMetadataSchema = v.object({
+  author: v.optional(
+    v.pipe(v.string(), v.maxLength(MAX_LENGTH_AUTHOR_STRING)),
+    metadataDefault.author,
+  ),
+})
+
+const FlameDescriptorVersionSchema = v.pipe(
+  v.string(),
+  v.nonEmpty('Please specify a non-empty version'),
+  v.maxLength(MAX_LENGTH_VERSION_STRING),
+)
+
+export const FlameDescriptorSchema = v.object({
+  version: v.optional(FlameDescriptorVersionSchema),
+  metadata: v.optional(FlameMetadataSchema, metadataDefault),
+  renderSettings: v.optional(RenderSettingsSchema, renderSettingsDefult),
+  transforms: v.record(TransformIdSchema, TransformFunctionSchema),
+})
+
+export type FlameDescriptorDraft = v.InferInput<typeof FlameDescriptorSchema>

--- a/packages/app/src/flame/schema/index.ts
+++ b/packages/app/src/flame/schema/index.ts
@@ -1,0 +1,29 @@
+import { BlobParamsSchema } from '../variations/parametric/blob'
+import { CurlParamsSchema } from '../variations/parametric/curl'
+import { Fan2ParamsSchema } from '../variations/parametric/fan2'
+import { GridParamsSchema } from '../variations/parametric/grid'
+import { JuliaNParamsSchema } from '../variations/parametric/juliaN'
+import { JuliaScopeParamsSchema } from '../variations/parametric/juliaScope'
+import { NgonParamsSchema } from '../variations/parametric/ngon'
+import { PdjParamsSchema } from '../variations/parametric/pdj'
+import { PerspectiveParamsSchema } from '../variations/parametric/perspective'
+import { PieParamsSchema } from '../variations/parametric/pie'
+import { RadialBlurParamsSchema } from '../variations/parametric/radialBlur'
+import { RectanglesParamsSchema } from '../variations/parametric/rectangles'
+import { Rings2ParamsSchema } from '../variations/parametric/rings2'
+
+export const parametricVariationParamsSchemas = {
+  blob: BlobParamsSchema,
+  curl: CurlParamsSchema,
+  fan2: Fan2ParamsSchema,
+  grid: GridParamsSchema,
+  juliaN: JuliaNParamsSchema,
+  juliaScope: JuliaScopeParamsSchema,
+  ngonVar: NgonParamsSchema,
+  pdjVar: PdjParamsSchema,
+  perspective: PerspectiveParamsSchema,
+  pie: PieParamsSchema,
+  radialBlurVar: RadialBlurParamsSchema,
+  rectanglesVar: RectanglesParamsSchema,
+  rings2: Rings2ParamsSchema,
+}

--- a/packages/app/src/flame/schema/variationSchema.ts
+++ b/packages/app/src/flame/schema/variationSchema.ts
@@ -1,0 +1,40 @@
+import * as v from 'valibot'
+import { transformVariationNames } from '../variations'
+import { parametricVariationParamsSchemas } from '.'
+import type { TransformVariation } from '../variations'
+
+function isParametricKey(
+  key: string,
+): key is keyof typeof parametricVariationParamsSchemas {
+  return key in parametricVariationParamsSchemas
+}
+
+type ValueUnion<T> = T[keyof T]
+type ParametricVarType = ValueUnion<typeof parametricVariationParamsSchemas>
+
+const simpleVariationSchema = v.optional(v.object({}))
+export const transformVariationsParamsSchemas = transformVariationNames.map(
+  (key) =>
+    [
+      key,
+      isParametricKey(key)
+        ? parametricVariationParamsSchemas[key]
+        : simpleVariationSchema,
+    ] as [TransformVariation, ParametricVarType],
+)
+const transformVariationSchemas = transformVariationsParamsSchemas.map(
+  ([key, paramSchema]) =>
+    v.object({
+      type: v.literal(key),
+      weight: v.number(),
+      params: v.optional(paramSchema),
+    }),
+)
+
+export const TransformVariationSchema = v.variant(
+  'type',
+  transformVariationSchemas,
+)
+export type TransformVariationDescriptor = v.InferOutput<
+  typeof TransformVariationSchema
+>

--- a/packages/app/src/flame/transformFunction.ts
+++ b/packages/app/src/flame/transformFunction.ts
@@ -9,37 +9,21 @@ import {
   transformAffine,
   VariationInfo,
 } from './variations/types'
-import type { DrawMode } from './drawMode'
+import type { InferOutput } from 'valibot'
 import type {
-  TransformVariation,
-  TransformVariationDescriptor,
-} from './variations'
+  FlameDescriptorSchema,
+  TransformFunctionSchema,
+  TransformIdSchema,
+  VariationIdSchema,
+} from './schema/flameSchema'
+import type { TransformVariation } from './variations'
 
-export type TransformId = string & { __brand: 'TransformId' }
-export type VariationId = string & { __brand: 'VariationId' }
+export type TransformId = InferOutput<typeof TransformIdSchema>
+export type VariationId = InferOutput<typeof VariationIdSchema>
+export type FlameDescriptor = InferOutput<typeof FlameDescriptorSchema>
+export type TransformFunction = InferOutput<typeof TransformFunctionSchema>
+
 export type TransformRecord = Record<TransformId, TransformFunction>
-export type VariationRecord = Record<VariationId, TransformVariationDescriptor>
-
-export type RenderSettings = {
-  exposure: number
-  skipIters: number
-  drawMode: DrawMode
-  backgroundColor?: [number, number, number]
-  camera: { zoom: number; position: [number, number] }
-}
-
-export type TransformFunction = {
-  probability: number
-  preAffine: AffineParams
-  postAffine: AffineParams
-  color: { x: number; y: number }
-  variations: VariationRecord
-}
-
-export type FlameDescriptor = {
-  renderSettings: RenderSettings
-  transforms: TransformRecord
-}
 
 const FlameUniformsBase = struct({
   probability: f32,

--- a/packages/app/src/flame/variations/index.ts
+++ b/packages/app/src/flame/variations/index.ts
@@ -1,3 +1,4 @@
+import { recordKeys } from '@/utils/record'
 import { blob } from './parametric/blob'
 import { curlVar } from './parametric/curl'
 import { fan2 } from './parametric/fan2'
@@ -52,6 +53,7 @@ import {
   waves,
 } from './simpleVariations'
 import type { Infer } from 'typegpu/data'
+import type { TransformVariationDescriptor } from '../schema/variationSchema'
 import type { ParametricVariation } from './types'
 
 export const transformVariations = {
@@ -110,6 +112,15 @@ export const transformVariations = {
 
 export type TransformVariation = keyof typeof transformVariations
 export const variationTypes = Object.keys(transformVariations)
+export const transformVariationNames = recordKeys(transformVariations)
+
+export type ParametricVariationDescriptor = {
+  [K in TransformVariation]: (typeof transformVariations)[K] extends ParametricVariation<
+    infer P
+  >
+    ? { type: K; weight: number; params: Infer<P> }
+    : never
+}[TransformVariation]
 
 export function isParametric(
   name: TransformVariation,
@@ -119,32 +130,12 @@ export function isParametric(
 
 export function isParametricType(
   v: TransformVariationDescriptor,
-): v is Extract<TransformVariationDescriptor, { params: unknown }> {
+): v is ParametricVariationDescriptor {
   return 'params' in v
 }
+
 export function isVariationType(
   maybeType: string,
 ): maybeType is TransformVariation {
   return variationTypes.includes(maybeType)
 }
-
-export type ParametricTransformParams<T extends TransformVariation> =
-  (typeof transformVariations)[T] extends ParametricVariation<infer P>
-    ? Infer<P>
-    : never
-
-export type TransformVariationDescriptor = {
-  [K in TransformVariation]: (typeof transformVariations)[K] extends ParametricVariation<
-    infer P
-  >
-    ? { type: K; weight: number; params: Infer<P> }
-    : { type: K; weight: number }
-}[TransformVariation]
-
-export type ParametricVariationDescriptor = {
-  [K in TransformVariation]: (typeof transformVariations)[K] extends ParametricVariation<
-    infer P
-  >
-    ? { type: K; weight: number; params: Infer<P> }
-    : never
-}[TransformVariation]

--- a/packages/app/src/flame/variations/parametric/blob.tsx
+++ b/packages/app/src/flame/variations/parametric/blob.tsx
@@ -1,20 +1,26 @@
-import { f32, struct } from 'typegpu/data'
+import * as v from 'valibot'
 import { RangeEditor } from '@/components/Sliders/ParametricEditors/RangeEditor'
 import { editorProps } from '@/components/Sliders/ParametricEditors/types'
+import { schemaToF32Struct } from '@/utils/schemaUtil'
 import { parametricVariation } from '../types'
 import type { Infer } from 'typegpu/data'
+import type { InferOutput } from 'valibot'
 import type { EditorFor } from '@/components/Sliders/ParametricEditors/types'
 
-export const BlobParams = struct({
-  high: f32,
-  low: f32,
-  waves: f32,
+export const BlobParamsSchema = v.object({
+  high: v.number(),
+  low: v.number(),
+  waves: v.number(),
 })
-export const BlobParamsDefaults: Infer<typeof BlobParams> = {
+
+const BlobParams = schemaToF32Struct(BlobParamsSchema.entries)
+
+const BlobParamsDefaults: InferOutput<typeof BlobParamsSchema> = {
   high: 2,
   low: 1,
   waves: 1,
 }
+
 export const BlobParamsEditor: EditorFor<Infer<typeof BlobParams>> = (
   props,
 ) => (

--- a/packages/app/src/flame/variations/parametric/curl.tsx
+++ b/packages/app/src/flame/variations/parametric/curl.tsx
@@ -1,20 +1,23 @@
-import { f32, struct } from 'typegpu/data'
+import * as v from 'valibot'
 import { RangeEditor } from '@/components/Sliders/ParametricEditors/RangeEditor'
 import { editorProps } from '@/components/Sliders/ParametricEditors/types'
+import { schemaToF32Struct } from '@/utils/schemaUtil'
 import { parametricVariation } from '../types'
 import type { Infer } from 'typegpu/data'
+import type { InferOutput } from 'valibot'
 import type { EditorFor } from '@/components/Sliders/ParametricEditors/types'
 
-export const CurlParams = struct({
-  c1: f32,
-  c2: f32,
+export const CurlParamsSchema = v.object({
+  c1: v.number(),
+  c2: v.number(),
 })
 
-export const CurlParamsDefaults: Infer<typeof CurlParams> = {
+const CurlParams = schemaToF32Struct(CurlParamsSchema.entries)
+
+const CurlParamsDefaults: InferOutput<typeof CurlParamsSchema> = {
   c1: 1,
   c2: 1,
 }
-
 export const CurlParamsEditor: EditorFor<Infer<typeof CurlParams>> = (
   props,
 ) => (

--- a/packages/app/src/flame/variations/parametric/fan2.tsx
+++ b/packages/app/src/flame/variations/parametric/fan2.tsx
@@ -1,17 +1,21 @@
-import { f32, struct } from 'typegpu/data'
+import * as v from 'valibot'
 import { RangeEditor } from '@/components/Sliders/ParametricEditors/RangeEditor'
 import { editorProps } from '@/components/Sliders/ParametricEditors/types'
 import { PI } from '@/flame/constants'
+import { schemaToF32Struct } from '@/utils/schemaUtil'
 import { parametricVariation } from '../types'
 import type { Infer } from 'typegpu/data'
+import type { InferOutput } from 'valibot'
 import type { EditorFor } from '@/components/Sliders/ParametricEditors/types'
 
-const Fan2Params = struct({
-  x: f32,
-  y: f32,
+export const Fan2ParamsSchema = v.object({
+  x: v.number(),
+  y: v.number(),
 })
 
-export const Fan2ParamsDefaults: Infer<typeof Fan2Params> = {
+const Fan2Params = schemaToF32Struct(Fan2ParamsSchema.entries)
+
+const Fan2ParamsDefaults: InferOutput<typeof Fan2ParamsSchema> = {
   x: 1,
   y: 1,
 }

--- a/packages/app/src/flame/variations/parametric/grid.tsx
+++ b/packages/app/src/flame/variations/parametric/grid.tsx
@@ -1,18 +1,22 @@
-import { f32, struct } from 'typegpu/data'
+import * as v from 'valibot'
 import { RangeEditor } from '@/components/Sliders/ParametricEditors/RangeEditor'
 import { editorProps } from '@/components/Sliders/ParametricEditors/types'
 import { random } from '@/shaders/random'
+import { schemaToF32Struct } from '@/utils/schemaUtil'
 import { parametricVariation } from '../types'
 import type { Infer } from 'typegpu/data'
+import type { InferOutput } from 'valibot'
 import type { EditorFor } from '@/components/Sliders/ParametricEditors/types'
 
-export const GridParams = struct({
-  divisions: f32,
-  size: f32,
-  jitterNearIntersectionsDistance: f32,
+export const GridParamsSchema = v.object({
+  divisions: v.number(),
+  size: v.number(),
+  jitterNearIntersectionsDistance: v.number(),
 })
 
-export const GridParamsDefaults: Infer<typeof GridParams> = {
+const GridParams = schemaToF32Struct(GridParamsSchema.entries)
+
+const GridParamsDefaults: InferOutput<typeof GridParamsSchema> = {
   divisions: 10.0,
   size: 1.0,
   jitterNearIntersectionsDistance: 0.002,

--- a/packages/app/src/flame/variations/parametric/index.ts
+++ b/packages/app/src/flame/variations/parametric/index.ts
@@ -1,10 +1,7 @@
 import { isParametric, transformVariations } from '..'
-import type {
-  ParametricVariationDescriptor,
-  TransformVariation,
-  TransformVariationDescriptor,
-} from '..'
+import type { ParametricVariationDescriptor, TransformVariation } from '..'
 import type { EditorFor } from '@/components/Sliders/ParametricEditors/types'
+import type { TransformVariationDescriptor } from '@/flame/schema/variationSchema'
 
 export function getVariationDefault(
   type: TransformVariation,

--- a/packages/app/src/flame/variations/parametric/juliaN.tsx
+++ b/packages/app/src/flame/variations/parametric/juliaN.tsx
@@ -1,22 +1,25 @@
-import { f32, struct } from 'typegpu/data'
+import * as v from 'valibot'
 import { RangeEditor } from '@/components/Sliders/ParametricEditors/RangeEditor'
 import { editorProps } from '@/components/Sliders/ParametricEditors/types'
 import { PI } from '@/flame/constants'
 import { random } from '@/shaders/random'
+import { schemaToF32Struct } from '@/utils/schemaUtil'
 import { parametricVariation } from '../types'
 import type { Infer } from 'typegpu/data'
+import type { InferOutput } from 'valibot'
 import type { EditorFor } from '@/components/Sliders/ParametricEditors/types'
 
-export const JuliaNParams = struct({
-  power: f32,
-  dist: f32,
+export const JuliaNParamsSchema = v.object({
+  power: v.number(),
+  dist: v.number(),
 })
 
-export const JuliaNParamsDefaults: Infer<typeof JuliaNParams> = {
+const JuliaNParams = schemaToF32Struct(JuliaNParamsSchema.entries)
+
+const JuliaNParamsDefaults: InferOutput<typeof JuliaNParamsSchema> = {
   power: 1,
   dist: 5,
 }
-
 export const JuliaNParamsEditor: EditorFor<Infer<typeof JuliaNParams>> = (
   props,
 ) => (

--- a/packages/app/src/flame/variations/parametric/juliaScope.tsx
+++ b/packages/app/src/flame/variations/parametric/juliaScope.tsx
@@ -1,18 +1,22 @@
-import { f32, struct } from 'typegpu/data'
+import * as v from 'valibot'
 import { RangeEditor } from '@/components/Sliders/ParametricEditors/RangeEditor'
 import { editorProps } from '@/components/Sliders/ParametricEditors/types'
 import { PI } from '@/flame/constants'
 import { parametricVariation } from '@/flame/variations/types'
 import { random } from '@/shaders/random'
+import { schemaToF32Struct } from '@/utils/schemaUtil'
 import type { Infer } from 'typegpu/data'
+import type { InferOutput } from 'valibot'
 import type { EditorFor } from '@/components/Sliders/ParametricEditors/types'
 
-export const JuliaScopeParams = struct({
-  power: f32,
-  dist: f32,
+export const JuliaScopeParamsSchema = v.object({
+  power: v.number(),
+  dist: v.number(),
 })
 
-export const JuliaScopeParamsDefaults: Infer<typeof JuliaScopeParams> = {
+const JuliaScopeParams = schemaToF32Struct(JuliaScopeParamsSchema.entries)
+
+const JuliaScopeParamsDefaults: InferOutput<typeof JuliaScopeParamsSchema> = {
   power: 1,
   dist: 5,
 }

--- a/packages/app/src/flame/variations/parametric/ngon.tsx
+++ b/packages/app/src/flame/variations/parametric/ngon.tsx
@@ -1,20 +1,23 @@
-import { f32, struct } from 'typegpu/data'
+import * as v from 'valibot'
 import { RangeEditor } from '@/components/Sliders/ParametricEditors/RangeEditor'
 import { editorProps } from '@/components/Sliders/ParametricEditors/types'
 import { PI } from '@/flame/constants'
+import { schemaToF32Struct } from '@/utils/schemaUtil'
 import { parametricVariation } from '../types'
 import type { Infer } from 'typegpu/data'
+import type { InferOutput } from 'valibot'
 import type { EditorFor } from '@/components/Sliders/ParametricEditors/types'
 
-const NgonParams = struct({
-  // some of those could be ints
-  power: f32,
-  sides: f32,
-  corners: f32,
-  circle: f32,
+export const NgonParamsSchema = v.object({
+  power: v.number(),
+  sides: v.number(),
+  corners: v.number(),
+  circle: v.number(),
 })
 
-export const NgonParamsDefaults: Infer<typeof NgonParams> = {
+const NgonParams = schemaToF32Struct(NgonParamsSchema.entries)
+
+const NgonParamsDefaults: InferOutput<typeof NgonParamsSchema> = {
   power: 2,
   sides: 3,
   corners: 4,

--- a/packages/app/src/flame/variations/parametric/pdj.tsx
+++ b/packages/app/src/flame/variations/parametric/pdj.tsx
@@ -1,18 +1,22 @@
-import { f32, struct } from 'typegpu/data'
+import * as v from 'valibot'
 import { RangeEditor } from '@/components/Sliders/ParametricEditors/RangeEditor'
 import { editorProps } from '@/components/Sliders/ParametricEditors/types'
+import { schemaToF32Struct } from '@/utils/schemaUtil'
 import { parametricVariation } from '../types'
 import type { Infer } from 'typegpu/data'
+import type { InferOutput } from 'valibot'
 import type { EditorFor } from '@/components/Sliders/ParametricEditors/types'
 
-export const PdjParams = struct({
-  a: f32,
-  b: f32,
-  c: f32,
-  d: f32,
+export const PdjParamsSchema = v.object({
+  a: v.number(),
+  b: v.number(),
+  c: v.number(),
+  d: v.number(),
 })
 
-export const PdjParamsDefaults: Infer<typeof PdjParams> = {
+export const PdjParams = schemaToF32Struct(PdjParamsSchema.entries)
+
+const PdjParamsDefaults: InferOutput<typeof PdjParamsSchema> = {
   a: 1,
   b: 2,
   c: 3,

--- a/packages/app/src/flame/variations/parametric/perspective.tsx
+++ b/packages/app/src/flame/variations/parametric/perspective.tsx
@@ -1,17 +1,22 @@
-import { f32, struct } from 'typegpu/data'
+import * as v from 'valibot'
 import { AngleEditor } from '@/components/Sliders/ParametricEditors/AngleEditor'
 import { RangeEditor } from '@/components/Sliders/ParametricEditors/RangeEditor'
 import { editorProps } from '@/components/Sliders/ParametricEditors/types'
+import { schemaToF32Struct } from '@/utils/schemaUtil'
 import { parametricVariation } from '../types'
 import type { Infer } from 'typegpu/data'
+import type { InferOutput } from 'valibot'
 import type { EditorFor } from '@/components/Sliders/ParametricEditors/types'
 
-export const PerspectiveParams = struct({
-  angle: f32,
-  dist: f32,
+export const PerspectiveParamsSchema = v.object({
+  angle: v.number(),
+  dist: v.number(),
 })
 
-export const PerspectiveParamsDefaults: Infer<typeof PerspectiveParams> = {
+export const PerspectiveParams = schemaToF32Struct(
+  PerspectiveParamsSchema.entries,
+)
+const PerspectiveParamsDefaults: InferOutput<typeof PerspectiveParamsSchema> = {
   angle: Math.PI,
   dist: 3,
 }

--- a/packages/app/src/flame/variations/parametric/pie.tsx
+++ b/packages/app/src/flame/variations/parametric/pie.tsx
@@ -1,20 +1,24 @@
-import { f32, struct } from 'typegpu/data'
+import * as v from 'valibot'
 import { AngleEditor } from '@/components/Sliders/ParametricEditors/AngleEditor'
 import { RangeEditor } from '@/components/Sliders/ParametricEditors/RangeEditor'
 import { editorProps } from '@/components/Sliders/ParametricEditors/types'
 import { random } from '@/shaders/random'
+import { schemaToF32Struct } from '@/utils/schemaUtil'
 import { PI } from '../../constants'
 import { parametricVariation } from '../types'
 import type { Infer } from 'typegpu/data'
+import type { InferOutput } from 'valibot'
 import type { EditorFor } from '@/components/Sliders/ParametricEditors/types'
 
-export const PieParams = struct({
-  slices: f32,
-  rotation: f32,
-  thickness: f32,
+export const PieParamsSchema = v.object({
+  slices: v.number(),
+  rotation: v.number(),
+  thickness: v.number(),
 })
 
-export const PieParamsDefaults: Infer<typeof PieParams> = {
+export const PieParams = schemaToF32Struct(PieParamsSchema.entries)
+
+const PieParamsDefaults: InferOutput<typeof PieParamsSchema> = {
   slices: 6,
   rotation: Math.PI,
   thickness: 0.5,

--- a/packages/app/src/flame/variations/parametric/radialBlur.tsx
+++ b/packages/app/src/flame/variations/parametric/radialBlur.tsx
@@ -1,16 +1,21 @@
-import { f32, struct } from 'typegpu/data'
+import * as v from 'valibot'
 import { AngleEditor } from '@/components/Sliders/ParametricEditors/AngleEditor'
 import { editorProps } from '@/components/Sliders/ParametricEditors/types'
 import { random } from '@/shaders/random'
+import { schemaToF32Struct } from '@/utils/schemaUtil'
 import { parametricVariation } from '../types'
 import type { Infer } from 'typegpu/data'
+import type { InferOutput } from 'valibot'
 import type { EditorFor } from '@/components/Sliders/ParametricEditors/types'
 
-export const RadialBlurParams = struct({
-  angle: f32,
+export const RadialBlurParamsSchema = v.object({
+  angle: v.number(),
 })
+export const RadialBlurParams = schemaToF32Struct(
+  RadialBlurParamsSchema.entries,
+)
 
-export const RadialBlurParamsDefaults: Infer<typeof RadialBlurParams> = {
+const RadialBlurParamsDefaults: InferOutput<typeof RadialBlurParamsSchema> = {
   angle: Math.PI,
 }
 

--- a/packages/app/src/flame/variations/parametric/rectangles.tsx
+++ b/packages/app/src/flame/variations/parametric/rectangles.tsx
@@ -1,16 +1,22 @@
-import { f32, struct } from 'typegpu/data'
+import * as v from 'valibot'
 import { RangeEditor } from '@/components/Sliders/ParametricEditors/RangeEditor'
 import { editorProps } from '@/components/Sliders/ParametricEditors/types'
+import { schemaToF32Struct } from '@/utils/schemaUtil'
 import { parametricVariation } from '../types'
 import type { Infer } from 'typegpu/data'
+import type { InferOutput } from 'valibot'
 import type { EditorFor } from '@/components/Sliders/ParametricEditors/types'
 
-export const RectanglesParams = struct({
-  x: f32,
-  y: f32,
+export const RectanglesParamsSchema = v.object({
+  x: v.number(),
+  y: v.number(),
 })
 
-export const RectanglesParamsDefaults: Infer<typeof RectanglesParams> = {
+export const RectanglesParams = schemaToF32Struct(
+  RectanglesParamsSchema.entries,
+)
+
+const RectanglesParamsDefaults: InferOutput<typeof RectanglesParamsSchema> = {
   x: 2,
   y: 4,
 }

--- a/packages/app/src/flame/variations/parametric/rings2.tsx
+++ b/packages/app/src/flame/variations/parametric/rings2.tsx
@@ -1,18 +1,21 @@
-import { f32, struct } from 'typegpu/data'
+import * as v from 'valibot'
 import { RangeEditor } from '@/components/Sliders/ParametricEditors/RangeEditor'
 import { editorProps } from '@/components/Sliders/ParametricEditors/types'
+import { schemaToF32Struct } from '@/utils/schemaUtil'
 import { parametricVariation } from '../types'
 import type { Infer } from 'typegpu/data'
+import type { InferOutput } from 'valibot'
 import type { EditorFor } from '@/components/Sliders/ParametricEditors/types'
 
-export const Rings2Params = struct({
-  val: f32,
+export const Rings2ParamsSchema = v.object({
+  val: v.number(),
 })
 
-export const Rings2ParamsDefaults: Infer<typeof Rings2Params> = {
+export const Rings2Params = schemaToF32Struct(Rings2ParamsSchema.entries)
+
+const Rings2ParamsDefaults: InferOutput<typeof Rings2ParamsSchema> = {
   val: 6,
 }
-
 export const Rings2ParamsEditor: EditorFor<Infer<typeof Rings2Params>> = (
   props,
 ) => (

--- a/packages/app/src/flame/variations/types.ts
+++ b/packages/app/src/flame/variations/types.ts
@@ -2,9 +2,11 @@ import { tgpu } from 'typegpu'
 import { f32, struct, vec2f } from 'typegpu/data'
 import type { TgpuFn } from 'typegpu'
 import type { AnyWgslData, Infer, Vec2f } from 'typegpu/data'
+import type { InferOutput } from 'valibot'
+import type { AffineParamsSchema } from '../schema/flameSchema'
 import type { EditorFor } from '@/components/Sliders/ParametricEditors/types'
 
-export type AffineParams = Infer<typeof AffineParams>
+export type AffineParams = InferOutput<typeof AffineParamsSchema>
 // prettier-ignore
 export const AffineParams = struct({
   a: f32, b: f32, c: f32,

--- a/packages/app/src/lib/Camera2D.tsx
+++ b/packages/app/src/lib/Camera2D.tsx
@@ -74,13 +74,12 @@ export const camera2DPixelRatio = tgpu['~unstable'].fn([], f32)/* wgsl */ `
 
 type Camera2DProps = {
   position: v2f
-  fovy: number
+  zoom: number
 }
 
 export function Camera2D(props: ParentProps<Camera2DProps>) {
   const { root } = useRootContext()
   const { canvasSize, pixelRatio } = useCanvas()
-  const zoom = () => 1 / props.fovy
 
   const uniformsBuffer = root
     .createBuffer(Camera2DUniforms)
@@ -92,11 +91,12 @@ export function Camera2D(props: ParentProps<Camera2DProps>) {
   })
 
   const uniforms = createMemo(() => {
-    const { position, fovy } = props
+    const { position, zoom } = props
     const { x, y } = position
     const { width, height } = canvasSize()
     const aspect = width / height
     const viewMatrix4 = mat4x4f()
+    const fovy = 1 / zoom
     mat4.ortho(
       x - aspect * fovy,
       x + aspect * fovy,
@@ -154,7 +154,7 @@ export function Camera2D(props: ParentProps<Camera2DProps>) {
           worldToClip,
           clipToWorld,
         },
-        zoom,
+        zoom: () => props.zoom,
       }}
     >
       {props.children}

--- a/packages/app/src/lib/WheelZoomCamera2D.tsx
+++ b/packages/app/src/lib/WheelZoomCamera2D.tsx
@@ -144,7 +144,7 @@ export function WheelZoomCamera2D(props: ParentProps<WheelZoomCamera2DProps>) {
   })
 
   return (
-    <Camera2D position={position()} fovy={1 / zoom()}>
+    <Camera2D position={position()} zoom={zoom()}>
       {(() => {
         const { js } = useCamera()
         // steal clipToWorld from the camera

--- a/packages/app/src/shaders/random.ts
+++ b/packages/app/src/shaders/random.ts
@@ -54,7 +54,6 @@ export const hash = tgpu['~unstable'].fn([u32], u32)/* wgsl */ `
     return x;
   }
 `
-
 export const randomUnitDisk = tgpu['~unstable'].fn([], vec2f)/* wgsl */ `
   () -> vec2f {
     let r = sqrt(random());

--- a/packages/app/src/utils/jsonQueryParam.ts
+++ b/packages/app/src/utils/jsonQueryParam.ts
@@ -1,6 +1,6 @@
+import { validateFlame } from '@/flame/examples/util'
 import { decodeBase64, encodeBase64 } from './base64'
 import { sum } from './sum'
-import type { FlameDescriptor } from '@/flame/transformFunction'
 
 const format: CompressionFormat = 'deflate'
 
@@ -50,8 +50,7 @@ export async function decompressJsonQuery(compressedBytes: Uint8Array) {
     chunks.push(chunk)
   }
 
-  // TODO: use valibot or something to validate this
-  return JSON.parse(chunks.join()) as FlameDescriptor
+  return validateFlame(JSON.parse(chunks.join()))
 }
 
 export async function decodeJsonQueryParam(param: string) {

--- a/packages/app/src/utils/schemaUtil.ts
+++ b/packages/app/src/utils/schemaUtil.ts
@@ -1,0 +1,12 @@
+import { f32, struct } from 'typegpu/data'
+import { recordKeys } from '@/utils/record'
+
+export function schemaToF32Struct<T extends Record<string, unknown>>(
+  schema: T,
+) {
+  const obj = {} as Record<keyof T, typeof f32>
+  for (const key of recordKeys(schema)) {
+    obj[key] = f32
+  }
+  return struct(obj)
+}

--- a/packages/app/src/utils/useLoadFlameFromFile.ts
+++ b/packages/app/src/utils/useLoadFlameFromFile.ts
@@ -11,14 +11,11 @@ export function useLoadFlameFromFile() {
       return
     }
     const arrBuf = new Uint8Array(arrayBuffer)
-    const newFlameDescriptor = await extractFlameFromPng(arrBuf).catch(
-      () => undefined,
-    )
-    if (!newFlameDescriptor) {
-      await alert(`Could not find Flame Description in '${file.name}'.`)
-      return
+    try {
+      return await extractFlameFromPng(arrBuf)
+    } catch (_) {
+      await alert(`No valid flame found in '${file.name}'.`)
     }
-    return newFlameDescriptor
   }
 
   return loadFromFile

--- a/packages/app/tsconfig.json
+++ b/packages/app/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": ["../../tsconfig.json"],
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,6 +88,9 @@ importers:
       typegpu:
         specifier: 0.5.8
         version: 0.5.8
+      valibot:
+        specifier: ^1.1.0
+        version: 1.1.0(typescript@5.8.3)
       wgpu-matrix:
         specifier: 3.4.0
         version: 3.4.0
@@ -207,160 +210,160 @@ packages:
     engines: {node: '>=18'}
 
   '@emnapi/core@1.4.3':
-    resolution: {integrity: sha512-4m62DuCE07lw01soJwPiBGC0nAww0Q+RY70VZ+n49yDIO13yyinhbWCeNnaob0lakDtWQzSdtNWzJeOJt2ma+g==}
+    resolution: {integrity: sha512-4m62DuCE07lw01soJwPiBGC0nAww0Q+RY70VZ+n49yDIO13yyinhbWCeNnaob0lakDtWQzSdtNWzJeOJt2ma+g==, tarball: https://registry.npmjs.org/@emnapi/core/-/core-1.4.3.tgz}
 
   '@emnapi/runtime@1.4.3':
-    resolution: {integrity: sha512-pBPWdu6MLKROBX05wSNKcNb++m5Er+KQ9QkB+WVM+pW2Kx9hoSrVTnu3BdkI5eBLZoKu/J6mW/B6i6bJB2ytXQ==}
+    resolution: {integrity: sha512-pBPWdu6MLKROBX05wSNKcNb++m5Er+KQ9QkB+WVM+pW2Kx9hoSrVTnu3BdkI5eBLZoKu/J6mW/B6i6bJB2ytXQ==, tarball: https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.4.3.tgz}
 
   '@emnapi/wasi-threads@1.0.2':
-    resolution: {integrity: sha512-5n3nTJblwRi8LlXkJ9eBzu+kZR8Yxcc7ubakyQTFzPMtIhFpUBRbsnc2Dv88IZDIbCDlBiWrknhB4Lsz7mg6BA==}
+    resolution: {integrity: sha512-5n3nTJblwRi8LlXkJ9eBzu+kZR8Yxcc7ubakyQTFzPMtIhFpUBRbsnc2Dv88IZDIbCDlBiWrknhB4Lsz7mg6BA==, tarball: https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.0.2.tgz}
 
   '@esbuild/aix-ppc64@0.25.5':
-    resolution: {integrity: sha512-9o3TMmpmftaCMepOdA5k/yDw8SfInyzWWTjYTFCX3kPSDJMROQTb8jg+h9Cnwnmm1vOzvxN7gIfB5V2ewpjtGA==}
+    resolution: {integrity: sha512-9o3TMmpmftaCMepOdA5k/yDw8SfInyzWWTjYTFCX3kPSDJMROQTb8jg+h9Cnwnmm1vOzvxN7gIfB5V2ewpjtGA==, tarball: https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.5.tgz}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
   '@esbuild/android-arm64@0.25.5':
-    resolution: {integrity: sha512-VGzGhj4lJO+TVGV1v8ntCZWJktV7SGCs3Pn1GRWI1SBFtRALoomm8k5E9Pmwg3HOAal2VDc2F9+PM/rEY6oIDg==}
+    resolution: {integrity: sha512-VGzGhj4lJO+TVGV1v8ntCZWJktV7SGCs3Pn1GRWI1SBFtRALoomm8k5E9Pmwg3HOAal2VDc2F9+PM/rEY6oIDg==, tarball: https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.5.tgz}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
   '@esbuild/android-arm@0.25.5':
-    resolution: {integrity: sha512-AdJKSPeEHgi7/ZhuIPtcQKr5RQdo6OO2IL87JkianiMYMPbCtot9fxPbrMiBADOWWm3T2si9stAiVsGbTQFkbA==}
+    resolution: {integrity: sha512-AdJKSPeEHgi7/ZhuIPtcQKr5RQdo6OO2IL87JkianiMYMPbCtot9fxPbrMiBADOWWm3T2si9stAiVsGbTQFkbA==, tarball: https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.5.tgz}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
 
   '@esbuild/android-x64@0.25.5':
-    resolution: {integrity: sha512-D2GyJT1kjvO//drbRT3Hib9XPwQeWd9vZoBJn+bu/lVsOZ13cqNdDeqIF/xQ5/VmWvMduP6AmXvylO/PIc2isw==}
+    resolution: {integrity: sha512-D2GyJT1kjvO//drbRT3Hib9XPwQeWd9vZoBJn+bu/lVsOZ13cqNdDeqIF/xQ5/VmWvMduP6AmXvylO/PIc2isw==, tarball: https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.5.tgz}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
   '@esbuild/darwin-arm64@0.25.5':
-    resolution: {integrity: sha512-GtaBgammVvdF7aPIgH2jxMDdivezgFu6iKpmT+48+F8Hhg5J/sfnDieg0aeG/jfSvkYQU2/pceFPDKlqZzwnfQ==}
+    resolution: {integrity: sha512-GtaBgammVvdF7aPIgH2jxMDdivezgFu6iKpmT+48+F8Hhg5J/sfnDieg0aeG/jfSvkYQU2/pceFPDKlqZzwnfQ==, tarball: https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.5.tgz}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.25.5':
-    resolution: {integrity: sha512-1iT4FVL0dJ76/q1wd7XDsXrSW+oLoquptvh4CLR4kITDtqi2e/xwXwdCVH8hVHU43wgJdsq7Gxuzcs6Iq/7bxQ==}
+    resolution: {integrity: sha512-1iT4FVL0dJ76/q1wd7XDsXrSW+oLoquptvh4CLR4kITDtqi2e/xwXwdCVH8hVHU43wgJdsq7Gxuzcs6Iq/7bxQ==, tarball: https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.5.tgz}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
   '@esbuild/freebsd-arm64@0.25.5':
-    resolution: {integrity: sha512-nk4tGP3JThz4La38Uy/gzyXtpkPW8zSAmoUhK9xKKXdBCzKODMc2adkB2+8om9BDYugz+uGV7sLmpTYzvmz6Sw==}
+    resolution: {integrity: sha512-nk4tGP3JThz4La38Uy/gzyXtpkPW8zSAmoUhK9xKKXdBCzKODMc2adkB2+8om9BDYugz+uGV7sLmpTYzvmz6Sw==, tarball: https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.5.tgz}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.25.5':
-    resolution: {integrity: sha512-PrikaNjiXdR2laW6OIjlbeuCPrPaAl0IwPIaRv+SMV8CiM8i2LqVUHFC1+8eORgWyY7yhQY+2U2fA55mBzReaw==}
+    resolution: {integrity: sha512-PrikaNjiXdR2laW6OIjlbeuCPrPaAl0IwPIaRv+SMV8CiM8i2LqVUHFC1+8eORgWyY7yhQY+2U2fA55mBzReaw==, tarball: https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.5.tgz}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
   '@esbuild/linux-arm64@0.25.5':
-    resolution: {integrity: sha512-Z9kfb1v6ZlGbWj8EJk9T6czVEjjq2ntSYLY2cw6pAZl4oKtfgQuS4HOq41M/BcoLPzrUbNd+R4BXFyH//nHxVg==}
+    resolution: {integrity: sha512-Z9kfb1v6ZlGbWj8EJk9T6czVEjjq2ntSYLY2cw6pAZl4oKtfgQuS4HOq41M/BcoLPzrUbNd+R4BXFyH//nHxVg==, tarball: https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.5.tgz}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
 
   '@esbuild/linux-arm@0.25.5':
-    resolution: {integrity: sha512-cPzojwW2okgh7ZlRpcBEtsX7WBuqbLrNXqLU89GxWbNt6uIg78ET82qifUy3W6OVww6ZWobWub5oqZOVtwolfw==}
+    resolution: {integrity: sha512-cPzojwW2okgh7ZlRpcBEtsX7WBuqbLrNXqLU89GxWbNt6uIg78ET82qifUy3W6OVww6ZWobWub5oqZOVtwolfw==, tarball: https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.5.tgz}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-ia32@0.25.5':
-    resolution: {integrity: sha512-sQ7l00M8bSv36GLV95BVAdhJ2QsIbCuCjh/uYrWiMQSUuV+LpXwIqhgJDcvMTj+VsQmqAHL2yYaasENvJ7CDKA==}
+    resolution: {integrity: sha512-sQ7l00M8bSv36GLV95BVAdhJ2QsIbCuCjh/uYrWiMQSUuV+LpXwIqhgJDcvMTj+VsQmqAHL2yYaasENvJ7CDKA==, tarball: https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.5.tgz}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
 
   '@esbuild/linux-loong64@0.25.5':
-    resolution: {integrity: sha512-0ur7ae16hDUC4OL5iEnDb0tZHDxYmuQyhKhsPBV8f99f6Z9KQM02g33f93rNH5A30agMS46u2HP6qTdEt6Q1kg==}
+    resolution: {integrity: sha512-0ur7ae16hDUC4OL5iEnDb0tZHDxYmuQyhKhsPBV8f99f6Z9KQM02g33f93rNH5A30agMS46u2HP6qTdEt6Q1kg==, tarball: https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.5.tgz}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-mips64el@0.25.5':
-    resolution: {integrity: sha512-kB/66P1OsHO5zLz0i6X0RxlQ+3cu0mkxS3TKFvkb5lin6uwZ/ttOkP3Z8lfR9mJOBk14ZwZ9182SIIWFGNmqmg==}
+    resolution: {integrity: sha512-kB/66P1OsHO5zLz0i6X0RxlQ+3cu0mkxS3TKFvkb5lin6uwZ/ttOkP3Z8lfR9mJOBk14ZwZ9182SIIWFGNmqmg==, tarball: https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.5.tgz}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.25.5':
-    resolution: {integrity: sha512-UZCmJ7r9X2fe2D6jBmkLBMQetXPXIsZjQJCjgwpVDz+YMcS6oFR27alkgGv3Oqkv07bxdvw7fyB71/olceJhkQ==}
+    resolution: {integrity: sha512-UZCmJ7r9X2fe2D6jBmkLBMQetXPXIsZjQJCjgwpVDz+YMcS6oFR27alkgGv3Oqkv07bxdvw7fyB71/olceJhkQ==, tarball: https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.5.tgz}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-riscv64@0.25.5':
-    resolution: {integrity: sha512-kTxwu4mLyeOlsVIFPfQo+fQJAV9mh24xL+y+Bm6ej067sYANjyEw1dNHmvoqxJUCMnkBdKpvOn0Ahql6+4VyeA==}
+    resolution: {integrity: sha512-kTxwu4mLyeOlsVIFPfQo+fQJAV9mh24xL+y+Bm6ej067sYANjyEw1dNHmvoqxJUCMnkBdKpvOn0Ahql6+4VyeA==, tarball: https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.5.tgz}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
   '@esbuild/linux-s390x@0.25.5':
-    resolution: {integrity: sha512-K2dSKTKfmdh78uJ3NcWFiqyRrimfdinS5ErLSn3vluHNeHVnBAFWC8a4X5N+7FgVE1EjXS1QDZbpqZBjfrqMTQ==}
+    resolution: {integrity: sha512-K2dSKTKfmdh78uJ3NcWFiqyRrimfdinS5ErLSn3vluHNeHVnBAFWC8a4X5N+7FgVE1EjXS1QDZbpqZBjfrqMTQ==, tarball: https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.5.tgz}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-x64@0.25.5':
-    resolution: {integrity: sha512-uhj8N2obKTE6pSZ+aMUbqq+1nXxNjZIIjCjGLfsWvVpy7gKCOL6rsY1MhRh9zLtUtAI7vpgLMK6DxjO8Qm9lJw==}
+    resolution: {integrity: sha512-uhj8N2obKTE6pSZ+aMUbqq+1nXxNjZIIjCjGLfsWvVpy7gKCOL6rsY1MhRh9zLtUtAI7vpgLMK6DxjO8Qm9lJw==, tarball: https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.5.tgz}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
   '@esbuild/netbsd-arm64@0.25.5':
-    resolution: {integrity: sha512-pwHtMP9viAy1oHPvgxtOv+OkduK5ugofNTVDilIzBLpoWAM16r7b/mxBvfpuQDpRQFMfuVr5aLcn4yveGvBZvw==}
+    resolution: {integrity: sha512-pwHtMP9viAy1oHPvgxtOv+OkduK5ugofNTVDilIzBLpoWAM16r7b/mxBvfpuQDpRQFMfuVr5aLcn4yveGvBZvw==, tarball: https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.5.tgz}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
 
   '@esbuild/netbsd-x64@0.25.5':
-    resolution: {integrity: sha512-WOb5fKrvVTRMfWFNCroYWWklbnXH0Q5rZppjq0vQIdlsQKuw6mdSihwSo4RV/YdQ5UCKKvBy7/0ZZYLBZKIbwQ==}
+    resolution: {integrity: sha512-WOb5fKrvVTRMfWFNCroYWWklbnXH0Q5rZppjq0vQIdlsQKuw6mdSihwSo4RV/YdQ5UCKKvBy7/0ZZYLBZKIbwQ==, tarball: https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.5.tgz}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
 
   '@esbuild/openbsd-arm64@0.25.5':
-    resolution: {integrity: sha512-7A208+uQKgTxHd0G0uqZO8UjK2R0DDb4fDmERtARjSHWxqMTye4Erz4zZafx7Di9Cv+lNHYuncAkiGFySoD+Mw==}
+    resolution: {integrity: sha512-7A208+uQKgTxHd0G0uqZO8UjK2R0DDb4fDmERtARjSHWxqMTye4Erz4zZafx7Di9Cv+lNHYuncAkiGFySoD+Mw==, tarball: https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.5.tgz}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.25.5':
-    resolution: {integrity: sha512-G4hE405ErTWraiZ8UiSoesH8DaCsMm0Cay4fsFWOOUcz8b8rC6uCvnagr+gnioEjWn0wC+o1/TAHt+It+MpIMg==}
+    resolution: {integrity: sha512-G4hE405ErTWraiZ8UiSoesH8DaCsMm0Cay4fsFWOOUcz8b8rC6uCvnagr+gnioEjWn0wC+o1/TAHt+It+MpIMg==, tarball: https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.5.tgz}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
   '@esbuild/sunos-x64@0.25.5':
-    resolution: {integrity: sha512-l+azKShMy7FxzY0Rj4RCt5VD/q8mG/e+mDivgspo+yL8zW7qEwctQ6YqKX34DTEleFAvCIUviCFX1SDZRSyMQA==}
+    resolution: {integrity: sha512-l+azKShMy7FxzY0Rj4RCt5VD/q8mG/e+mDivgspo+yL8zW7qEwctQ6YqKX34DTEleFAvCIUviCFX1SDZRSyMQA==, tarball: https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.5.tgz}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
   '@esbuild/win32-arm64@0.25.5':
-    resolution: {integrity: sha512-O2S7SNZzdcFG7eFKgvwUEZ2VG9D/sn/eIiz8XRZ1Q/DO5a3s76Xv0mdBzVM5j5R639lXQmPmSo0iRpHqUUrsxw==}
+    resolution: {integrity: sha512-O2S7SNZzdcFG7eFKgvwUEZ2VG9D/sn/eIiz8XRZ1Q/DO5a3s76Xv0mdBzVM5j5R639lXQmPmSo0iRpHqUUrsxw==, tarball: https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.5.tgz}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
   '@esbuild/win32-ia32@0.25.5':
-    resolution: {integrity: sha512-onOJ02pqs9h1iMJ1PQphR+VZv8qBMQ77Klcsqv9CNW2w6yLqoURLcgERAIurY6QE63bbLuqgP9ATqajFLK5AMQ==}
+    resolution: {integrity: sha512-onOJ02pqs9h1iMJ1PQphR+VZv8qBMQ77Klcsqv9CNW2w6yLqoURLcgERAIurY6QE63bbLuqgP9ATqajFLK5AMQ==, tarball: https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.5.tgz}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
   '@esbuild/win32-x64@0.25.5':
-    resolution: {integrity: sha512-TXv6YnJ8ZMVdX+SXWVBo/0p8LTcrUYngpWjvm91TMjjBQii7Oz11Lw5lbDV5Y0TzuhSJHwiH4hEtC1I42mMS0g==}
+    resolution: {integrity: sha512-TXv6YnJ8ZMVdX+SXWVBo/0p8LTcrUYngpWjvm91TMjjBQii7Oz11Lw5lbDV5Y0TzuhSJHwiH4hEtC1I42mMS0g==, tarball: https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.5.tgz}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -454,7 +457,7 @@ packages:
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
 
   '@napi-rs/wasm-runtime@0.2.11':
-    resolution: {integrity: sha512-9DPkXtvHydrcOsopiYpUgPHpmj0HWZKMUnL2dZqpvC42lsratuBG06V5ipyno0fUek5VlFsNQ+AcFATSrJXgMA==}
+    resolution: {integrity: sha512-9DPkXtvHydrcOsopiYpUgPHpmj0HWZKMUnL2dZqpvC42lsratuBG06V5ipyno0fUek5VlFsNQ+AcFATSrJXgMA==, tarball: https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.11.tgz}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -469,102 +472,102 @@ packages:
     engines: {node: '>= 8'}
 
   '@rollup/rollup-android-arm-eabi@4.43.0':
-    resolution: {integrity: sha512-Krjy9awJl6rKbruhQDgivNbD1WuLb8xAclM4IR4cN5pHGAs2oIMMQJEiC3IC/9TZJ+QZkmZhlMO/6MBGxPidpw==}
+    resolution: {integrity: sha512-Krjy9awJl6rKbruhQDgivNbD1WuLb8xAclM4IR4cN5pHGAs2oIMMQJEiC3IC/9TZJ+QZkmZhlMO/6MBGxPidpw==, tarball: https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.43.0.tgz}
     cpu: [arm]
     os: [android]
 
   '@rollup/rollup-android-arm64@4.43.0':
-    resolution: {integrity: sha512-ss4YJwRt5I63454Rpj+mXCXicakdFmKnUNxr1dLK+5rv5FJgAxnN7s31a5VchRYxCFWdmnDWKd0wbAdTr0J5EA==}
+    resolution: {integrity: sha512-ss4YJwRt5I63454Rpj+mXCXicakdFmKnUNxr1dLK+5rv5FJgAxnN7s31a5VchRYxCFWdmnDWKd0wbAdTr0J5EA==, tarball: https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.43.0.tgz}
     cpu: [arm64]
     os: [android]
 
   '@rollup/rollup-darwin-arm64@4.43.0':
-    resolution: {integrity: sha512-eKoL8ykZ7zz8MjgBenEF2OoTNFAPFz1/lyJ5UmmFSz5jW+7XbH1+MAgCVHy72aG59rbuQLcJeiMrP8qP5d/N0A==}
+    resolution: {integrity: sha512-eKoL8ykZ7zz8MjgBenEF2OoTNFAPFz1/lyJ5UmmFSz5jW+7XbH1+MAgCVHy72aG59rbuQLcJeiMrP8qP5d/N0A==, tarball: https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.43.0.tgz}
     cpu: [arm64]
     os: [darwin]
 
   '@rollup/rollup-darwin-x64@4.43.0':
-    resolution: {integrity: sha512-SYwXJgaBYW33Wi/q4ubN+ldWC4DzQY62S4Ll2dgfr/dbPoF50dlQwEaEHSKrQdSjC6oIe1WgzosoaNoHCdNuMg==}
+    resolution: {integrity: sha512-SYwXJgaBYW33Wi/q4ubN+ldWC4DzQY62S4Ll2dgfr/dbPoF50dlQwEaEHSKrQdSjC6oIe1WgzosoaNoHCdNuMg==, tarball: https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.43.0.tgz}
     cpu: [x64]
     os: [darwin]
 
   '@rollup/rollup-freebsd-arm64@4.43.0':
-    resolution: {integrity: sha512-SV+U5sSo0yujrjzBF7/YidieK2iF6E7MdF6EbYxNz94lA+R0wKl3SiixGyG/9Klab6uNBIqsN7j4Y/Fya7wAjQ==}
+    resolution: {integrity: sha512-SV+U5sSo0yujrjzBF7/YidieK2iF6E7MdF6EbYxNz94lA+R0wKl3SiixGyG/9Klab6uNBIqsN7j4Y/Fya7wAjQ==, tarball: https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.43.0.tgz}
     cpu: [arm64]
     os: [freebsd]
 
   '@rollup/rollup-freebsd-x64@4.43.0':
-    resolution: {integrity: sha512-J7uCsiV13L/VOeHJBo5SjasKiGxJ0g+nQTrBkAsmQBIdil3KhPnSE9GnRon4ejX1XDdsmK/l30IYLiAaQEO0Cg==}
+    resolution: {integrity: sha512-J7uCsiV13L/VOeHJBo5SjasKiGxJ0g+nQTrBkAsmQBIdil3KhPnSE9GnRon4ejX1XDdsmK/l30IYLiAaQEO0Cg==, tarball: https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.43.0.tgz}
     cpu: [x64]
     os: [freebsd]
 
   '@rollup/rollup-linux-arm-gnueabihf@4.43.0':
-    resolution: {integrity: sha512-gTJ/JnnjCMc15uwB10TTATBEhK9meBIY+gXP4s0sHD1zHOaIh4Dmy1X9wup18IiY9tTNk5gJc4yx9ctj/fjrIw==}
+    resolution: {integrity: sha512-gTJ/JnnjCMc15uwB10TTATBEhK9meBIY+gXP4s0sHD1zHOaIh4Dmy1X9wup18IiY9tTNk5gJc4yx9ctj/fjrIw==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.43.0.tgz}
     cpu: [arm]
     os: [linux]
 
   '@rollup/rollup-linux-arm-musleabihf@4.43.0':
-    resolution: {integrity: sha512-ZJ3gZynL1LDSIvRfz0qXtTNs56n5DI2Mq+WACWZ7yGHFUEirHBRt7fyIk0NsCKhmRhn7WAcjgSkSVVxKlPNFFw==}
+    resolution: {integrity: sha512-ZJ3gZynL1LDSIvRfz0qXtTNs56n5DI2Mq+WACWZ7yGHFUEirHBRt7fyIk0NsCKhmRhn7WAcjgSkSVVxKlPNFFw==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.43.0.tgz}
     cpu: [arm]
     os: [linux]
 
   '@rollup/rollup-linux-arm64-gnu@4.43.0':
-    resolution: {integrity: sha512-8FnkipasmOOSSlfucGYEu58U8cxEdhziKjPD2FIa0ONVMxvl/hmONtX/7y4vGjdUhjcTHlKlDhw3H9t98fPvyA==}
+    resolution: {integrity: sha512-8FnkipasmOOSSlfucGYEu58U8cxEdhziKjPD2FIa0ONVMxvl/hmONtX/7y4vGjdUhjcTHlKlDhw3H9t98fPvyA==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.43.0.tgz}
     cpu: [arm64]
     os: [linux]
 
   '@rollup/rollup-linux-arm64-musl@4.43.0':
-    resolution: {integrity: sha512-KPPyAdlcIZ6S9C3S2cndXDkV0Bb1OSMsX0Eelr2Bay4EsF9yi9u9uzc9RniK3mcUGCLhWY9oLr6er80P5DE6XA==}
+    resolution: {integrity: sha512-KPPyAdlcIZ6S9C3S2cndXDkV0Bb1OSMsX0Eelr2Bay4EsF9yi9u9uzc9RniK3mcUGCLhWY9oLr6er80P5DE6XA==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.43.0.tgz}
     cpu: [arm64]
     os: [linux]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.43.0':
-    resolution: {integrity: sha512-HPGDIH0/ZzAZjvtlXj6g+KDQ9ZMHfSP553za7o2Odegb/BEfwJcR0Sw0RLNpQ9nC6Gy8s+3mSS9xjZ0n3rhcYg==}
+    resolution: {integrity: sha512-HPGDIH0/ZzAZjvtlXj6g+KDQ9ZMHfSP553za7o2Odegb/BEfwJcR0Sw0RLNpQ9nC6Gy8s+3mSS9xjZ0n3rhcYg==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.43.0.tgz}
     cpu: [loong64]
     os: [linux]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.43.0':
-    resolution: {integrity: sha512-gEmwbOws4U4GLAJDhhtSPWPXUzDfMRedT3hFMyRAvM9Mrnj+dJIFIeL7otsv2WF3D7GrV0GIewW0y28dOYWkmw==}
+    resolution: {integrity: sha512-gEmwbOws4U4GLAJDhhtSPWPXUzDfMRedT3hFMyRAvM9Mrnj+dJIFIeL7otsv2WF3D7GrV0GIewW0y28dOYWkmw==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.43.0.tgz}
     cpu: [ppc64]
     os: [linux]
 
   '@rollup/rollup-linux-riscv64-gnu@4.43.0':
-    resolution: {integrity: sha512-XXKvo2e+wFtXZF/9xoWohHg+MuRnvO29TI5Hqe9xwN5uN8NKUYy7tXUG3EZAlfchufNCTHNGjEx7uN78KsBo0g==}
+    resolution: {integrity: sha512-XXKvo2e+wFtXZF/9xoWohHg+MuRnvO29TI5Hqe9xwN5uN8NKUYy7tXUG3EZAlfchufNCTHNGjEx7uN78KsBo0g==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.43.0.tgz}
     cpu: [riscv64]
     os: [linux]
 
   '@rollup/rollup-linux-riscv64-musl@4.43.0':
-    resolution: {integrity: sha512-ruf3hPWhjw6uDFsOAzmbNIvlXFXlBQ4nk57Sec8E8rUxs/AI4HD6xmiiasOOx/3QxS2f5eQMKTAwk7KHwpzr/Q==}
+    resolution: {integrity: sha512-ruf3hPWhjw6uDFsOAzmbNIvlXFXlBQ4nk57Sec8E8rUxs/AI4HD6xmiiasOOx/3QxS2f5eQMKTAwk7KHwpzr/Q==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.43.0.tgz}
     cpu: [riscv64]
     os: [linux]
 
   '@rollup/rollup-linux-s390x-gnu@4.43.0':
-    resolution: {integrity: sha512-QmNIAqDiEMEvFV15rsSnjoSmO0+eJLoKRD9EAa9rrYNwO/XRCtOGM3A5A0X+wmG+XRrw9Fxdsw+LnyYiZWWcVw==}
+    resolution: {integrity: sha512-QmNIAqDiEMEvFV15rsSnjoSmO0+eJLoKRD9EAa9rrYNwO/XRCtOGM3A5A0X+wmG+XRrw9Fxdsw+LnyYiZWWcVw==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.43.0.tgz}
     cpu: [s390x]
     os: [linux]
 
   '@rollup/rollup-linux-x64-gnu@4.43.0':
-    resolution: {integrity: sha512-jAHr/S0iiBtFyzjhOkAics/2SrXE092qyqEg96e90L3t9Op8OTzS6+IX0Fy5wCt2+KqeHAkti+eitV0wvblEoQ==}
+    resolution: {integrity: sha512-jAHr/S0iiBtFyzjhOkAics/2SrXE092qyqEg96e90L3t9Op8OTzS6+IX0Fy5wCt2+KqeHAkti+eitV0wvblEoQ==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.43.0.tgz}
     cpu: [x64]
     os: [linux]
 
   '@rollup/rollup-linux-x64-musl@4.43.0':
-    resolution: {integrity: sha512-3yATWgdeXyuHtBhrLt98w+5fKurdqvs8B53LaoKD7P7H7FKOONLsBVMNl9ghPQZQuYcceV5CDyPfyfGpMWD9mQ==}
+    resolution: {integrity: sha512-3yATWgdeXyuHtBhrLt98w+5fKurdqvs8B53LaoKD7P7H7FKOONLsBVMNl9ghPQZQuYcceV5CDyPfyfGpMWD9mQ==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.43.0.tgz}
     cpu: [x64]
     os: [linux]
 
   '@rollup/rollup-win32-arm64-msvc@4.43.0':
-    resolution: {integrity: sha512-wVzXp2qDSCOpcBCT5WRWLmpJRIzv23valvcTwMHEobkjippNf+C3ys/+wf07poPkeNix0paTNemB2XrHr2TnGw==}
+    resolution: {integrity: sha512-wVzXp2qDSCOpcBCT5WRWLmpJRIzv23valvcTwMHEobkjippNf+C3ys/+wf07poPkeNix0paTNemB2XrHr2TnGw==, tarball: https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.43.0.tgz}
     cpu: [arm64]
     os: [win32]
 
   '@rollup/rollup-win32-ia32-msvc@4.43.0':
-    resolution: {integrity: sha512-fYCTEyzf8d+7diCw8b+asvWDCLMjsCEA8alvtAutqJOJp/wL5hs1rWSqJ1vkjgW0L2NB4bsYJrpKkiIPRR9dvw==}
+    resolution: {integrity: sha512-fYCTEyzf8d+7diCw8b+asvWDCLMjsCEA8alvtAutqJOJp/wL5hs1rWSqJ1vkjgW0L2NB4bsYJrpKkiIPRR9dvw==, tarball: https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.43.0.tgz}
     cpu: [ia32]
     os: [win32]
 
   '@rollup/rollup-win32-x64-msvc@4.43.0':
-    resolution: {integrity: sha512-SnGhLiE5rlK0ofq8kzuDkM0g7FN1s5VYY+YSMTibP7CqShxCQvqtNxTARS4xX4PFJfHjG0ZQYX9iGzI3FQh5Aw==}
+    resolution: {integrity: sha512-SnGhLiE5rlK0ofq8kzuDkM0g7FN1s5VYY+YSMTibP7CqShxCQvqtNxTARS4xX4PFJfHjG0ZQYX9iGzI3FQh5Aw==, tarball: https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.43.0.tgz}
     cpu: [x64]
     os: [win32]
 
@@ -573,7 +576,7 @@ packages:
     engines: {node: '>=10.13.0'}
 
   '@tybys/wasm-util@0.9.0':
-    resolution: {integrity: sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw==}
+    resolution: {integrity: sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw==, tarball: https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.9.0.tgz}
 
   '@typegpu/color@0.0.5':
     resolution: {integrity: sha512-OoRwt5av85lv4pAw7jZHjL2tCY169TqZT/Z0G1S5hmBqSLmZ3x975RjGfyVhGutOb72sHyobBHtIUEYxgVDliA==}
@@ -676,97 +679,97 @@ packages:
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@unrs/resolver-binding-android-arm-eabi@1.9.0':
-    resolution: {integrity: sha512-h1T2c2Di49ekF2TE8ZCoJkb+jwETKUIPDJ/nO3tJBKlLFPu+fyd93f0rGP/BvArKx2k2HlRM4kqkNarj3dvZlg==}
+    resolution: {integrity: sha512-h1T2c2Di49ekF2TE8ZCoJkb+jwETKUIPDJ/nO3tJBKlLFPu+fyd93f0rGP/BvArKx2k2HlRM4kqkNarj3dvZlg==, tarball: https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.9.0.tgz}
     cpu: [arm]
     os: [android]
 
   '@unrs/resolver-binding-android-arm64@1.9.0':
-    resolution: {integrity: sha512-sG1NHtgXtX8owEkJ11yn34vt0Xqzi3k9TJ8zppDmyG8GZV4kVWw44FHwKwHeEFl07uKPeC4ZoyuQaGh5ruJYPA==}
+    resolution: {integrity: sha512-sG1NHtgXtX8owEkJ11yn34vt0Xqzi3k9TJ8zppDmyG8GZV4kVWw44FHwKwHeEFl07uKPeC4ZoyuQaGh5ruJYPA==, tarball: https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.9.0.tgz}
     cpu: [arm64]
     os: [android]
 
   '@unrs/resolver-binding-darwin-arm64@1.9.0':
-    resolution: {integrity: sha512-nJ9z47kfFnCxN1z/oYZS7HSNsFh43y2asePzTEZpEvK7kGyuShSl3RRXnm/1QaqFL+iP+BjMwuB+DYUymOkA5A==}
+    resolution: {integrity: sha512-nJ9z47kfFnCxN1z/oYZS7HSNsFh43y2asePzTEZpEvK7kGyuShSl3RRXnm/1QaqFL+iP+BjMwuB+DYUymOkA5A==, tarball: https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.9.0.tgz}
     cpu: [arm64]
     os: [darwin]
 
   '@unrs/resolver-binding-darwin-x64@1.9.0':
-    resolution: {integrity: sha512-TK+UA1TTa0qS53rjWn7cVlEKVGz2B6JYe0C++TdQjvWYIyx83ruwh0wd4LRxYBM5HeuAzXcylA9BH2trARXJTw==}
+    resolution: {integrity: sha512-TK+UA1TTa0qS53rjWn7cVlEKVGz2B6JYe0C++TdQjvWYIyx83ruwh0wd4LRxYBM5HeuAzXcylA9BH2trARXJTw==, tarball: https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.9.0.tgz}
     cpu: [x64]
     os: [darwin]
 
   '@unrs/resolver-binding-freebsd-x64@1.9.0':
-    resolution: {integrity: sha512-6uZwzMRFcD7CcCd0vz3Hp+9qIL2jseE/bx3ZjaLwn8t714nYGwiE84WpaMCYjU+IQET8Vu/+BNAGtYD7BG/0yA==}
+    resolution: {integrity: sha512-6uZwzMRFcD7CcCd0vz3Hp+9qIL2jseE/bx3ZjaLwn8t714nYGwiE84WpaMCYjU+IQET8Vu/+BNAGtYD7BG/0yA==, tarball: https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.9.0.tgz}
     cpu: [x64]
     os: [freebsd]
 
   '@unrs/resolver-binding-linux-arm-gnueabihf@1.9.0':
-    resolution: {integrity: sha512-bPUBksQfrgcfv2+mm+AZinaKq8LCFvt5PThYqRotqSuuZK1TVKkhbVMS/jvSRfYl7jr3AoZLYbDkItxgqMKRkg==}
+    resolution: {integrity: sha512-bPUBksQfrgcfv2+mm+AZinaKq8LCFvt5PThYqRotqSuuZK1TVKkhbVMS/jvSRfYl7jr3AoZLYbDkItxgqMKRkg==, tarball: https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.9.0.tgz}
     cpu: [arm]
     os: [linux]
 
   '@unrs/resolver-binding-linux-arm-musleabihf@1.9.0':
-    resolution: {integrity: sha512-uT6E7UBIrTdCsFQ+y0tQd3g5oudmrS/hds5pbU3h4s2t/1vsGWbbSKhBSCD9mcqaqkBwoqlECpUrRJCmldl8PA==}
+    resolution: {integrity: sha512-uT6E7UBIrTdCsFQ+y0tQd3g5oudmrS/hds5pbU3h4s2t/1vsGWbbSKhBSCD9mcqaqkBwoqlECpUrRJCmldl8PA==, tarball: https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.9.0.tgz}
     cpu: [arm]
     os: [linux]
 
   '@unrs/resolver-binding-linux-arm64-gnu@1.9.0':
-    resolution: {integrity: sha512-vdqBh911wc5awE2bX2zx3eflbyv8U9xbE/jVKAm425eRoOVv/VseGZsqi3A3SykckSpF4wSROkbQPvbQFn8EsA==}
+    resolution: {integrity: sha512-vdqBh911wc5awE2bX2zx3eflbyv8U9xbE/jVKAm425eRoOVv/VseGZsqi3A3SykckSpF4wSROkbQPvbQFn8EsA==, tarball: https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.9.0.tgz}
     cpu: [arm64]
     os: [linux]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.9.0':
-    resolution: {integrity: sha512-/8JFZ/SnuDr1lLEVsxsuVwrsGquTvT51RZGvyDB/dOK3oYK2UqeXzgeyq6Otp8FZXQcEYqJwxb9v+gtdXn03eQ==}
+    resolution: {integrity: sha512-/8JFZ/SnuDr1lLEVsxsuVwrsGquTvT51RZGvyDB/dOK3oYK2UqeXzgeyq6Otp8FZXQcEYqJwxb9v+gtdXn03eQ==, tarball: https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.9.0.tgz}
     cpu: [arm64]
     os: [linux]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.9.0':
-    resolution: {integrity: sha512-FkJjybtrl+rajTw4loI3L6YqSOpeZfDls4SstL/5lsP2bka9TiHUjgMBjygeZEis1oC8LfJTS8FSgpKPaQx2tQ==}
+    resolution: {integrity: sha512-FkJjybtrl+rajTw4loI3L6YqSOpeZfDls4SstL/5lsP2bka9TiHUjgMBjygeZEis1oC8LfJTS8FSgpKPaQx2tQ==, tarball: https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.9.0.tgz}
     cpu: [ppc64]
     os: [linux]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.9.0':
-    resolution: {integrity: sha512-w/NZfHNeDusbqSZ8r/hp8iL4S39h4+vQMc9/vvzuIKMWKppyUGKm3IST0Qv0aOZ1rzIbl9SrDeIqK86ZpUK37w==}
+    resolution: {integrity: sha512-w/NZfHNeDusbqSZ8r/hp8iL4S39h4+vQMc9/vvzuIKMWKppyUGKm3IST0Qv0aOZ1rzIbl9SrDeIqK86ZpUK37w==, tarball: https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.9.0.tgz}
     cpu: [riscv64]
     os: [linux]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.9.0':
-    resolution: {integrity: sha512-bEPBosut8/8KQbUixPry8zg/fOzVOWyvwzOfz0C0Rw6dp+wIBseyiHKjkcSyZKv/98edrbMknBaMNJfA/UEdqw==}
+    resolution: {integrity: sha512-bEPBosut8/8KQbUixPry8zg/fOzVOWyvwzOfz0C0Rw6dp+wIBseyiHKjkcSyZKv/98edrbMknBaMNJfA/UEdqw==, tarball: https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.9.0.tgz}
     cpu: [riscv64]
     os: [linux]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.9.0':
-    resolution: {integrity: sha512-LDtMT7moE3gK753gG4pc31AAqGUC86j3AplaFusc717EUGF9ZFJ356sdQzzZzkBk1XzMdxFyZ4f/i35NKM/lFA==}
+    resolution: {integrity: sha512-LDtMT7moE3gK753gG4pc31AAqGUC86j3AplaFusc717EUGF9ZFJ356sdQzzZzkBk1XzMdxFyZ4f/i35NKM/lFA==, tarball: https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.9.0.tgz}
     cpu: [s390x]
     os: [linux]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.9.0':
-    resolution: {integrity: sha512-WmFd5KINHIXj8o1mPaT8QRjA9HgSXhN1gl9Da4IZihARihEnOylu4co7i/yeaIpcfsI6sYs33cNZKyHYDh0lrA==}
+    resolution: {integrity: sha512-WmFd5KINHIXj8o1mPaT8QRjA9HgSXhN1gl9Da4IZihARihEnOylu4co7i/yeaIpcfsI6sYs33cNZKyHYDh0lrA==, tarball: https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.9.0.tgz}
     cpu: [x64]
     os: [linux]
 
   '@unrs/resolver-binding-linux-x64-musl@1.9.0':
-    resolution: {integrity: sha512-CYuXbANW+WgzVRIl8/QvZmDaZxrqvOldOwlbUjIM4pQ46FJ0W5cinJ/Ghwa/Ng1ZPMJMk1VFdsD/XwmCGIXBWg==}
+    resolution: {integrity: sha512-CYuXbANW+WgzVRIl8/QvZmDaZxrqvOldOwlbUjIM4pQ46FJ0W5cinJ/Ghwa/Ng1ZPMJMk1VFdsD/XwmCGIXBWg==, tarball: https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.9.0.tgz}
     cpu: [x64]
     os: [linux]
 
   '@unrs/resolver-binding-wasm32-wasi@1.9.0':
-    resolution: {integrity: sha512-6Rp2WH0OoitMYR57Z6VE8Y6corX8C6QEMWLgOV6qXiJIeZ1F9WGXY/yQ8yDC4iTraotyLOeJ2Asea0urWj2fKQ==}
+    resolution: {integrity: sha512-6Rp2WH0OoitMYR57Z6VE8Y6corX8C6QEMWLgOV6qXiJIeZ1F9WGXY/yQ8yDC4iTraotyLOeJ2Asea0urWj2fKQ==, tarball: https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.9.0.tgz}
     engines: {node: '>=14.0.0'}
     cpu: [wasm32]
 
   '@unrs/resolver-binding-win32-arm64-msvc@1.9.0':
-    resolution: {integrity: sha512-rknkrTRuvujprrbPmGeHi8wYWxmNVlBoNW8+4XF2hXUnASOjmuC9FNF1tGbDiRQWn264q9U/oGtixyO3BT8adQ==}
+    resolution: {integrity: sha512-rknkrTRuvujprrbPmGeHi8wYWxmNVlBoNW8+4XF2hXUnASOjmuC9FNF1tGbDiRQWn264q9U/oGtixyO3BT8adQ==, tarball: https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.9.0.tgz}
     cpu: [arm64]
     os: [win32]
 
   '@unrs/resolver-binding-win32-ia32-msvc@1.9.0':
-    resolution: {integrity: sha512-Ceymm+iBl+bgAICtgiHyMLz6hjxmLJKqBim8tDzpX61wpZOx2bPK6Gjuor7I2RiUynVjvvkoRIkrPyMwzBzF3A==}
+    resolution: {integrity: sha512-Ceymm+iBl+bgAICtgiHyMLz6hjxmLJKqBim8tDzpX61wpZOx2bPK6Gjuor7I2RiUynVjvvkoRIkrPyMwzBzF3A==, tarball: https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.9.0.tgz}
     cpu: [ia32]
     os: [win32]
 
   '@unrs/resolver-binding-win32-x64-msvc@1.9.0':
-    resolution: {integrity: sha512-k59o9ZyeyS0hAlcaKFezYSH2agQeRFEB7KoQLXl3Nb3rgkqT1NY9Vwy+SqODiLmYnEjxWJVRE/yq2jFVqdIxZw==}
+    resolution: {integrity: sha512-k59o9ZyeyS0hAlcaKFezYSH2agQeRFEB7KoQLXl3Nb3rgkqT1NY9Vwy+SqODiLmYnEjxWJVRE/yq2jFVqdIxZw==, tarball: https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.9.0.tgz}
     cpu: [x64]
     os: [win32]
 
@@ -974,7 +977,7 @@ packages:
     engines: {node: '>=18'}
 
   csstype@3.1.3:
-    resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
+    resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==, tarball: https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz}
 
   data-urls@5.0.0:
     resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
@@ -1176,7 +1179,7 @@ packages:
     resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
 
   fsevents@2.3.3:
-    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==, tarball: https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
@@ -1548,13 +1551,13 @@ packages:
     hasBin: true
 
   seroval-plugins@1.3.2:
-    resolution: {integrity: sha512-0QvCV2lM3aj/U3YozDiVwx9zpH0q8A60CTWIv4Jszj/givcudPb48B+rkU5D51NJ0pTpweGMttHjboPa9/zoIQ==}
+    resolution: {integrity: sha512-0QvCV2lM3aj/U3YozDiVwx9zpH0q8A60CTWIv4Jszj/givcudPb48B+rkU5D51NJ0pTpweGMttHjboPa9/zoIQ==, tarball: https://registry.npmjs.org/seroval-plugins/-/seroval-plugins-1.3.2.tgz}
     engines: {node: '>=10'}
     peerDependencies:
       seroval: ^1.0
 
   seroval@1.3.2:
-    resolution: {integrity: sha512-RbcPH1n5cfwKrru7v7+zrZvjLurgHhGyso3HTyGtRivGWgYjbOmGuivCQaORNELjNONoK35nj28EoWul9sb1zQ==}
+    resolution: {integrity: sha512-RbcPH1n5cfwKrru7v7+zrZvjLurgHhGyso3HTyGtRivGWgYjbOmGuivCQaORNELjNONoK35nj28EoWul9sb1zQ==, tarball: https://registry.npmjs.org/seroval/-/seroval-1.3.2.tgz}
     engines: {node: '>=10'}
 
   shebang-command@2.0.0:
@@ -1569,7 +1572,7 @@ packages:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
   solid-js@1.9.7:
-    resolution: {integrity: sha512-/saTKi8iWEM233n5OSi1YHCCuh66ZIQ7aK2hsToPe4tqGm7qAejU1SwNuTPivbWAYq7SjuHVVYxxuZQNRbICiw==}
+    resolution: {integrity: sha512-/saTKi8iWEM233n5OSi1YHCCuh66ZIQ7aK2hsToPe4tqGm7qAejU1SwNuTPivbWAYq7SjuHVVYxxuZQNRbICiw==, tarball: https://registry.npmjs.org/solid-js/-/solid-js-1.9.7.tgz}
 
   solid-refresh@0.6.3:
     resolution: {integrity: sha512-F3aPsX6hVw9ttm5LYlth8Q15x6MlI/J3Dn+o3EQyRTtTxidepSTwAYdozt01/YA+7ObcciagGEyXIopGZzQtbA==}
@@ -1672,7 +1675,7 @@ packages:
     engines: {node: '>=6'}
 
   tslib@2.8.1:
-    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==, tarball: https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz}
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -1716,6 +1719,14 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  valibot@1.1.0:
+    resolution: {integrity: sha512-Nk8lX30Qhu+9txPYTwM0cFlWLdPFsFr6LblzqIySfbZph9+BFsAHsNvHOymEviUepeIW6KFHzpX8TKhbptBXXw==, tarball: https://registry.npmjs.org/valibot/-/valibot-1.1.0.tgz}
+    peerDependencies:
+      typescript: '>=5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   validate-html-nesting@1.2.2:
     resolution: {integrity: sha512-hGdgQozCsQJMyfK5urgFcWEqsSSrK63Awe0t/IMR0bZ0QMtnuaiHzThW81guu3qx9abLi99NEuiaN6P9gVYsNg==}
@@ -3435,6 +3446,10 @@ snapshots:
       punycode: 2.3.1
 
   util-deprecate@1.0.2: {}
+
+  valibot@1.1.0(typescript@5.8.3):
+    optionalDependencies:
+      typescript: 5.8.3
 
   validate-html-nesting@1.2.2: {}
 


### PR DESCRIPTION
Add all validated schemas
Validate all examples to infer output types
Update schema for draw mode
All variations are now using valibot defined defaults and they infer typegpu types from those structures
Add valibot on PNG load
Fix tsconfig and utils
Update variation schema
Resolve all warnings and type errors