### PR TITLE
Use typepu compilation plugin for variations

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.46.2",
     "typescript-plugin-css-modules": "^5.2.0",
+    "unplugin-typegpu": "^0.8.0",
     "vite": "^7.1.12",
     "vite-bundle-analyzer": "^1.2.3",
     "vite-plugin-solid": "^2.11.10",

--- a/packages/app/src/flame/affineTranform.ts
+++ b/packages/app/src/flame/affineTranform.ts
@@ -24,11 +24,6 @@ export const AffineParams = struct({
 export const transformAffine = tgpu.fn(
   [AffineParams, vec2f],
   vec2f,
-) /* wgsl */ `
-  (T: AffineParams, p: vec2f) -> vec2f {
-    return vec2f(
-      T.a * p.x + T.b * p.y + T.c,
-      T.d * p.x + T.e * p.y + T.f
-    );
-  }
-`
+)((T, p) => {
+  return vec2f(T.a * p.x + T.b * p.y + T.c, T.d * p.x + T.e * p.y + T.f)
+})

--- a/packages/app/src/flame/blurPipeline.ts
+++ b/packages/app/src/flame/blurPipeline.ts
@@ -18,11 +18,11 @@ const bindGroupLayout = tgpu.bindGroupLayout({
     uniform: vec2i,
   },
   accumulationBuffer: {
-    storage: (length: number) => arrayOf(Bucket, length),
+    storage: arrayOf(Bucket),
     access: 'readonly',
   },
   postprocessBuffer: {
-    storage: (length: number) => arrayOf(Bucket, length),
+    storage: arrayOf(Bucket),
     access: 'mutable',
   },
 })
@@ -49,7 +49,7 @@ export function createBlurPipeline(
     textureSize: textureSizeBuffer,
   })
 
-  const blurCode = wgsl/* wgsl */ `
+  const blurCode = wgsl /* wgsl */ `
     ${{
       ...bindGroupLayout.bound,
     }}

--- a/packages/app/src/flame/colorGrading.ts
+++ b/packages/app/src/flame/colorGrading.ts
@@ -22,7 +22,7 @@ const bindGroupLayout = tgpu.bindGroupLayout({
     uniform: vec2i,
   },
   accumulationBuffer: {
-    storage: (length: number) => arrayOf(Bucket, length),
+    storage: arrayOf(Bucket),
     access: 'readonly',
   },
 })
@@ -49,7 +49,7 @@ export function createColorGradingPipeline(
     textureSize: textureSizeBuffer,
   })
 
