### PR TITLE
feat: request-benchmark deep link (?benchmark, ?benchmark=auto)

### DIFF
--- a/packages/app/CHANGELOG.md
+++ b/packages/app/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Request-benchmark deep link**: a `?benchmark` query param (also `?benchmark=1` / `?benchmark=true`) skips the welcome screen and opens the benchmark dialog on load, so the app lands one click ("Run Benchmark") from a standardized GPU benchmark. `?benchmark=0` / `?benchmark=false` are treated as off.
+- **Request-benchmark deep link**: a `?benchmark` query param (also `?benchmark=1` / `?benchmark=true`) skips the welcome screen and opens the benchmark dialog on load, so the app lands one click ("Run Benchmark") from a standardized GPU benchmark. `?benchmark=auto` additionally starts the run automatically; `?benchmark=0` / `?benchmark=false` are treated as off.
 
 ## [0.9.1] - 2026-06-13
 

--- a/packages/app/CHANGELOG.md
+++ b/packages/app/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.2] - 2026-06-13
+
+### Added
+
+- **Request-benchmark deep link**: a `?benchmark` query param (also `?benchmark=1` / `?benchmark=true`) skips the welcome screen and opens the benchmark dialog on load, so the app lands one click ("Run Benchmark") from a standardized GPU benchmark. `?benchmark=0` / `?benchmark=false` are treated as off.
+
 ## [0.9.1] - 2026-06-13
 
 ### Added

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chaos-master",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "WebGPU based IFS Flame Generator for Artists & Explorers",
   "type": "module",
   "scripts": {

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -16,7 +16,7 @@ import { example2CreationTour } from './tours/example2CreationTour'
 import { flameCreationTour } from './tours/flameCreationTour'
 import { sidebarTour } from './tours/sidebarTour'
 import { timelineTour } from './tours/timelineTour'
-import { isBenchmarkRequested } from './utils/benchmarkRequest'
+import { isBenchmarkAuto, isBenchmarkRequested } from './utils/benchmarkRequest'
 import { decodeSharePayload } from './utils/jsonQueryParam'
 import { persistentSignal } from './utils/persistentSignal'
 import { recordKeys } from './utils/record'
@@ -69,7 +69,9 @@ function QueryErrorToast(props: { error: string | null }) {
 export function Wrappers() {
   // `?benchmark` (or `?benchmark=1`) is the "request benchmark" entry point:
   // skip the welcome screen and open the benchmark dialog straight away.
+  // `?benchmark=auto` additionally starts the run on load.
   const benchmarkRequested = isBenchmarkRequested(window.location.search)
+  const benchmarkAuto = isBenchmarkAuto(window.location.search)
   const [showWelcome, setShowWelcome] = createSignal(
     !hasWelcomeBeenDismissed() && !benchmarkRequested,
   )
@@ -217,6 +219,7 @@ export function Wrappers() {
                         flameFromWelcome={selectedFlame}
                         welcomeTracks={selectedWelcomeTracks}
                         autoOpenBenchmark={benchmarkRequested}
+                        autoStartBenchmark={benchmarkAuto}
                         hardwareTier={hardwareTier()}
                         onHardwareTierChange={setHardwareTier}
                         resetFlameFromWelcome={() => {

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -16,6 +16,7 @@ import { example2CreationTour } from './tours/example2CreationTour'
 import { flameCreationTour } from './tours/flameCreationTour'
 import { sidebarTour } from './tours/sidebarTour'
 import { timelineTour } from './tours/timelineTour'
+import { isBenchmarkRequested } from './utils/benchmarkRequest'
 import { decodeSharePayload } from './utils/jsonQueryParam'
 import { persistentSignal } from './utils/persistentSignal'
 import { recordKeys } from './utils/record'
@@ -66,7 +67,12 @@ function QueryErrorToast(props: { error: string | null }) {
 }
 
 export function Wrappers() {
-  const [showWelcome, setShowWelcome] = createSignal(!hasWelcomeBeenDismissed())
+  // `?benchmark` (or `?benchmark=1`) is the "request benchmark" entry point:
+  // skip the welcome screen and open the benchmark dialog straight away.
+  const benchmarkRequested = isBenchmarkRequested(window.location.search)
+  const [showWelcome, setShowWelcome] = createSignal(
+    !hasWelcomeBeenDismissed() && !benchmarkRequested,
+  )
   const [dontShowAgain, setDontShowAgain] = persistentSignal(
     'dontShowWelcome',
     false,
@@ -210,6 +216,7 @@ export function Wrappers() {
                         flameFromQuery={flameFromQuery()}
                         flameFromWelcome={selectedFlame}
                         welcomeTracks={selectedWelcomeTracks}
+                        autoOpenBenchmark={benchmarkRequested}
                         hardwareTier={hardwareTier()}
                         onHardwareTierChange={setHardwareTier}
                         resetFlameFromWelcome={() => {

--- a/packages/app/src/MainWorkspace.tsx
+++ b/packages/app/src/MainWorkspace.tsx
@@ -178,6 +178,8 @@ export type AppProps = {
   /** When true (driven by the `?benchmark` query param), open the benchmark
    *  dialog on mount so the user lands one click from running it. */
   autoOpenBenchmark?: boolean
+  /** When true (`?benchmark=auto`), also start the run automatically. */
+  autoStartBenchmark?: boolean
 }
 
 export function extractFlameVariationTypes(
@@ -616,7 +618,7 @@ export function MainWorkspace(props: AppProps) {
       setRandomizerHistory,
     )
     if (props.autoOpenBenchmark) {
-      void showBenchmark()
+      void showBenchmark({ autoStart: props.autoStartBenchmark })
     }
     if (IS_DEV) {
       console.info('[share:app] onMount', {
@@ -4245,7 +4247,11 @@ export function MainWorkspace(props: AppProps) {
             }}
           />
           <SpotlightTour tourContext={tourContext} />
-          <BenchmarkButton onClick={showBenchmark} />
+          <BenchmarkButton
+            onClick={() => {
+              void showBenchmark()
+            }}
+          />
           <SoftwareVersion
             showHelp={createShowHelp(
               quickPickerMode,

--- a/packages/app/src/MainWorkspace.tsx
+++ b/packages/app/src/MainWorkspace.tsx
@@ -175,6 +175,9 @@ export type AppProps = {
   resetFlameFromWelcome?: () => void
   hardwareTier?: HardwareTier | null
   onHardwareTierChange?: (tier: HardwareTier) => void
+  /** When true (driven by the `?benchmark` query param), open the benchmark
+   *  dialog on mount so the user lands one click from running it. */
+  autoOpenBenchmark?: boolean
 }
 
 export function extractFlameVariationTypes(
@@ -603,12 +606,18 @@ export function MainWorkspace(props: AppProps) {
     setPrePaletteColors({})
   }
 
+  // Shared by the toolbar Benchmark button and the `?benchmark` auto-open.
+  const showBenchmark = createShowBenchmark()
+
   onMount(() => {
     loadCustomVariations()
     setCustomVarsVersion((v) => v + 1)
     void loadRandomizerHistoryEntries(MAX_RANDOMIZER_HISTORY_LIMIT).then(
       setRandomizerHistory,
     )
+    if (props.autoOpenBenchmark) {
+      void showBenchmark()
+    }
     if (IS_DEV) {
       console.info('[share:app] onMount', {
         hasQueryFlame: !!props.flameFromQuery?.flame,
@@ -4236,7 +4245,7 @@ export function MainWorkspace(props: AppProps) {
             }}
           />
           <SpotlightTour tourContext={tourContext} />
-          <BenchmarkButton onClick={createShowBenchmark()} />
+          <BenchmarkButton onClick={showBenchmark} />
           <SoftwareVersion
             showHelp={createShowHelp(
               quickPickerMode,

--- a/packages/app/src/components/BenchmarkModal/BenchmarkModal.tsx
+++ b/packages/app/src/components/BenchmarkModal/BenchmarkModal.tsx
@@ -1,4 +1,4 @@
-import { createMemo, createResource, createSignal, Show, Suspense, } from 'solid-js'
+import { createMemo, createResource, createSignal, onMount, Show, Suspense, } from 'solid-js'
 import { vec2f, vec4f } from 'typegpu/data'
 import { DEFAULT_POINT_COUNT } from '@/defaults'
 import { examples } from '@/flame/examples'
@@ -186,7 +186,7 @@ function drawAchievementBadge(
   ctx.fillText(label, x + 8, y + 15)
 }
 
-function BenchmarkModal(props: { respond: () => void }) {
+function BenchmarkModal(props: { respond: () => void; autoStart?: boolean }) {
   const [gpuDeviceInfo] = createResource(getGPUDeviceInformation)
   const [state, setState] = createSignal<BenchmarkState>('idle')
   const [totalPoints, setTotalPoints] = createSignal(0)
@@ -207,6 +207,15 @@ function BenchmarkModal(props: { respond: () => void }) {
     running = true
     setState('running')
   }
+
+  // `?benchmark=auto` starts the run as soon as the dialog mounts. The elapsed
+  // timer only begins on the first accumulated points (see handleAccumulatedPoints),
+  // so starting before the GPU is warm doesn't skew the measurement.
+  onMount(() => {
+    if (props.autoStart) {
+      handleStart()
+    }
+  })
 
   function handleCancel() {
     running = false
@@ -676,10 +685,12 @@ function BenchmarkModal(props: { respond: () => void }) {
 export function createShowBenchmark() {
   const requestModal = useRequestModal()
 
-  async function showBenchmark() {
+  async function showBenchmark(options?: { autoStart?: boolean }) {
     await requestModal({
       class: ui.benchmarkModal,
-      content: ({ respond }) => <BenchmarkModal respond={respond} />,
+      content: ({ respond }) => (
+        <BenchmarkModal respond={respond} autoStart={options?.autoStart} />
+      ),
     })
   }
 

--- a/packages/app/src/utils/benchmarkRequest.test.ts
+++ b/packages/app/src/utils/benchmarkRequest.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { isBenchmarkRequested } from './benchmarkRequest'
+import { isBenchmarkAuto, isBenchmarkRequested } from './benchmarkRequest'
 
 describe('isBenchmarkRequested', () => {
   it('opts in when the param is present', () => {
@@ -14,5 +14,16 @@ describe('isBenchmarkRequested', () => {
     expect(isBenchmarkRequested('?foo=bar')).toBe(false)
     expect(isBenchmarkRequested('?benchmark=0')).toBe(false)
     expect(isBenchmarkRequested('?benchmark=false')).toBe(false)
+  })
+
+  it('treats =auto as both requested and auto-start', () => {
+    expect(isBenchmarkRequested('?benchmark=auto')).toBe(true)
+    expect(isBenchmarkAuto('?benchmark=auto')).toBe(true)
+  })
+
+  it('does not auto-start for a plain request', () => {
+    expect(isBenchmarkAuto('?benchmark')).toBe(false)
+    expect(isBenchmarkAuto('?benchmark=1')).toBe(false)
+    expect(isBenchmarkAuto('')).toBe(false)
   })
 })

--- a/packages/app/src/utils/benchmarkRequest.test.ts
+++ b/packages/app/src/utils/benchmarkRequest.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+import { isBenchmarkRequested } from './benchmarkRequest'
+
+describe('isBenchmarkRequested', () => {
+  it('opts in when the param is present', () => {
+    expect(isBenchmarkRequested('?benchmark')).toBe(true)
+    expect(isBenchmarkRequested('?benchmark=1')).toBe(true)
+    expect(isBenchmarkRequested('?benchmark=true')).toBe(true)
+    expect(isBenchmarkRequested('?foo=bar&benchmark=')).toBe(true)
+  })
+
+  it('opts out when absent or explicitly disabled', () => {
+    expect(isBenchmarkRequested('')).toBe(false)
+    expect(isBenchmarkRequested('?foo=bar')).toBe(false)
+    expect(isBenchmarkRequested('?benchmark=0')).toBe(false)
+    expect(isBenchmarkRequested('?benchmark=false')).toBe(false)
+  })
+})

--- a/packages/app/src/utils/benchmarkRequest.ts
+++ b/packages/app/src/utils/benchmarkRequest.ts
@@ -10,3 +10,11 @@ export function isBenchmarkRequested(search: string): boolean {
   const value = new URLSearchParams(search).get('benchmark')
   return value !== null && value !== '0' && value !== 'false'
 }
+
+/**
+ * `?benchmark=auto` additionally starts the run automatically on load, instead
+ * of waiting for the user to click "Run Benchmark". Implies a request.
+ */
+export function isBenchmarkAuto(search: string): boolean {
+  return new URLSearchParams(search).get('benchmark') === 'auto'
+}

--- a/packages/app/src/utils/benchmarkRequest.ts
+++ b/packages/app/src/utils/benchmarkRequest.ts
@@ -1,0 +1,12 @@
+/**
+ * The "request benchmark" entry point: a `?benchmark` query param that makes
+ * the app skip the welcome screen and open the benchmark dialog on load.
+ *
+ * Treated as requested when the param is present and not explicitly disabled,
+ * so `?benchmark`, `?benchmark=1` and `?benchmark=true` all opt in, while
+ * `?benchmark=0` and `?benchmark=false` do not.
+ */
+export function isBenchmarkRequested(search: string): boolean {
+  const value = new URLSearchParams(search).get('benchmark')
+  return value !== null && value !== '0' && value !== 'false'
+}


### PR DESCRIPTION
## Summary

Adds a **request-benchmark deep link** so the app can launch straight into the GPU benchmark, bypassing the welcome screen. Bumps to **0.9.2**.

- `?benchmark` (also `?benchmark=1` / `?benchmark=true`) — skips the welcome screen and opens the benchmark dialog on load, so the app lands one click ("Run Benchmark") from a standardized benchmark.
- `?benchmark=auto` — additionally **starts the run automatically** on load.
- `?benchmark=0` / `?benchmark=false` — treated as off (normal startup).

## Implementation

- `utils/benchmarkRequest.ts` — `isBenchmarkRequested(search)` / `isBenchmarkAuto(search)` helpers (+ unit tests for the opt-in / opt-out / auto cases).
- `App.tsx` — parse the param, force the welcome screen off when requested, and thread `autoOpenBenchmark` / `autoStartBenchmark` into `MainWorkspace`.
- `MainWorkspace.tsx` — hoist the shared `createShowBenchmark()` handler (reused by the toolbar button) and open the dialog on mount when requested.
- `BenchmarkModal` — accepts an `autoStart` prop and calls `handleStart` on mount. The elapsed timer only begins on the first accumulated points, so auto-starting before the GPU is warm does not skew the BPS measurement.

The benchmark dialog already renders its own benchmark model (`examples.benchmark`) and run button, so the workspace flame is deliberately left untouched — a second heavy render behind the modal would compete for the GPU and skew results.

## Testing

- `pnpm check` green: typecheck, lint, format, `validate-wgsl`.
- Full vitest suite green (141 tests), including the new `benchmarkRequest` cases.
- Manual: `/?benchmark` opens the dialog with welcome skipped; `/?benchmark=auto` opens and starts the run.