-  const renderShaderCode = wgsl/* wgsl */ `
+  const renderShaderCode = wgsl /* wgsl */ `
     ${{
       ...bindGroupLayout.bound,
       oklabToRgb: oklabToRgb.with(

--- a/packages/app/src/flame/drawMode.ts
+++ b/packages/app/src/flame/drawMode.ts
@@ -1,5 +1,6 @@
 import { tgpu } from 'typegpu'
 import { f32 } from 'typegpu/data'
+import { clamp } from 'typegpu/std'
 import { recordKeys } from '@/utils/record'
 import * as v from '@/valibot'
 import type { TgpuFn } from 'typegpu'
@@ -7,13 +8,15 @@ import type { F32 } from 'typegpu/data'
 
 export type DrawModeFn = TgpuFn<(x: F32) => F32>
 const drawModeFn = tgpu.fn([f32], f32)
-export const lightMode = drawModeFn(
-  /* wgsl */ ` (x: f32) -> f32 { return clamp(x, 0, 1); }`,
-)
+export const lightMode = drawModeFn((x) => {
+  'use gpu'
+  return clamp(x, 0, 1)
+})
 
-export const paintMode = drawModeFn(
-  /* wgsl */ `(x: f32) -> f32 { return 1 - clamp(x, 0, 1); }`,
-)
+export const paintMode = drawModeFn((x) => {
+  'use gpu'
+  return 1 - clamp(x, 0, 1)
+})
 
 export const drawModeToImplFn = {
   light: lightMode,

--- a/packages/app/src/flame/histogramPipeline.ts
+++ b/packages/app/src/flame/histogramPipeline.ts
@@ -16,9 +16,10 @@ const bindGroupLayout = tgpu.bindGroupLayout({
   },
   accumulationTexture: {
     texture: texture2d(f32),
+    sampleType: 'unfilterable-float',
   },
   histogram: {
-    storage: (length: number) => arrayOf(atomic(u32), length),
+    storage: arrayOf(atomic(u32)),
     access: 'mutable',
   },
 })

--- a/packages/app/src/flame/ifsPipeline.ts
+++ b/packages/app/src/flame/ifsPipeline.ts
@@ -48,7 +48,7 @@ export function createIFSPipeline(
 
   const bindGroupLayout = tgpu.bindGroupLayout({
     pointRandomSeeds: {
-      storage: (length: number) => arrayOf(vec4u, length),
+      storage: arrayOf(vec4u),
       access: 'mutable',
     },
     flameUniforms: {
@@ -59,7 +59,7 @@ export function createIFSPipeline(
       uniform: vec2i,
     },
     accumulationBuffer: {
-      storage: (length: number) => arrayOf(AtomicBucket, length),
+      storage: arrayOf(AtomicBucket),
       access: 'mutable',
     },
   })
@@ -77,7 +77,7 @@ export function createIFSPipeline(
     accumulationBuffer,
   })
 
-  const ifsShaderCode = wgsl/* wgsl */ `
+  const ifsShaderCode = wgsl /* wgsl */ `
     ${{
       ...camera.BindGroupLayout.bound,
       ...bindGroupLayout.bound,

--- a/packages/app/src/flame/renderHistogram.ts
+++ b/packages/app/src/flame/renderHistogram.ts
@@ -7,7 +7,7 @@ import type { LayoutEntryToInput, TgpuRoot } from 'typegpu'
 const bindGroupLayout = tgpu
   .bindGroupLayout({
     histogram: {
-      storage: (length: number) => arrayOf(u32, length),
+      storage: arrayOf(u32),
       access: 'readonly',
     },
   })
@@ -25,7 +25,7 @@ export function createRenderHistogramPipeline(
     histogram,
   })
 
-  const renderHistogramShaderCode = wgsl/* wgsl */ `
+  const renderHistogramShaderCode = wgsl /* wgsl */ `
     ${{
       ...bindGroupLayout.bound,
     }}

--- a/packages/app/src/flame/variations/parametric/blob.tsx
+++ b/packages/app/src/flame/variations/parametric/blob.tsx
@@ -1,4 +1,5 @@
-import { f32, struct } from 'typegpu/data'
+import { f32, struct, vec2f } from 'typegpu/data'
+import { atan2, cos, length, sin } from 'typegpu/std'
 import { RangeEditor } from '@/components/Sliders/ParametricEditors/RangeEditor'
 import { editorProps } from '@/components/Sliders/ParametricEditors/types'
 import { parametricVariation } from './types'
@@ -44,16 +45,16 @@ export const blob = parametricVariation(
   BlobParams,
   BlobParamsDefaults,
   BlobParamsEditor,
-  /* wgsl */ `
-  (pos: vec2f, _varInfo: VariationInfo, P: BlobParams) -> vec2f {
-    let p1 = P.high;
-    let p2 = P.low;
-    let p3 = P.waves;
-    let r = length(pos);
-    let theta = atan2(pos.y, pos.x);
-    let sinWavesTheta = sin(p3 * theta);
-    let sinFactor = (p1 - p2) / 2;
-    let blobFact = r * (p2 + sinFactor * (sinWavesTheta + 1));
-    return blobFact * vec2f(cos(theta), sin(theta));
-  }`,
+  (pos, _varInfo, P) => {
+    'use gpu'
+    const p1 = P.high
+    const p2 = P.low
+    const p3 = P.waves
+    const r = length(pos)
+    const theta = atan2(pos.y, pos.x)
+    const sinWavesTheta = sin(p3 * theta)
+    const sinFactor = (p1 - p2) / 2
+    const blobFact = r * (p2 + sinFactor * (sinWavesTheta + 1))
+    return vec2f(cos(theta), sin(theta)).mul(blobFact)
+  },
 )

--- a/packages/app/src/flame/variations/parametric/curl.tsx
+++ b/packages/app/src/flame/variations/parametric/curl.tsx
@@ -1,4 +1,4 @@
-import { f32, struct } from 'typegpu/data'
+import { f32, struct, vec2f } from 'typegpu/data'
 import { RangeEditor } from '@/components/Sliders/ParametricEditors/RangeEditor'
 import { editorProps } from '@/components/Sliders/ParametricEditors/types'
 import { parametricVariation } from './types'
@@ -38,18 +38,15 @@ export const curlVar = parametricVariation(
   CurlParams,
   CurlParamsDefaults,
   CurlParamsEditor,
-  /* wgsl */ `
-  (pos: vec2f, _varInfo: VariationInfo, P: CurlParams) -> vec2f {
-    let p1 = P.c1; 
-    let p2 = P.c2; 
-    let squareDiff = (pos.x * pos.x - pos.y * pos.y);
-    let t1 = 1 + p1 * pos.x + p2 * squareDiff; 
-    let t2 = p1 * pos.y + 2 * p2 * pos.x * pos.y;
-    let tSqSum = t1 * t1 + t2 * t2;
-    let factor = 1 / (tSqSum);
-    return factor * vec2f(
-        pos.x * t1 + pos.y * t2,
-        pos.y * t1 - pos.x * t2
-      );
-  }`,
+  (pos, _varInfo, P) => {
+    'use gpu'
+    const p1 = P.c1
+    const p2 = P.c2
+    const squareDiff = pos.x * pos.x - pos.y * pos.y
+    const t1 = 1 + p1 * pos.x + p2 * squareDiff
+    const t2 = p1 * pos.y + 2 * p2 * pos.x * pos.y
+    const tSqSum = t1 * t1 + t2 * t2
+    const factor = 1 / tSqSum
+    return vec2f(pos.x * t1 + pos.y * t2, pos.y * t1 - pos.x * t2).mul(factor)
+  },
 )

--- a/packages/app/src/flame/variations/parametric/fan2.tsx
+++ b/packages/app/src/flame/variations/parametric/fan2.tsx
@@ -1,4 +1,5 @@
-import { f32, struct } from 'typegpu/data'
+import { f32, struct, vec2f } from 'typegpu/data'
+import { atan2, cos, length, select, sin, trunc } from 'typegpu/std'
 import { RangeEditor } from '@/components/Sliders/ParametricEditors/RangeEditor'
 import { editorProps } from '@/components/Sliders/ParametricEditors/types'
 import { PI } from '@/flame/constants'
@@ -39,19 +40,18 @@ export const fan2 = parametricVariation(
   Fan2Params,
   Fan2ParamsDefaults,
   Fan2ParamsEditor,
-  /* wgsl */ `
-  (pos: vec2f, _varInfo: VariationInfo, P: FanParams) -> vec2f {
-    let p1 = PI * P.x * P.x;
-    let p2 = P.y; 
-    let theta = atan2(pos.y, pos.x);
-    let t = theta + p2 - p1 * trunc((2 * theta * p2) / p1); 
-    let r = length(pos); 
+  (pos, _varInfo, P) => {
+    'use gpu'
+    const p1 = PI.$ * P.x * P.x
+    const p2 = P.y
+    const theta = atan2(pos.y, pos.x)
+    const t = theta + p2 - p1 * trunc((2 * theta * p2) / p1)
+    const r = length(pos)
 
-    let p1half = p1 / 2;
-    let trueAngle = theta - p1half;
-    let falseAngle = theta + p1half;
-    let angle = select(falseAngle, trueAngle, t > p1half);
-    return r * vec2f(sin(angle), cos(angle));
-  }`,
-  { PI },
+    const p1half = p1 / 2
+    const trueAngle = theta - p1half
+    const falseAngle = theta + p1half
+    const angle = select(falseAngle, trueAngle, t > p1half)
+    return vec2f(sin(angle), cos(angle)).mul(r)
+  },
 )

--- a/packages/app/src/flame/variations/parametric/juliaN.tsx
+++ b/packages/app/src/flame/variations/parametric/juliaN.tsx
@@ -1,4 +1,5 @@
-import { f32, struct } from 'typegpu/data'
+import { f32, struct, vec2f } from 'typegpu/data'
+import { abs, atan2, cos, length, pow, sin, trunc } from 'typegpu/std'
 import { RangeEditor } from '@/components/Sliders/ParametricEditors/RangeEditor'
 import { editorProps } from '@/components/Sliders/ParametricEditors/types'
 import { PI } from '@/flame/constants'
@@ -40,16 +41,15 @@ export const juliaN = parametricVariation(
   JuliaNParams,
   JuliaNParamsDefaults,
   JuliaNParamsEditor,
-  /* wgsl */ `
-  (pos: vec2f, _varInfo: VariationInfo, P: JuliaNParams) -> vec2f {
-    let p1 = P.power; 
-    let p2 = P.dist; 
-    let p3 = trunc(abs(p1) * random()); 
-    let r = length(pos);
-    let phi = atan2(pos.y, pos.x);
-    let t = (phi + 2 * PI * p3) / p1;
-    let factor = pow(r, p2 / p1);
-    return factor * vec2f(cos(t), sin(t));
-  }`,
-  { PI, random },
+  (pos, _varInfo, P) => {
+    'use gpu'
+    const p1 = P.power
+    const p2 = P.dist
+    const p3 = trunc(abs(p1) * random())
+    const r = length(pos)
+    const phi = atan2(pos.y, pos.x)
+    const t = (phi + 2 * PI.$ * p3) / p1
+    const factor = pow(r, p2 / p1)
+    return vec2f(cos(t), sin(t)).mul(factor)
+  },
 )

--- a/packages/app/src/flame/variations/parametric/juliaScope.tsx
+++ b/packages/app/src/flame/variations/parametric/juliaScope.tsx
@@ -1,4 +1,5 @@
-import { f32, struct } from 'typegpu/data'
+import { f32, struct, vec2f } from 'typegpu/data'
+import { abs, atan2, cos, length, pow, select, sin, trunc } from 'typegpu/std'
 import { RangeEditor } from '@/components/Sliders/ParametricEditors/RangeEditor'
 import { editorProps } from '@/components/Sliders/ParametricEditors/types'
 import { PI } from '@/flame/constants'
@@ -40,17 +41,16 @@ export const juliaScope = parametricVariation(
   JuliaScopeParams,
   JuliaScopeParamsDefaults,
   JuliaScopeParamsEditor,
-  /* wgsl */ `
-  (pos: vec2f, _varInfo: VariationInfo, P: JuliaScopeParams) -> vec2f {
-    let p1 = P.power; 
-    let p2 = P.dist; 
-    let p3 = trunc(abs(p1) * random()); 
-    let r = length(pos);
-    let phi = atan2(pos.y, pos.x);
-    let lambda = select(-1.0, 1.0, random() > 0.5);
-    let t = (lambda * phi + 2 * PI * p3) / p1;
-    let factor = pow(r, p2 / p1);
-    return factor * vec2f(cos(t), sin(t));
-  }`,
-  { PI, random },
+  (pos, _varInfo, P) => {
+    'use gpu'
+    const p1 = P.power
+    const p2 = P.dist
+    const p3 = trunc(abs(p1) * random())
+    const r = length(pos)
+    const phi = atan2(pos.y, pos.x)
+    const lambda = select(-1.0, 1.0, random() > 0.5)
+    const t = (lambda * phi + 2 * PI.$ * p3) / p1
+    const factor = pow(r, p2 / p1)
+    return vec2f(cos(t), sin(t)).mul(factor)
+  },
 )

--- a/packages/app/src/flame/variations/parametric/ngon.tsx
+++ b/packages/app/src/flame/variations/parametric/ngon.tsx
@@ -1,4 +1,5 @@
 import { f32, struct } from 'typegpu/data'
+import { atan2, cos, floor, length, pow, select } from 'typegpu/std'
 import { RangeEditor } from '@/components/Sliders/ParametricEditors/RangeEditor'
 import { editorProps } from '@/components/Sliders/ParametricEditors/types'
 import { PI } from '@/flame/constants'
@@ -55,20 +56,19 @@ export const ngonVar = parametricVariation(
   NgonParams,
   NgonParamsDefaults,
   NgonParamsEditor,
-  /* wgsl */ `
-  (pos: vec2f, varInfo: VariationInfo, P: NgonParams) -> vec2f {
-    let p1 = P.power; 
-    let p2 = 2 * PI / P.sides; 
-    let p3 = P.corners; 
-    let p4 = P.circle; 
-    let phi = atan2(pos.y, pos.x);
-    let r = length(pos); 
-    let t3 = phi - p2 * floor(phi / p2);
-    let t4 = select(t3 - p2, t3, t3 > p2 / 2);
-    let kNum = p3 * (1/cos(t4) - 1) + p4;
-    let kDen = pow(r, p1);
-    let k = kNum / kDen;
-    return  k * pos;
-  }`,
-  { PI },
+  (pos, _varInfo, P) => {
+    'use gpu'
+    const p1 = P.power
+    const p2 = (2 * PI.$) / P.sides
+    const p3 = P.corners
+    const p4 = P.circle
+    const phi = atan2(pos.y, pos.x)
+    const r = length(pos)
+    const t3 = phi - p2 * floor(phi / p2)
+    const t4 = select(t3 - p2, t3, t3 > p2 / 2)
+    const kNum = p3 * (1 / cos(t4) - 1) + p4
+    const kDen = pow(r, p1)
+    const k = kNum / kDen
+    return pos.mul(k)
+  },
 )

--- a/packages/app/src/flame/variations/parametric/pdj.tsx
+++ b/packages/app/src/flame/variations/parametric/pdj.tsx
@@ -1,4 +1,5 @@
-import { f32, struct } from 'typegpu/data'
+import { f32, struct, vec2f } from 'typegpu/data'
+import { cos, sin } from 'typegpu/std'
 import { RangeEditor } from '@/components/Sliders/ParametricEditors/RangeEditor'
 import { editorProps } from '@/components/Sliders/ParametricEditors/types'
 import { parametricVariation } from './types'
@@ -54,14 +55,15 @@ export const pdjVar = parametricVariation(
   PdjParams,
   PdjParamsDefaults,
   PdjParamsEditor,
-  /* wgsl */ `(pos: vec2f, _varInfo: VariationInfo, P: PdjParams) -> vec2f {
-    let p1 = P.a;
-    let p2 = P.b;
-    let p3 = P.c;
-    let p4 = P.d;
+  (pos, _varInfo, P) => {
+    'use gpu'
+    const p1 = P.a
+    const p2 = P.b
+    const p3 = P.c
+    const p4 = P.d
     return vec2f(
       sin(p1 * pos.y) - cos(p2 * pos.x),
-      sin(p3 * pos.x) - cos(p4 * pos.y)
-    );
-  }`,
+      sin(p3 * pos.x) - cos(p4 * pos.y),
+    )
+  },
 )

--- a/packages/app/src/flame/variations/parametric/perspective.tsx
+++ b/packages/app/src/flame/variations/parametric/perspective.tsx
@@ -1,4 +1,5 @@
-import { f32, struct } from 'typegpu/data'
+import { f32, struct, vec2f } from 'typegpu/data'
+import { cos, sin } from 'typegpu/std'
 import { AngleEditor } from '@/components/Sliders/ParametricEditors/AngleEditor'
 import { RangeEditor } from '@/components/Sliders/ParametricEditors/RangeEditor'
 import { editorProps } from '@/components/Sliders/ParametricEditors/types'
@@ -34,11 +35,11 @@ export const perspective = parametricVariation(
   PerspectiveParams,
   PerspectiveParamsDefaults,
   PerspectiveParamsEditor,
-  /* wgsl */ `
-  (pos: vec2f, _varInfo: VariationInfo, P: PerspectiveParams) -> vec2f {
-    let p1 = P.angle; 
-    let p2 = P.dist; 
-    let factor = p2 / (p2 - pos.y * sin(p1));
-    return factor * vec2f(pos.x, pos.y * cos(p1));
-  }`,
+  (pos, _varInfo, P) => {
+    'use gpu'
+    const p1 = P.angle
+    const p2 = P.dist
+    const factor = p2 / (p2 - pos.y * sin(p1))
+    return vec2f(pos.x, pos.y * cos(p1)).mul(factor)
+  },
 )

--- a/packages/app/src/flame/variations/parametric/pie.tsx
+++ b/packages/app/src/flame/variations/parametric/pie.tsx
@@ -1,4 +1,5 @@
-import { f32, struct } from 'typegpu/data'
+import { f32, struct, vec2f } from 'typegpu/data'
+import { cos, sin, trunc } from 'typegpu/std'
 import { AngleEditor } from '@/components/Sliders/ParametricEditors/AngleEditor'
 import { RangeEditor } from '@/components/Sliders/ParametricEditors/RangeEditor'
 import { editorProps } from '@/components/Sliders/ParametricEditors/types'
@@ -44,16 +45,16 @@ export const pie = parametricVariation(
   PieParams,
   PieParamsDefaults,
   PieParamsEditor,
-  /* wgsl */ `(_pos: vec2f, _varInfo: VariationInfo, P: PieParams) -> vec2f {
-    let p1 = P.slices;
-    let p2 = P.rotation;
-    let p3 = P.thickness;
-    let r1 = random();
-    let r2 = random();
-    let r3 = random();
-    let t1 = trunc(r1 * p1 + 0.5);
-    let t2 = p2 + (t1 + r2 * p3) * 2 * PI / p1;
-    return r3 * vec2f(cos(t2), sin(t2));
-  }`,
-  { random, PI },
+  (_pos, _varInfo, P) => {
+    'use gpu'
+    const p1 = P.slices
+    const p2 = P.rotation
+    const p3 = P.thickness
+    const r1 = random()
+    const r2 = random()
+    const r3 = random()
+    const t1 = trunc(r1 * p1 + 0.5)
+    const t2 = p2 + ((t1 + r2 * p3) * 2 * PI.$) / p1
+    return vec2f(cos(t2), sin(t2)).mul(r3)
+  },
 )

--- a/packages/app/src/flame/variations/parametric/radialBlur.tsx
+++ b/packages/app/src/flame/variations/parametric/radialBlur.tsx
@@ -1,4 +1,5 @@
-import { f32, struct } from 'typegpu/data'
+import { f32, struct, vec2f } from 'typegpu/data'
+import { atan2, cos, length, sin } from 'typegpu/std'
 import { AngleEditor } from '@/components/Sliders/ParametricEditors/AngleEditor'
 import { editorProps } from '@/components/Sliders/ParametricEditors/types'
 import { random } from '@/shaders/random'
@@ -16,9 +17,7 @@ const RadialBlurParamsDefaults: RadialBlurParams = {
 }
 
 const RadialBlurEditor: EditorFor<Infer<typeof RadialBlurParams>> = (props) => (
-  <>
-    <AngleEditor {...editorProps(props, 'angle', 'Angle')} />
-  </>
+  <AngleEditor {...editorProps(props, 'angle', 'Angle')} />
 )
 
 export const radialBlurVar = parametricVariation(
@@ -26,20 +25,16 @@ export const radialBlurVar = parametricVariation(
   RadialBlurParams,
   RadialBlurParamsDefaults,
   RadialBlurEditor,
-  /* wgsl */ `
-  (pos: vec2f, varInfo: VariationInfo, P: RadialBlurParams) -> vec2f {
-    let weight = varInfo.weight;
-    let p1 = P.angle; 
-    let randSum = random() + random() + random() + random() - 2;
-    let r = length(pos); 
-    let t1 = weight * randSum; 
-    let phi = atan2(pos.y, pos.x);
-    let t2 = phi + t1 * sin(p1); 
-    let t3 = t1 * cos(p1) - 1;
-    return 1 / weight * vec2f(
-        r * cos(t2) + t3 * pos.x,
-        r * sin(t2) + t3 * pos.y
-    );
-  }`,
-  { random },
+  (pos, varInfo, P) => {
+    'use gpu'
+    const weight = varInfo.weight
+    const p1 = P.angle
+    const randSum = random() + random() + random() + random() - 2
+    const r = length(pos)
+    const t1 = weight * randSum
+    const phi = atan2(pos.y, pos.x)
+    const t2 = phi + t1 * sin(p1)
+    const t3 = t1 * cos(p1) - 1
+    return vec2f(r * cos(t2) + t3 * pos.x, r * sin(t2) + t3 * pos.y).div(weight)
+  },
 )

--- a/packages/app/src/flame/variations/parametric/rectangles.tsx
+++ b/packages/app/src/flame/variations/parametric/rectangles.tsx
@@ -1,4 +1,5 @@
-import { f32, struct } from 'typegpu/data'
+import { f32, struct, vec2f } from 'typegpu/data'
+import { floor } from 'typegpu/std'
 import { RangeEditor } from '@/components/Sliders/ParametricEditors/RangeEditor'
 import { editorProps } from '@/components/Sliders/ParametricEditors/types'
 import { parametricVariation } from './types'
@@ -38,15 +39,12 @@ export const rectanglesVar = parametricVariation(
   RectanglesParams,
   RectanglesParamsDefaults,
   RectanglesParamsEditor,
-  /* wgsl */ `
-  (pos: vec2f, _varInfo: VariationInfo, P: RectanglesParams) -> vec2f {
-    let p1 = P.x; 
-    let p2 = P.y; 
-    let p1Fact = (2 * floor(pos.x / p1) + 1);
-    let p2Fact = (2 * floor(pos.y / p2) + 1);
-    return vec2f(
-        p1Fact * p1 - pos.x,
-        p2Fact * p2 - pos.y,
-      );
-  }`,
+  (pos, _varInfo, P) => {
+    'use gpu'
+    const p1 = P.x
+    const p2 = P.y
+    const p1Fact = 2 * floor(pos.x / p1) + 1
+    const p2Fact = 2 * floor(pos.y / p2) + 1
+    return vec2f(p1Fact * p1 - pos.x, p2Fact * p2 - pos.y)
+  },
 )

--- a/packages/app/src/flame/variations/parametric/rings2.tsx
+++ b/packages/app/src/flame/variations/parametric/rings2.tsx
@@ -1,4 +1,5 @@
-import { f32, struct } from 'typegpu/data'
+import { f32, struct, vec2f } from 'typegpu/data'
+import { atan2, cos, length, sin, trunc } from 'typegpu/std'
 import { RangeEditor } from '@/components/Sliders/ParametricEditors/RangeEditor'
 import { editorProps } from '@/components/Sliders/ParametricEditors/types'
 import { parametricVariation } from './types'
@@ -30,13 +31,13 @@ export const rings2 = parametricVariation(
   Rings2Params,
   Rings2ParamsDefaults,
   Rings2ParamsEditor,
-  /* wgsl */ `
-  (pos: vec2f, _varInfo: VariationInfo, P: RingsParams) -> vec2f {
-    let p = P.val; 
-    let r = length(pos); 
-    let theta = atan2(pos.y, pos.x);
-    let twop = 2 * p;
-    let t = r - twop * trunc((r + p) / twop) + r * (1 - p);
-    return t * vec2f(sin(theta), cos(theta));
-  }`,
+  (pos, _varInfo, P) => {
+    'use gpu'
+    const p = P.val
+    const r = length(pos)
+    const theta = atan2(pos.y, pos.x)
+    const twop = 2 * p
+    const t = r - twop * trunc((r + p) / twop) + r * (1 - p)
+    return vec2f(sin(theta), cos(theta)).mul(t)
+  },
 )

--- a/packages/app/src/flame/variations/parametric/types.ts
+++ b/packages/app/src/flame/variations/parametric/types.ts
@@ -4,7 +4,7 @@ import { structToSchema } from '@/utils/schemaUtil'
 import * as v from '@/valibot'
 import { VariationInfo } from '../simple/types'
 import type { TgpuFn } from 'typegpu'
-import type { BaseData, Infer, Vec2f, WgslStruct } from 'typegpu/data'
+import type { BaseData, Infer, v2f, Vec2f, WgslStruct } from 'typegpu/data'
 import type { EditorFor } from '@/components/Sliders/ParametricEditors/types'
 
 type ParametricVariationDescriptor<
@@ -62,16 +62,13 @@ export function parametricVariation<
   paramStruct: WgslStruct<T>,
   paramDefaults: Infer<WgslStruct<T>>,
   editor: EditorFor<Infer<WgslStruct<T>>>,
-  wgsl: string,
-  dependencyMap: Record<string, unknown> = {},
+  impl: (pos: v2f, varInfo: VariationInfo, params: Infer<WgslStruct<T>>) => v2f,
 ): ParametricVariation<K, T> {
   return {
     DescriptorSchema: parametricVariationDescriptor(variationKey, paramStruct),
     paramStruct,
     paramDefaults,
     editor,
-    fn: tgpu
-      .fn([vec2f, VariationInfo, paramStruct], vec2f)(wgsl)
-      .$uses(dependencyMap),
+    fn: tgpu.fn([vec2f, VariationInfo, paramStruct], vec2f)(impl),
   }
 }

--- a/packages/app/src/flame/variations/simple/index.ts
+++ b/packages/app/src/flame/variations/simple/index.ts
@@ -1,462 +1,305 @@
+import { vec2f } from 'typegpu/data'
+import {
+  atan2,
+  cos,
+  cosh,
+  dot,
+  exp,
+  length,
+  log,
+  pow,
+  select,
+  sin,
+  sinh,
+  sqrt,
+  tan,
+} from 'typegpu/std'
 import { random, randomUnitDisk } from '@/shaders/random'
 import { PI } from '../../constants'
 import { simpleVariation } from './types'
 
-export const waves = simpleVariation(
-  'waves',
-  /* wgsl */ `
-  (pos: vec2f, varInfo: VariationInfo) -> vec2f {
-    let T = varInfo.affineCoefs;
-    let xSinArg = pos.y / (T.c * T.c); 
-    let ySinArg = pos.x / (T.f * T.f); 
-    return vec2f(
-      pos.x + T.b * sin(xSinArg),
-      pos.y + T.e * sin(ySinArg),
-    );
-  }`,
-)
+export const waves = simpleVariation('waves', (pos, varInfo) => {
+  'use gpu'
+  const T = varInfo.affineCoefs
+  const xSinArg = pos.y / (T.c * T.c)
+  const ySinArg = pos.x / (T.f * T.f)
+  const delta = vec2f(T.b * sin(xSinArg), T.e * sin(ySinArg))
+  return pos.add(delta)
+})
 
-export const popcorn = simpleVariation(
-  'popcorn',
-  /* wgsl */ `
-  (pos: vec2f, varInfo: VariationInfo) -> vec2f {
-    let T = varInfo.affineCoefs;
-    return pos + vec2f(
-      T.c * sin(tan(3 * pos.y)),
-      T.f * sin(tan(3 * pos.x)),
-    );
-  }`,
-)
+export const popcorn = simpleVariation('popcorn', (pos, varInfo) => {
+  'use gpu'
+  const T = varInfo.affineCoefs
+  const delta = vec2f(T.c * sin(tan(3 * pos.y)), T.f * sin(tan(3 * pos.x)))
+  return pos.add(delta)
+})
 
-export const rings = simpleVariation(
-  'rings',
-  /* wgsl */ `
-  (pos: vec2f, varInfo: VariationInfo) -> vec2f {
-    let T = varInfo.affineCoefs;
-    let c2 = T.c * T.c;
-    let r = length(pos); 
-    let theta = atan2(pos.y, pos.x);
-    let factor = (r + c2) % (2 * c2) - c2 + r * (1 - c2);
-    return factor * vec2f(cos(theta), sin(theta));
-  }`,
-)
+export const rings = simpleVariation('rings', (pos, varInfo) => {
+  'use gpu'
+  const T = varInfo.affineCoefs
+  const c2 = T.c * T.c
+  const r = length(pos)
+  const theta = atan2(pos.y, pos.x)
+  const factor = ((r + c2) % (2 * c2)) - c2 + r * (1 - c2)
+  return vec2f(cos(theta), sin(theta)).mul(factor)
+})
 
-export const fan = simpleVariation(
-  'fan',
-  /* wgsl */ `
-  (pos: vec2f, varInfo: VariationInfo) -> vec2f {
-    let T = varInfo.affineCoefs;
-    let t = PI * T.c * T.c;
-    let r = length(pos); 
-    let theta = atan2(pos.y, pos.x);
+export const fan = simpleVariation('fan', (pos, varInfo) => {
+  'use gpu'
+  const T = varInfo.affineCoefs
+  const t = PI.$ * T.c * T.c
+  const r = length(pos)
+  const theta = atan2(pos.y, pos.x)
 
-    let thalf = t / 2;
-    let trueAngle = theta - thalf;
-    let falseAngle = theta + thalf;
-    let modCond = (theta + T.f) % t;
-    let angle = select(falseAngle, trueAngle, modCond > thalf);
-    return r * vec2f(cos(angle), sin(angle));
-  }`,
-  { PI },
-)
-export const linear = simpleVariation(
-  'linear',
-  /* wgsl */ `
-  (pos: vec2f, _varInfo: VariationInfo) -> vec2f {
-    return pos;
-  }`,
-)
+  const thalf = t / 2
+  const trueAngle = theta - thalf
+  const falseAngle = theta + thalf
+  const modCond = (theta + T.f) % t
+  const angle = select(falseAngle, trueAngle, modCond > thalf)
+  return vec2f(cos(angle), sin(angle)).mul(r)
+})
 
-export const randomDisk = simpleVariation(
-  'randomDisk',
-  /* wgsl */ `
-  (_pos: vec2f, _varInfo: VariationInfo) -> vec2f {
-    return randomUnitDisk();
-  }`,
-  { randomUnitDisk },
-)
+export const linear = simpleVariation('linear', (pos, _varInfo) => {
+  'use gpu'
+  return pos
+})
 
-export const gaussian = simpleVariation(
-  'gaussian',
-  /* wgsl */ `
-  (pos: vec2f, _varInfo: VariationInfo) -> vec2f {
-    let r = random() + random() + random() + random() - 2;
-    let theta = random() * 2 * PI;
-    return r * vec2f(cos(theta), sin(theta));
-  }`,
-  { random, PI },
-)
+export const randomDisk = simpleVariation('randomDisk', (_pos, _varInfo) => {
+  'use gpu'
+  return randomUnitDisk()
+})
 
-export const sinusoidal = simpleVariation(
-  'sinusoidal',
-  /* wgsl */ `
-  (pos: vec2f, _varInfo: VariationInfo) -> vec2f {
-    return vec2f(sin(pos.x), sin(pos.y));
-  }`,
-)
+export const gaussian = simpleVariation('gaussian', (_pos, _varInfo) => {
+  'use gpu'
+  const r = random() + random() + random() + random() - 2
+  const theta = random() * 2 * PI.$
+  return vec2f(cos(theta), sin(theta)).mul(r)
+})
 
-export const spherical = simpleVariation(
-  'spherical',
-  /* wgsl */ `
-  (pos: vec2f, _varInfo: VariationInfo) -> vec2f {
-    let r2 = dot(pos, pos);
-    return pos / r2;
-  }`,
-)
+export const sinusoidal = simpleVariation('sinusoidal', (pos, _varInfo) => {
+  'use gpu'
+  return vec2f(sin(pos.x), sin(pos.y))
+})
 
-export const swirl = simpleVariation(
-  'swirl',
-  /* wgsl */ `
-  (pos: vec2f, _varInfo: VariationInfo) -> vec2f {
-    let r2 = dot(pos, pos);
-    let s2 = sin(r2);
-    let c2 = cos(r2);
-    return vec2f(
-      pos.x * s2 - pos.y * c2,
-      pos.x * c2 + pos.y * s2,
-    );
-  }`,
-)
+export const spherical = simpleVariation('spherical', (pos, _varInfo) => {
+  'use gpu'
+  const r2 = dot(pos, pos)
+  return pos.div(r2)
+})
 
-export const horseshoe = simpleVariation(
-  'horseshoe',
-  /* wgsl */ `
-  (pos: vec2f, _varInfo: VariationInfo) -> vec2f {
-    let r = length(pos); 
-    return vec2f(
-      (pos.x - pos.y) * (pos.x + pos.y),
-      2 * pos.x * pos.y
-    ) / r;
-  }`,
-)
+export const swirl = simpleVariation('swirl', (pos, _varInfo) => {
+  'use gpu'
+  const r2 = dot(pos, pos)
+  const s2 = sin(r2)
+  const c2 = cos(r2)
+  return vec2f(pos.x * s2 - pos.y * c2, pos.x * c2 + pos.y * s2)
+})
 
-export const polar = simpleVariation(
-  'polar',
-  /* wgsl */ `
-  (pos: vec2f, _varInfo: VariationInfo) -> vec2f {
-    let r = length(pos); 
-    let theta = atan2(pos.y, pos.x);
-    return vec2f(theta / PI, r - 1);
-  }`,
-  { PI },
-)
+export const horseshoe = simpleVariation('horseshoe', (pos, _varInfo) => {
+  'use gpu'
+  const r = length(pos)
+  return vec2f((pos.x - pos.y) * (pos.x + pos.y), 2 * pos.x * pos.y).div(r)
+})
 
-export const handkerchief = simpleVariation(
-  'handkerchief',
-  /* wgsl */ `
-  (pos: vec2f, _varInfo: VariationInfo) -> vec2f {
-    let r = length(pos); 
-    let theta = atan2(pos.y, pos.x);
-    return r * vec2f(sin(theta + r), cos(theta - r));
-  }`,
-)
+export const polar = simpleVariation('polar', (pos, _varInfo) => {
+  'use gpu'
+  const r = length(pos)
+  const theta = atan2(pos.y, pos.x)
+  return vec2f(theta / PI.$, r - 1)
+})
 
-export const heart = simpleVariation(
-  'heart',
-  /* wgsl */ `
-  (pos: vec2f, _varInfo: VariationInfo) -> vec2f {
-    let r = length(pos); 
-    let theta = atan2(pos.y, pos.x);
-    return r * vec2f(sin(theta * r), -cos(theta * r));
-  }`,
-)
+export const handkerchief = simpleVariation('handkerchief', (pos, _varInfo) => {
+  'use gpu'
+  const r = length(pos)
+  const theta = atan2(pos.y, pos.x)
+  return vec2f(sin(theta + r), cos(theta - r)).mul(r)
+})
 
-export const disc = simpleVariation(
-  'disc',
-  /* wgsl */ `
-  (pos: vec2f, _varInfo: VariationInfo) -> vec2f {
-    let r = length(pos);
-    let theta = atan2(pos.y, pos.x);
-    let thOverPi = theta / PI;
-    return thOverPi * vec2f(sin(PI * r), cos(PI * r));
-  }`,
-  { PI },
-)
+export const heart = simpleVariation('heart', (pos, _varInfo) => {
+  'use gpu'
+  const r = length(pos)
+  const theta = atan2(pos.y, pos.x)
+  return vec2f(sin(theta * r), -cos(theta * r)).mul(r)
+})
 
-export const spiral = simpleVariation(
-  'spiral',
-  /* wgsl */ `
-  (pos: vec2f, _varInfo: VariationInfo) -> vec2f {
-    let r = length(pos);
-    let theta = atan2(pos.y, pos.x);
-    let oneOverR = 1 / r;
-    return oneOverR * vec2f(
-      (cos(theta) + sin(r)),
-      (sin(theta) - cos(r))
-    );
-  }`,
-  { PI },
-)
+export const disc = simpleVariation('disc', (pos, _varInfo) => {
+  'use gpu'
+  const r = length(pos)
+  const theta = atan2(pos.y, pos.x)
+  const thOverPi = theta / PI.$
+  return vec2f(sin(PI.$ * r), cos(PI.$ * r)).mul(thOverPi)
+})
 
-export const hyperbolic = simpleVariation(
-  'hyperbolic',
-  /* wgsl */ `
-  (pos: vec2f, _varInfo: VariationInfo) -> vec2f {
-    let r = length(pos);
-    let theta = atan2(pos.y, pos.x);
-    return vec2f(sin(theta) / r, r * cos(theta));
-  }`,
-)
+export const spiral = simpleVariation('spiral', (pos, _varInfo) => {
+  'use gpu'
+  const r = length(pos)
+  const theta = atan2(pos.y, pos.x)
+  return vec2f(cos(theta) + sin(r), sin(theta) - cos(r)).div(r)
+})
 
-export const diamond = simpleVariation(
-  'diamond',
-  /* wgsl */ `
-  (pos: vec2f, _varInfo: VariationInfo) -> vec2f {
-    let r = length(pos);
-    let theta = atan2(pos.y, pos.x);
-    return vec2f(sin(theta) * cos(r), cos(theta) * sin(r));
-  }`,
-)
+export const hyperbolic = simpleVariation('hyperbolic', (pos, _varInfo) => {
+  'use gpu'
+  const r = length(pos)
+  const theta = atan2(pos.y, pos.x)
+  return vec2f(sin(theta) / r, r * cos(theta))
+})
 
-export const exVar = simpleVariation(
-  'exVar',
-  /* wgsl */ `
-  (pos: vec2f, _varInfo: VariationInfo) -> vec2f {
-    let r = length(pos);
-    let theta = atan2(pos.y, pos.x);
-    let p0 = sin(theta + r);
-    let p1 = cos(theta - r);
-    let p03 = p0 * p0 * p0;
-    let p13 = p1 * p1 * p1;
-    return r * vec2f((p03 + p13), (p03 - p13));
-  }`,
-)
+export const diamond = simpleVariation('diamond', (pos, _varInfo) => {
+  'use gpu'
+  const r = length(pos)
+  const theta = atan2(pos.y, pos.x)
+  return vec2f(sin(theta) * cos(r), cos(theta) * sin(r))
+})
 
-export const julia = simpleVariation(
-  'julia',
-  /* wgsl */ `
-  (pos: vec2f, _varInfo: VariationInfo) -> vec2f {
-    let sqrtr = sqrt(length(pos));
-    let theta = atan2(pos.y, pos.x);
-    let rand = random();
-    let omega = select(0, PI, random() > 0.5);
-    let angle = theta / 2.0 + omega;
-    return sqrtr * vec2f(cos(angle), sin(angle));
-  }`,
-  { random, PI },
-)
+export const exVar = simpleVariation('exVar', (pos, _varInfo) => {
+  'use gpu'
+  const r = length(pos)
+  const theta = atan2(pos.y, pos.x)
+  const p0 = sin(theta + r)
+  const p1 = cos(theta - r)
+  const p03 = p0 * p0 * p0
+  const p13 = p1 * p1 * p1
+  return vec2f(p03 + p13, p03 - p13).mul(r)
+})
 
-export const bent = simpleVariation(
-  'bent',
-  /* wgsl */ `
-  (pos: vec2f, _varInfo: VariationInfo) -> vec2f {
-    let fx = select(pos.x, 2.0 * pos.x, pos.x < 0);
-    let fy = select(pos.y, pos.y / 2.0, pos.y < 0);
-    return vec2f(fx, fy);
-  }`,
-)
+export const julia = simpleVariation('julia', (pos, _varInfo) => {
+  'use gpu'
+  const sqrtr = sqrt(length(pos))
+  const theta = atan2(pos.y, pos.x)
+  const omega = select(0, PI.$, random() > 0.5)
+  const angle = theta / 2.0 + omega
+  return vec2f(cos(angle), sin(angle)).mul(sqrtr)
+})
 
-export const fisheye = simpleVariation(
-  'fisheye',
-  /* wgsl */ `
-  (pos: vec2f, _varInfo: VariationInfo) -> vec2f {
-    let r = length(pos);
-    let factor = 2 / (r + 1); 
-    return factor * pos.yx;
-  }`,
-)
+export const bent = simpleVariation('bent', (pos, _varInfo) => {
+  'use gpu'
+  const fx = select(pos.x, 2.0 * pos.x, pos.x < 0)
+  const fy = select(pos.y, pos.y / 2.0, pos.y < 0)
+  return vec2f(fx, fy)
+})
 
-export const eyefish = simpleVariation(
-  'eyefish',
-  /* wgsl */ `
-  (pos: vec2f, _varInfo: VariationInfo) -> vec2f {
-    let r = length(pos);
-    let factor = 2 / (r + 1); 
-    return factor * pos;
-  }`,
-)
+export const fisheye = simpleVariation('fisheye', (pos, _varInfo) => {
+  'use gpu'
+  const r = length(pos)
+  const factor = 2 / (r + 1)
+  return pos.yx.mul(factor)
+})
 
-export const exponential = simpleVariation(
-  'exponential',
-  /* wgsl */ `
-  (pos: vec2f, _varInfo: VariationInfo) -> vec2f {
-    let factor = exp(pos.x - 1);
-    let piY = PI * pos.y;
-    return factor * vec2f(cos(piY), sin(piY));
-  }`,
-  { PI },
-)
+export const eyefish = simpleVariation('eyefish', (pos, _varInfo) => {
+  'use gpu'
+  const r = length(pos)
+  const factor = 2 / (r + 1)
+  return pos.mul(factor)
+})
 
-export const power = simpleVariation(
-  'power',
-  /* wgsl */ `
-  (pos: vec2f, _varInfo: VariationInfo) -> vec2f {
-    let r = length(pos);
-    let theta = atan2(pos.y, pos.x);
-    let sinTheta = sin(theta);
-    let factor = pow(r, sinTheta);
-    return factor * vec2f(cos(theta), sinTheta);
-  }`,
-)
+export const exponential = simpleVariation('exponential', (pos, _varInfo) => {
+  'use gpu'
+  const factor = exp(pos.x - 1)
+  const piY = PI.$ * pos.y
+  return vec2f(cos(piY), sin(piY)).mul(factor)
+})
 
-export const cosine = simpleVariation(
-  'cosine',
-  /* wgsl */ `
-  (pos: vec2f, _varInfo: VariationInfo) -> vec2f {
-    let piX = PI * pos.x;
-    return vec2f(
-      cos(piX) * cosh(pos.y),
-      -sin(piX) * sinh(pos.y)
-    );
-  }`,
-  { PI },
-)
+export const power = simpleVariation('power', (pos, _varInfo) => {
+  'use gpu'
+  const r = length(pos)
+  const theta = atan2(pos.y, pos.x)
+  const sinTheta = sin(theta)
+  const factor = pow(r, sinTheta)
+  return vec2f(cos(theta), sinTheta).mul(factor)
+})
 
-export const bubble = simpleVariation(
-  'bubble',
-  /* wgsl */ `
-  (pos: vec2f, _varInfo: VariationInfo) -> vec2f {
-    let r = length(pos);
-    let r2 = r * r;
-    let factor = 4 / (r2 + 4);
-    return factor * vec2f(pos.x, pos.y);
-  }`,
-)
+export const cosine = simpleVariation('cosine', (pos, _varInfo) => {
+  'use gpu'
+  const piX = PI.$ * pos.x
+  return vec2f(cos(piX) * cosh(pos.y), -sin(piX) * sinh(pos.y))
+})
 
-export const cylinder = simpleVariation(
-  'cylinder',
-  /* wgsl */ `
-  (pos: vec2f, _varInfo: VariationInfo) -> vec2f {
-    return vec2f(sin(pos.x), pos.y);
-  }`,
-)
+export const bubble = simpleVariation('bubble', (pos, _varInfo) => {
+  'use gpu'
+  const r = length(pos)
+  const r2 = r * r
+  const factor = 4 / (r2 + 4)
+  return vec2f(pos.x, pos.y).mul(factor)
+})
 
-export const noise = simpleVariation(
-  'noise',
-  /* wgsl */ `
-  (pos: vec2f, _varInfo: VariationInfo) -> vec2f {
-    let rand = random();
-    let angle = 2 * PI * random();
-    return rand * vec2f(pos.x * cos(angle), pos.y * sin(angle));
-  }`,
-  { random, PI },
-)
+export const cylinder = simpleVariation('cylinder', (pos, _varInfo) => {
+  'use gpu'
+  return vec2f(sin(pos.x), pos.y)
+})
 
-export const blurVar = simpleVariation(
-  'blurVar',
-  /* wgsl */ `
-  (pos: vec2f, _varInfo: VariationInfo) -> vec2f {
-    let rand = random();
-    let angle = 2 * PI * random();
-    return rand * vec2f(cos(angle), sin(angle));
-  }`,
-  { random, PI },
-)
+export const noise = simpleVariation('noise', (pos, _varInfo) => {
+  'use gpu'
+  const rand = random()
+  const angle = 2 * PI.$ * random()
+  return vec2f(pos.x * cos(angle), pos.y * sin(angle)).mul(rand)
+})
 
-export const archVar = simpleVariation(
-  'archVar',
-  /* wgsl */ `
-  (pos: vec2f, varInfo: VariationInfo) -> vec2f {
-    let weight = varInfo.weight;
-    let angle = random() * PI * weight;
-    return vec2f(
-      sin(angle), 
-      (sin(angle) * sin(angle)) / cos(angle)
-    );
-  }`,
-  { random, PI },
-)
+export const blurVar = simpleVariation('blurVar', (_pos, _varInfo) => {
+  'use gpu'
+  const rand = random()
+  const angle = 2 * PI.$ * random()
+  return vec2f(cos(angle), sin(angle)).mul(rand)
+})
 
-export const tangentVar = simpleVariation(
-  'tangentVar',
-  /* wgsl */ `
-  (pos: vec2f, _varInfo: VariationInfo) -> vec2f {
-    return vec2f(
-      sin(pos.x) / cos(pos.y), 
-      tan(pos.y)
-    );
-  }`,
-)
+export const archVar = simpleVariation('archVar', (_pos, varInfo) => {
+  'use gpu'
+  const weight = varInfo.weight
+  const angle = random() * PI.$ * weight
+  return vec2f(sin(angle), (sin(angle) * sin(angle)) / cos(angle))
+})
 
-export const squareVar = simpleVariation(
-  'squareVar',
-  /* wgsl */ `
-  (pos: vec2f, _varInfo: VariationInfo) -> vec2f {
-    let randX = random();
-    let randY = random();
-    return vec2f(
-      randX - 0.5,
-      randY - 0.5,
-    );
-  }`,
-  { random },
-)
+export const tangentVar = simpleVariation('tangentVar', (pos, _varInfo) => {
+  'use gpu'
+  return vec2f(sin(pos.x) / cos(pos.y), tan(pos.y))
+})
 
-export const raysVar = simpleVariation(
-  'raysVar',
-  /* wgsl */ `
-  (pos: vec2f, varInfo: VariationInfo) -> vec2f {
-    let weight = varInfo.weight;
-    let rand = random();
-    let r = length(pos);
-    let angle = rand * PI * weight;
-    let fact = (weight * tan(angle)) / (r * r);
-    return fact * vec2f(
-      cos(pos.x),
-      sin(pos.y)
-    );
-  }`,
-  { random, PI },
-)
+export const squareVar = simpleVariation('squareVar', (_pos, _varInfo) => {
+  'use gpu'
+  const randX = random()
+  const randY = random()
+  return vec2f(randX - 0.5, randY - 0.5)
+})
 
-export const bladeVar = simpleVariation(
-  'bladeVar',
-  /* wgsl */ `
-  (pos: vec2f, varInfo: VariationInfo) -> vec2f {
-    let weight = varInfo.weight;
-    let rand = random();
-    let r = length(pos);
-    let angle = rand * r * weight;
-    return pos.x * vec2f(
-      cos(angle) + sin(angle),
-      cos(angle) - sin(angle),
-    );
-  }`,
-  { random, PI },
-)
+export const raysVar = simpleVariation('raysVar', (pos, varInfo) => {
+  'use gpu'
+  const weight = varInfo.weight
+  const rand = random()
+  const r = length(pos)
+  const angle = rand * PI.$ * weight
+  const fact = (weight * tan(angle)) / (r * r)
+  return vec2f(cos(pos.x), sin(pos.y)).mul(fact)
+})
 
-export const secantVar = simpleVariation(
-  'secantVar',
-  /* wgsl */ `
-  (pos: vec2f, varInfo: VariationInfo) -> vec2f {
-    let weight = varInfo.weight;
-    let r = length(pos);
-    let angle = weight * r;
-    return  vec2f(
-      pos.x,
-      1 / (weight * cos(angle))
-    );
-  }`,
-  { PI },
-)
+export const bladeVar = simpleVariation('bladeVar', (pos, varInfo) => {
+  'use gpu'
+  const weight = varInfo.weight
+  const rand = random()
+  const r = length(pos)
+  const angle = rand * r * weight
+  return vec2f(cos(angle) + sin(angle), cos(angle) - sin(angle)).mul(pos.x)
+})
 
-export const twintrianVar = simpleVariation(
-  'twintrianVar',
-  /* wgsl */ `
-  (pos: vec2f, varInfo: VariationInfo) -> vec2f {
-    let weight = varInfo.weight;
-    let r = length(pos);
-    let angle = random() * r * weight;
-    let sinAngle = sin(angle);
-    let t = (log(sinAngle * sinAngle) / log(10)) + cos(angle);
-    return pos.x * vec2f(
-      t,
-      t - PI * sinAngle
-    );
-  }`,
-  { random, PI },
-)
+export const secantVar = simpleVariation('secantVar', (pos, varInfo) => {
+  'use gpu'
+  const weight = varInfo.weight
+  const r = length(pos)
+  const angle = weight * r
+  return vec2f(pos.x, 1 / (weight * cos(angle)))
+})
 
-export const crossVar = simpleVariation(
-  'crossVar',
-  /* wgsl */ `
-  (pos: vec2f, _varInfo: VariationInfo) -> vec2f {
-    let squareDiff = (pos.x * pos.x - pos.y * pos.y);
-    let fact = sqrt(1/(squareDiff * squareDiff));
-    return fact * vec2f(
-      pos.x,
-      pos.y,
-    );
-  }`,
-  { PI },
-)
+export const twintrianVar = simpleVariation('twintrianVar', (pos, varInfo) => {
+  'use gpu'
+  const weight = varInfo.weight
+  const r = length(pos)
+  const angle = random() * r * weight
+  const sinAngle = sin(angle)
+  const t = log(sinAngle * sinAngle) / log(10) + cos(angle)
+  return vec2f(t, t - PI.$ * sinAngle).mul(pos.x)
+})
+
+export const crossVar = simpleVariation('crossVar', (pos, _varInfo) => {
+  'use gpu'
+  const squareDiff = pos.x * pos.x - pos.y * pos.y
+  const fact = sqrt(1 / (squareDiff * squareDiff))
+  return vec2f(pos.x, pos.y).mul(fact)
+})

--- a/packages/app/src/flame/variations/simple/types.ts
+++ b/packages/app/src/flame/variations/simple/types.ts
@@ -3,9 +3,9 @@ import { f32, struct, vec2f } from 'typegpu/data'
 import * as v from '@/valibot'
 import { AffineParams } from '../../affineTranform'
 import type { TgpuFn } from 'typegpu'
-import type { Infer, Vec2f } from 'typegpu/data'
+import type { Infer, v2f, Vec2f } from 'typegpu/data'
 
-export type VariationInfoType = Infer<typeof VariationInfo>
+export type VariationInfo = Infer<typeof VariationInfo>
 export const VariationInfo = struct({
   weight: f32,
   affineCoefs: AffineParams,
@@ -24,14 +24,13 @@ export type SimpleVariation<K extends string> = {
 
 export function simpleVariation<K extends string>(
   variationKey: K,
-  wgsl: string,
-  dependencyMap: Record<string, unknown> = {},
+  impl: (pos: v2f, varInfo: VariationInfo) => v2f,
 ): SimpleVariation<K> {
   return {
     DescriptorSchema: v.object({
       type: v.literal(variationKey),
       weight: v.number(),
     }),
-    fn: tgpu.fn([vec2f, VariationInfo], vec2f)(wgsl).$uses(dependencyMap),
+    fn: tgpu.fn([vec2f, VariationInfo], vec2f)(impl),
   }
 }

--- a/packages/app/src/lib/Camera2D.tsx
+++ b/packages/app/src/lib/Camera2D.tsx
@@ -1,7 +1,7 @@
 import { createMemo } from 'solid-js'
 import { tgpu } from 'typegpu'
 import { f32, mat3x3f, mat4x4f, struct, vec2f, vec3f } from 'typegpu/data'
-import { mul } from 'typegpu/std'
+import { div, mul } from 'typegpu/std'
 import { mat3, mat4 } from 'wgpu-matrix'
 import { CameraContextProvider } from './CameraContext'
 import { useCanvas } from './CanvasContext'
@@ -22,47 +22,47 @@ export const Camera2DBindGroupLayout = tgpu
   })
   .$name('Camera2DBindGroupLayout')
 
-export const camera2DWorldToClip = tgpu.fn([vec2f], vec2f) /* wgsl */ `
-  (world: vec2f) -> vec2f {
-    let clip = camera2DUniforms.viewMatrix * vec3(world, 1);
-    return clip.xy / clip.z;
-  }
-`
-  .$uses({ ...Camera2DBindGroupLayout.bound })
-  .$name('camera2DWorldToClip')
+export const camera2DWorldToClip = tgpu.fn(
+  [vec2f],
+  vec2f,
+)((world) => {
+  const camera2DUniforms = Camera2DBindGroupLayout.$.camera2DUniforms
+  const clip = mul(camera2DUniforms.viewMatrix, vec3f(world, 1))
+  return div(clip.xy, clip.z)
+})
 
-export const camera2DClipToWorld = tgpu.fn([vec2f], vec2f) /* wgsl */ `
-  (clip: vec2f) -> vec2f {
-    let world = camera2DUniforms.viewMatrixInverse * vec3(clip, 1);
-    return world.xy / world.z;
-  }
-`
-  .$uses({ ...Camera2DBindGroupLayout.bound })
-  .$name('camera2DClipToWorld')
+export const camera2DClipToWorld = tgpu.fn(
+  [vec2f],
+  vec2f,
+)((clip) => {
+  const camera2DUniforms = Camera2DBindGroupLayout.$.camera2DUniforms
+  const world = mul(camera2DUniforms.viewMatrixInverse, vec3f(clip, 1))
+  return div(world.xy, world.z)
+})
 
-export const camera2DClipToPixels = tgpu.fn([vec2f], vec2f) /* wgsl */ `
-  (clip: vec2f) -> vec2f {
-    return 0.5 * clip * camera2DUniforms.resolution;
-  }
-`
-  .$uses({ ...Camera2DBindGroupLayout.bound })
-  .$name('camera2DClipToPixels')
+export const camera2DClipToPixels = tgpu.fn(
+  [vec2f],
+  vec2f,
+)((clip) => {
+  const camera2DUniforms = Camera2DBindGroupLayout.$.camera2DUniforms
+  return mul(mul(0.5, clip), camera2DUniforms.resolution)
+})
 
-export const camera2DResolution = tgpu.fn([], vec2f) /* wgsl */ `
-  () -> vec2f {
-    return camera2DUniforms.resolution;
-  }
-`
-  .$uses({ ...Camera2DBindGroupLayout.bound })
-  .$name('camera2DResolution')
+export const camera2DResolution = tgpu.fn(
+  [],
+  vec2f,
+)(() => {
+  const camera2DUniforms = Camera2DBindGroupLayout.$.camera2DUniforms
+  return camera2DUniforms.resolution
+})
 
-export const camera2DPixelRatio = tgpu.fn([], f32) /* wgsl */ `
-  () -> f32 {
-    return camera2DUniforms.pixelRatio;
-  }
-`
-  .$uses({ ...Camera2DBindGroupLayout.bound })
-  .$name('camera2DPixelRatio')
+export const camera2DPixelRatio = tgpu.fn(
+  [],
+  f32,
+)(() => {
+  const camera2DUniforms = Camera2DBindGroupLayout.$.camera2DUniforms
+  return camera2DUniforms.pixelRatio
+})
 
 type Camera2DProps = {
   position: v2f

--- a/packages/app/src/lib/CameraContext.ts
+++ b/packages/app/src/lib/CameraContext.ts
@@ -9,11 +9,11 @@ export type CameraContext = {
   bindGroup: TgpuBindGroup
   BindGroupLayout: TgpuBindGroupLayout
   wgsl: {
-    worldToClip: TgpuFn<[Vec2f], Vec2f>
-    clipToWorld: TgpuFn<[Vec2f], Vec2f>
-    clipToPixels: TgpuFn<[Vec2f], Vec2f>
-    resolution: TgpuFn<[], Vec2f>
-    pixelRatio: TgpuFn<[], F32>
+    worldToClip: TgpuFn<(pos: Vec2f) => Vec2f>
+    clipToWorld: TgpuFn<(pos: Vec2f) => Vec2f>
+    clipToPixels: TgpuFn<(pos: Vec2f) => Vec2f>
+    resolution: TgpuFn<() => Vec2f>
+    pixelRatio: TgpuFn<() => F32>
   }
   js: {
     worldToClip: (clip: v2f) => v2f

--- a/packages/app/src/shaders/random.ts
+++ b/packages/app/src/shaders/random.ts
@@ -1,57 +1,63 @@
 import { tgpu } from 'typegpu'
 import { f32, u32, vec2f, vec4u } from 'typegpu/data'
+import { bitcastU32toF32, cos, mul, sin, sqrt } from 'typegpu/std'
 import { PI } from '@/flame/constants'
 
 export const randomState = tgpu.privateVar(vec4u, vec4u(0, 0, 0, 0))
 
-const tausStep = tgpu.fn([u32, u32, u32, u32, u32], u32) /* wgsl */ `
-  (z: u32, S1: u32, S2: u32, S3: u32, M: u32) -> u32 {
-    let b = ((z << S1) ^ z) >> S2;
-    return (((z & M) << S3) ^ b);
-  }
-`
+const tausStep = tgpu.fn(
+  [u32, u32, u32, u32, u32],
+  u32,
+)((z, S1, S2, S3, M) => {
+  const b = ((z << S1) ^ z) >> S2
+  return ((z & M) << S3) ^ b
+})
 
-const lcgStep = tgpu.fn([u32, u32, u32], u32) /* wgsl */ `
-  (z: u32, A: u32, C: u32) -> u32 {
-    return (A * z + C);
-  }
-`
+const lcgStep = tgpu.fn(
+  [u32, u32, u32],
+  u32,
+)((z, A, C) => {
+  return A * z + C
+})
 
-export const setSeed = tgpu.fn([vec4u]) /* wgsl */ `
-  (newRandomState: vec4u) {
-    randomState = newRandomState;
-  }
-`.$uses({ randomState })
+export const setSeed = tgpu.fn([vec4u])((newRandomState) => {
+  randomState.$ = newRandomState
+})
 
-export const random = tgpu.fn([], f32) /* wgsl */ `
-  () -> f32 {
-    let x = tausStep(s.x, 13, 19, 12, 4294967294);
-    let y = tausStep(s.y, 2, 25, 4, 4294967288);
-    let z = tausStep(s.z, 3, 11, 17, 4294967280);
-    let w = lcgStep(s.w, 1664525, 1013904223);
-    setSeed(vec4u(x, y, z, w));
+export const random = tgpu.fn(
+  [],
+  f32,
+)(() => {
+  const s = randomState.$
+  const x = tausStep(s.x, 13, 19, 12, 4294967294)
+  const y = tausStep(s.y, 2, 25, 4, 4294967288)
+  const z = tausStep(s.z, 3, 11, 17, 4294967280)
+  const w = lcgStep(s.w, 1664525, 1013904223)
+  setSeed(vec4u(x, y, z, w))
 
-    let a = x ^ y ^ z ^ w;
-    return bitcast<f32>((a & 0x007FFFFF) | 0x3F800000) - 1.0;
-  }
-`.$uses({ s: randomState, setSeed, tausStep, lcgStep })
+  const a = x ^ y ^ z ^ w
+  return bitcastU32toF32((a & 0x007fffff) | 0x3f800000) - 1.0
+})
 
-export const hash = tgpu.fn([u32], u32) /* wgsl */ `
-  (i: u32) -> u32 {
-    var x = i ^ (i >> 17);
-    x *= 0xed5ad4bbu;
-    x ^= x >> 11;
-    x *= 0xac4c1b51u;
-    x ^= x >> 15;
-    x *= 0x31848babu;
-    x ^= x >> 14;
-    return x;
-  }
-`
-export const randomUnitDisk = tgpu.fn([], vec2f) /* wgsl */ `
-  () -> vec2f {
-    let r = sqrt(random());
-    let theta = random() * 2 * PI;
-    return r * vec2f(cos(theta), sin(theta));
-  }
-`.$uses({ random, PI })
+export const hash = tgpu.fn(
+  [u32],
+  u32,
+)((i) => {
+  let x = i ^ (i >> 17)
+  x *= u32(0xed5ad4bb)
+  x ^= x >> 11
+  x *= u32(0xac4c1b51)
+  x ^= x >> 15
+  x *= u32(0x31848bab)
+  x ^= x >> 14
+  return x
+})
+
+export const randomUnitDisk = tgpu.fn(
+  [],
+  vec2f,
+)(() => {
+  const r = sqrt(random())
+  const theta = random() * 2 * PI.$
+  return mul(r, vec2f(cos(theta), sin(theta)))
+})

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -1,4 +1,5 @@
 import ssl from '@vitejs/plugin-basic-ssl'
+import typegpuPlugin from 'unplugin-typegpu/vite'
 import { defineConfig } from 'vite'
 import bundleAnalyzer from 'vite-bundle-analyzer'
 import solidPlugin from 'vite-plugin-solid'
@@ -11,6 +12,7 @@ export default defineConfig({
   plugins: [
     solidPlugin(),
     solidSvg({ defaultAsComponent: true }),
+    typegpuPlugin({}),
     ssl(),
     ANALYZE_BUNDLE ? bundleAnalyzer() : undefined,
   ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,6 +58,9 @@ importers:
       typescript-plugin-css-modules:
         specifier: ^5.2.0
         version: 5.2.0(typescript@5.9.3)
+      unplugin-typegpu:
+        specifier: ^0.8.0
+        version: 0.8.0(typegpu@0.8.0)
       vite:
         specifier: ^7.1.12
         version: 7.1.12
@@ -180,6 +183,10 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+
+  '@babel/standalone@7.28.5':
+    resolution: {integrity: sha512-1DViPYJpRU50irpGMfLBQ9B4kyfQuL6X7SS7pwTeWeZX0mNkjzPi0XFqxCjSdddZXUQy4AhnQnnesA/ZHnvAdw==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/template@7.27.2':
     resolution: {integrity: sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==}
@@ -459,6 +466,9 @@ packages:
   '@jridgewell/gen-mapping@0.3.8':
     resolution: {integrity: sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==}
     engines: {node: '>=6.0.0'}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
 
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
@@ -1121,6 +1131,9 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
+  defu@6.1.4:
+    resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
+
   dom-serializer@2.0.0:
     resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
 
@@ -1479,6 +1492,10 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
+  magic-string-ast@1.0.3:
+    resolution: {integrity: sha512-CvkkH1i81zl7mmb94DsRiFeG9V2fR2JeuK8yDgS8oiZSFa++wWLEgZ5ufEOyLHbvSbD1gTRKv9NdX69Rnvr9JA==}
+    engines: {node: '>=20.19.0'}
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -1768,6 +1785,10 @@ packages:
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
+  tinyest-for-wgsl@0.1.3:
+    resolution: {integrity: sha512-Wm5ADG1UyDxykf42S1gLYP4U9e1QP/TdtJeovQi6y68zttpiFLKqQGioHmPs9Mjysh7YMSAr/Lpuk0cD2MVdGA==}
+    engines: {node: '>=12.20.0'}
+
   tinyest@0.1.2:
     resolution: {integrity: sha512-aHRmouyowIq1P5jrTF+YK6pGX+WuvFtSCLbqk91yHnU3SWQRIcNIamZLM5XF6lLqB13AWz0PGPXRff2QGDsxIg==}
     engines: {node: '>=12.20.0'}
@@ -1846,6 +1867,15 @@ packages:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  unplugin-typegpu@0.8.0:
+    resolution: {integrity: sha512-VJHdXSXGOkAx0WhwFczhVUjAI6HyDkrQXk20HnwyuzIE3FdqE5l9sJTCYZzoVGo3z8i/IA5TMHCDzzP0Bc97Cw==}
+    peerDependencies:
+      typegpu: ^0.8.0
+
+  unplugin@2.3.10:
+    resolution: {integrity: sha512-6NCPkv1ClwH+/BGE9QeoTIl09nuiAt0gS28nn1PvYXsGKRwM2TCbFA2QiilmehPDTXIe684k4rZI1yl3A1PCUw==}
+    engines: {node: '>=18.12.0'}
 
   unrs-resolver@1.11.1:
     resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
@@ -1985,6 +2015,9 @@ packages:
   webidl-conversions@8.0.0:
     resolution: {integrity: sha512-n4W4YFyz5JzOfQeA8oN7dUYpR+MBP3PIUsn2jLjWXwK5ASUzt0Jc/A5sAUZoCYFJRGF0FBKJ+1JjN43rNdsQzA==}
     engines: {node: '>=20'}
+
+  webpack-virtual-modules@0.6.2:
+    resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
 
   wgpu-matrix@3.4.0:
     resolution: {integrity: sha512-kXHrbAPKEn9A32Wf4wVldyx9MmnzwhuB5p8GCqoJP3ItU5+iDT4J3aTQwPZWkfb153hwGtqZtUwR2M+ipJKadg==}
@@ -2157,6 +2190,8 @@ snapshots:
     dependencies:
       '@babel/core': 7.27.4
       '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/standalone@7.28.5': {}
 
   '@babel/template@7.27.2':
     dependencies:
@@ -2368,6 +2403,11 @@ snapshots:
     dependencies:
       '@jridgewell/set-array': 1.2.1
       '@jridgewell/sourcemap-codec': 1.5.0
+      '@jridgewell/trace-mapping': 0.3.25
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.8
       '@jridgewell/trace-mapping': 0.3.25
 
   '@jridgewell/resolve-uri@3.1.2': {}
@@ -2929,6 +2969,8 @@ snapshots:
 
   deep-is@0.1.4: {}
 
+  defu@6.1.4: {}
+
   dom-serializer@2.0.0:
     dependencies:
       domelementtype: 2.3.0
@@ -3307,6 +3349,10 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
+  magic-string-ast@1.0.3:
+    dependencies:
+      magic-string: 0.30.21
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -3564,6 +3610,10 @@ snapshots:
 
   tinybench@2.9.0: {}
 
+  tinyest-for-wgsl@0.1.3:
+    dependencies:
+      tinyest: 0.1.2
+
   tinyest@0.1.2: {}
 
   tinyexec@0.3.2: {}
@@ -3657,6 +3707,26 @@ snapshots:
       - ts-node
 
   typescript@5.9.3: {}
+
+  unplugin-typegpu@0.8.0(typegpu@0.8.0):
+    dependencies:
+      '@babel/standalone': 7.28.5
+      defu: 6.1.4
+      estree-walker: 3.0.3
+      magic-string-ast: 1.0.3
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      tinyest: 0.1.2
+      tinyest-for-wgsl: 0.1.3
+      typegpu: 0.8.0
+      unplugin: 2.3.10
+
+  unplugin@2.3.10:
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      acorn: 8.15.0
+      picomatch: 4.0.3
+      webpack-virtual-modules: 0.6.2
 
   unrs-resolver@1.11.1:
     dependencies:
@@ -3803,6 +3873,8 @@ snapshots:
       xml-name-validator: 5.0.0
 
   webidl-conversions@8.0.0: {}
+
+  webpack-virtual-modules@0.6.2: {}
 
   wgpu-matrix@3.4.0: {}
 


### PR DESCRIPTION
Instead of using `/* wgsl */` to implement variations, we can now directly implement them in TS thanks to typegpu 0.8. Only required thing is to put `'use gpu'` inside the function body.