### PR TITLE
feat: OG link-sharing previews (rich social cards) via client render + R2

### DIFF
--- a/docs/og-link-previews.md
+++ b/docs/og-link-previews.md
@@ -31,13 +31,17 @@ Long-form `/?flame=…` links (created outside the share flow) get a generic tex
 
 ## One-time setup (before deploy)
 
-Create the R2 buckets (free tier — 10 GB, egress free):
+Create the R2 buckets (free tier — 10 GB, egress free). Requires `wrangler login`
+first. From `packages/app`:
 
 ```bash
-cd packages/app
-pnpm exec wrangler r2 bucket create chaos-master-og-images       # prod
-pnpm exec wrangler r2 bucket create chaos-master-og-images-dev   # dev/preview
+pnpm run r2:create:dev     # chaos-master-og-images-dev   (dev + preview envs)
+pnpm run r2:create:prod    # chaos-master-og-images       (prod env)
 ```
+
+You only need `r2:create:dev` to test on the dev environment. Bucket names /
+bindings are wired in `wrangler.jsonc` (`OG_IMAGES`); R2 is local-simulated under
+`wrangler dev`, so no bucket is needed for local testing.
 
 **Optional — auto-expire images** to bound storage (recommended; matches the plan).
 R2 lifecycle rules are set in the Cloudflare dashboard → R2 → bucket → Settings →

--- a/docs/og-link-previews.md
+++ b/docs/og-link-previews.md
@@ -7,18 +7,25 @@ Worker stores it in R2 and injects `og:*` / `twitter:*` meta tags. **$0 / free t
 
 ## How it works
 
-1. **Share** — `ShareLinkModal` creates a short link (`POST /api/shorten` → `?s=<id>`),
-   then in the background captures the current flame canvas, downscales it (≤1000 px,
-   aspect preserved), and `POST /api/og/<id>` with the PNG + title/description.
-2. **Store** — the Worker puts the PNG in the **`OG_IMAGES` R2 bucket** under `<id>` and
-   the title/description in KV under `og:<id>`.
-3. **Serve** — `GET /og/<id>` streams the PNG from R2 (cached 24 h).
-4. **Inject** — when a crawler fetches `/?s=<id>`, the Worker reads `og:<id>`, fetches the
-   built `index.html` from assets, and injects `og:*` / `twitter:*` tags (absolute URLs)
-   plus a richer `<title>`. Human visitors still get the normal SPA.
+1. **Share** — `ShareLinkModal` builds `?flame=<encoded>`, upgrades to `?s=<id>` if
+   `POST /api/shorten` succeeds, then (background) captures the current flame canvas,
+   downscales it (≤1000 px), **embeds the flame descriptor** into the PNG (deflate zTXt
+   chunk, same as Discord share), and `POST /api/og/<key>` with the PNG + title/description.
+   `<key>` is `ogKey(encoded)` = SHA-256 of the encoded payload (first 32 hex) —
+   **content-addressed**, so it's independent of the short id.
+2. **Store** — the Worker puts the PNG in the **`OG_IMAGES` R2 bucket** under `<key>` and
+   the title/description in KV under `og:<key>`.
+3. **Serve** — `GET /og/<key>` streams the PNG from R2 (cached 24 h). Because the flame is
+   embedded, downloading this image lets the user load the flame back into the app.
+4. **Inject** — for `/?s=<id>` the Worker resolves the payload from KV then hashes it to
+   `<key>`; for `/?flame=<encoded>` it hashes the inline payload directly. Either way it
+   reads `og:<key>`, fetches the built `index.html` via `env.ASSETS`, and injects
+   `og:*` / `twitter:*` tags (absolute URLs) + a richer `<title>`. Human visitors still
+   get the normal SPA.
 
-Long-form `/?flame=…` links (created outside the share flow) get a generic text card
-(no stored image).
+Because the image is content-addressed, **`?flame=` and `?s=` produce the same preview** —
+so a link shared without (or after a failed) shortener still gets the full image card. A
+`?flame=` link built outside the app (no uploaded image) falls back to a text card.
 
 ## Files
 

--- a/docs/og-link-previews.md
+++ b/docs/og-link-previews.md
@@ -1,0 +1,80 @@
+# OG Link Previews — Setup & Testing
+
+Rich social previews (Discord / Slack / X / Facebook / LinkedIn) for shared flame
+links, implemented as **Option C** of [`plans/og-meta-tags-plan.md`](./plans/og-meta-tags-plan.md):
+the client GPU-renders the flame, uploads a downscaled PNG, and the existing app
+Worker stores it in R2 and injects `og:*` / `twitter:*` meta tags. **$0 / free tier.**
+
+## How it works
+
+1. **Share** — `ShareLinkModal` creates a short link (`POST /api/shorten` → `?s=<id>`),
+   then in the background captures the current flame canvas, downscales it (≤1000 px,
+   aspect preserved), and `POST /api/og/<id>` with the PNG + title/description.
+2. **Store** — the Worker puts the PNG in the **`OG_IMAGES` R2 bucket** under `<id>` and
+   the title/description in KV under `og:<id>`.
+3. **Serve** — `GET /og/<id>` streams the PNG from R2 (cached 24 h).
+4. **Inject** — when a crawler fetches `/?s=<id>`, the Worker reads `og:<id>`, fetches the
+   built `index.html` from assets, and injects `og:*` / `twitter:*` tags (absolute URLs)
+   plus a richer `<title>`. Human visitors still get the normal SPA.
+
+Long-form `/?flame=…` links (created outside the share flow) get a generic text card
+(no stored image).
+
+## Files
+
+| File | Change |
+|------|--------|
+| `packages/app/src/worker/index.ts` | `POST /api/og/:id`, `GET /og/:id`, meta injection on `/?s=` and `/?flame=` |
+| `packages/app/wrangler.jsonc` | `OG_IMAGES` R2 binding (prod / dev / preview) |
+| `packages/app/src/MainWorkspace.tsx` | `captureOgImageBlob()` — clean-frame capture + downscale |
+| `packages/app/src/components/ShareLinkModal/ShareLinkModal.tsx` | background upload + title/description |
+
+## One-time setup (before deploy)
+
+Create the R2 buckets (free tier — 10 GB, egress free):
+
+```bash
+cd packages/app
+pnpm exec wrangler r2 bucket create chaos-master-og-images       # prod
+pnpm exec wrangler r2 bucket create chaos-master-og-images-dev   # dev/preview
+```
+
+**Optional — auto-expire images** to bound storage (recommended; matches the plan).
+R2 lifecycle rules are set in the Cloudflare dashboard → R2 → bucket → Settings →
+Object lifecycle rules → "Delete objects N days after creation" (e.g. 30). Note: if the
+image TTL is shorter than the 60-day link TTL, old links fall back to the text card.
+
+## Deploy
+
+```bash
+cd packages/app
+pnpm run deploy:dev     # → dev.chaos-master.com
+# pnpm run deploy:prod  # → chaos-master.com
+```
+
+## Testing
+
+1. Open the app, build/select a flame, **Share Link** → copy the `?s=<id>` URL.
+2. Confirm the image stored:
+   ```bash
+   curl -I "https://dev.chaos-master.com/og/<id>"      # → 200, Content-Type: image/png
+   ```
+3. Confirm meta tags injected:
+   ```bash
+   curl -s "https://dev.chaos-master.com/?s=<id>" | grep -i 'og:\|twitter:'
+   ```
+4. Validate with the platform debuggers (they also force a re-scrape):
+   - Facebook: https://developers.facebook.com/tools/debug/
+   - X/Twitter: https://cards-dev.twitter.com/validator
+   - LinkedIn: https://www.linkedin.com/post-inspector/
+   - Discord/Slack: paste the URL in any channel.
+
+## Notes / limitations
+
+- **Race:** the image uploads ~1–2 s after the link is created. If a crawler scrapes
+  before the upload lands, the first preview has no image; platforms re-scrape later
+  (or use the debugger to force it).
+- **Canvas capture** relies on `canvas.toBlob` of the live WebGPU canvas (same path as
+  Discord sharing). Verify on iOS Safari during testing.
+- **Cost:** PNG ≤ ~100 KB; thousands of images stay well within R2's 10 GB free tier;
+  egress (serving previews) is free. See the plan doc's storage analysis.

--- a/docs/plans/og-meta-tags-plan.md
+++ b/docs/plans/og-meta-tags-plan.md
@@ -1,0 +1,258 @@
+# OG Meta Tags & Link-Sharing Previews — Plan / Replan
+
+**Status:** Planning (no implementation yet)
+**Date:** 2026-06-13
+**Branches involved:**
+- `feat/og-meta-tags-image` — original OG work (rebased onto `upstream/main`, 3 commits, preserved locally)
+- `feat/server-side-gpu-renderer` — Deno render-worker (real WGSL pipeline, server-side)
+- `feat/og-meta-tags-render-worker` — **this branch** (cut from the server-side renderer, where we replan + cherry-pick)
+
+---
+
+## TL;DR
+
+The feature has **two independent parts**:
+
+1. **Meta-tag injection** — make crawlers (Discord/Slack/X/FB/LinkedIn) see `og:*` / `twitter:*`
+   tags for `/?flame=…` and `/?s=…` URLs. This is small, must live in the **existing app
+   Cloudflare Worker** (`packages/app/src/worker/index.ts`) via `HTMLRewriter`, and is the same
+   regardless of how we produce the image.
+
+2. **The preview image** — the actual PNG. This is the real decision, and the original branch's
+   approach **does not work on Cloudflare as written** (see hard constraints). Three viable paths,
+   analysed below.
+
+**Recommendation:** **Option C (client-render + store in R2)** as primary — free, highest quality,
+trivial server CPU — with **Option A (Worker CPU render)** as a no-storage fallback. Use the Deno
+render-worker (**Option B**) only if/when it is already deployed for the premium server-render
+feature, in which case OG previews can piggyback on it for pixel-accuracy.
+
+---
+
+## Background — what already exists
+
+### a) `feat/og-meta-tags-image` (the original OG work)
+A standalone Cloudflare Worker (`packages/worker/`, name `chaos-master-og`) that:
+- `/og/?flame=` → renders a 600×315 PNG with a from-scratch **Canvas2D chaos-game** (`renderFlameToPng.ts`)
+- `/?flame=` → injects `og:*` / `twitter:*` tags
+- assumes **app-on-Vercel + separate OG worker on its own domain**
+
+It was written ~2026-03-14 and never deployed/merged. Since then the architecture changed.
+
+### b) The app today (`upstream/main` ≈ `origin/main`)
+The whole site is served by **one Cloudflare Worker**: `packages/app/src/worker/index.ts`
+(`wrangler.jsonc`, name `chaos-master`, prod `chaos-master.com`, dev `dev.chaos-master.com`).
+It already has:
+- **KV-backed URL shortening** — `POST /api/shorten` + `GET /api/shorten/:id`, binding `KV_SHORTENER`.
+- Static SPA served via `env.ASSETS.fetch` (assets dir `dist`).
+- Share format is a **wrapper**: `encodeSharePayload(flame, animation?)` → `{ flame, animation? }`,
+  base64url (`-_`, no pad). Most shares are auto-shortened to **`?s=<id>`** (ShareLinkModal calls
+  `/api/shorten`); raw `?flame=` URLs are the long-form fallback.
+
+### c) `feat/server-side-gpu-renderer` (the Deno render-worker)
+Lives in `workers/render-worker/` (Deno, **not** `packages/`). It:
+- Reuses the **exact app WGSL pipeline** (`ifsPipeline`, `densityEstimationPipeline`,
+  `adaptiveBlur`, `colorGrading`, OkLab palettes) under Deno native WebGPU → **pixel-accurate**.
+- "CPU fallback" = **software Vulkan (Mesa lavapipe)**, *not* pure JS — still needs Deno + Dawn in a
+  container (`VK_ICD_FILENAMES=lvp_icd`).
+- Deploys as a **Docker container on a host** (GPU via `run-nvidia.sh`/`run-amd.sh`, or software
+  Vulkan). **Not serverless / not free.**
+- API is an **async job model**: `POST /render` → jobId; poll `GET /render/:id`;
+  `GET /render/:id/result` → PNG. No synchronous render endpoint.
+
+---
+
+## Hard constraints discovered (these drive the decision)
+
+1. **Cloudflare Workers have NO Canvas / OffscreenCanvas.** workerd has no DOM/canvas. The original
+   `renderFlameToPng.ts` uses `new OffscreenCanvas(...)`, `ctx.createImageData`, `convertToBlob` —
+   **these throw on Cloudflare.** Any in-Worker rendering must build the pixel buffer in plain JS and
+   **encode the PNG manually** (pure-JS encoder, ideally *stored*/uncompressed deflate blocks to stay
+   cheap) or use a WASM lib (`@cf-wasm/photon`, `resvg`) — extra bundle weight + CPU.
+
+2. **Free Worker CPU = 10 ms / request** (100k req/day). A real flame needs millions of samples for
+   smooth density; ~10 ms only buys a few hundred-thousand chaos-game iterations (atan2/sin/cos are
+   expensive) → **sparse, approximate** previews. Wall-clock (I/O wait) is uncapped, but rendering is
+   CPU-bound, so 10 ms is the binding limit on the free tier.
+
+3. **Two original decode bugs** (must avoid by reusing app utils, not the worker's copies):
+   - `decompressJsonQuery` constructed `new CompressionStream('deflate')` — should be
+     `DecompressionStream`. As written it can't decode anything.
+   - It parsed a bare `FlameDescriptor`, but the app now sends `{ flame, animation }` → must unwrap.
+
+4. **Short links dominate.** `/og/` in the original only reads `?flame=`. Real shares are `?s=<id>`
+   → need a KV lookup first (the app worker already binds `KV_SHORTENER`).
+
+5. **render-worker is host-bound + async.** Crawlers issue a **single synchronous GET** for
+   `og:image` and time out fast. The job-based API needs a synchronous wrapper, and the host must be
+   always-on.
+
+6. **OG URLs must be absolute** (`https://chaos-master.com/...`); the original emitted relative URLs.
+
+---
+
+## Options for producing the preview image
+
+### Option A — Cloudflare Worker CPU render (self-contained, "free CPU we have")
+Port the chaos-game accumulation into the app worker, **drop the canvas dependency**, and encode the
+PNG by hand (stored/uncompressed zlib blocks + CRC32 — cheap). Decode via the app's real
+`decodeSharePayload`.
+
+- ➕ Truly free, serverless, zero extra infra, low latency, in-memory + edge cache.
+- ➖ Must write/own a pure-JS PNG encoder; **approximate quality** under 10 ms CPU; a **second,
+  lower-fidelity renderer** to maintain (only ~20 variations re-implemented, no DE/blur/real palette,
+  ignores camera/zoom); not pixel-accurate to the app.
+
+### Option B — Proxy the Deno render-worker (pixel-accurate)
+App worker injects meta tags; `og:image` is served by (or proxied from) the render-worker, which
+renders with the **real pipeline**.
+
+- ➕ Pixel-accurate, single source of truth for rendering, supports every variation + 3D + DE.
+- ➖ **Not free / not serverless** — needs an always-on Docker host (GPU or software Vulkan); async
+  job API needs a **synchronous** wrapper for crawlers; render latency (seconds) → aggressive caching
+  mandatory; couples the OG PR to the large server-side-renderer work.
+
+### Option C — Client-render + store (recommended primary)
+The app **already GPU-renders the flame in the browser**. At share time, read back the canvas,
+downscale to ~1200×630, and upload the PNG alongside the short link; the worker serves it for
+`og:image`.
+
+- Flow: `ShareLinkModal` → render/readback PNG → `POST /api/share` stores `{ payload, png }`
+  (payload in KV, **PNG in R2** keyed by short id) → `og:image = https://chaos-master.com/og/<id>.png`.
+- Worker: `GET /og/:id.png` → stream from R2; `HTMLRewriter` injects meta with the absolute R2 URL.
+- ➕ **Free** (R2 free tier 10 GB + generous ops), **highest quality** (the real GPU render the user
+  sees), **near-zero server CPU**, no second renderer, no canvas-in-worker problem.
+- ➖ Only covers links created via the share flow (the common path); raw hand-built `?flame=` URLs
+  have no stored image → fall back to a generic static card. Adds an R2 bucket + a storage write to
+  the share flow. (KV write cap on free is 1k/day → use **R2** for the image, not KV.)
+
+### Option D — Cloudflare Browser Rendering / screenshot service
+Headless-Chrome screenshot of the app. ➖ Paid (Browser Rendering is a paid binding), heavyweight,
+slow. **Dismissed.**
+
+---
+
+## Tradeoff summary
+
+| Criterion | A: Worker CPU | B: render-worker | C: client-render + R2 |
+|---|---|---|---|
+| Cost | Free | Host (not free) | Free (R2 free tier) |
+| Quality | Approximate | Pixel-accurate | Pixel-accurate (real GPU) |
+| Server CPU | High (10 ms cap) | On the host | ~Zero |
+| Infra added | None | Always-on container | R2 bucket |
+| Canvas-in-worker problem | Yes (manual PNG enc.) | N/A | N/A |
+| Covers raw `?flame=` URLs | Yes | Yes | No (needs share flow → fallback card) |
+| Crawler latency | Low (cached) | Risky (async, secs) | Low (static R2) |
+| Maintains 2nd renderer | Yes | No | No |
+| Couples to big server PR | No | Yes | No |
+
+---
+
+## Recommendation
+
+1. **Ship the meta-tag injection now** in the app worker (common to all). Low risk, immediate value.
+2. **Image = Option C** (client-render + R2) as the primary path — free, accurate, simplest server.
+3. **Fallback = a generic static OG card** for non-share-flow URLs (and as the day-1 image if C slips).
+4. Keep **Option B** in mind only if the render-worker gets deployed for the paid server-render
+   feature — then OG can reuse it for `?flame=`-only links too. Don't block OG on it.
+5. **Option A** only if we explicitly want zero-storage + self-contained and accept approximate
+   quality; if so, it must replace the canvas with a hand-rolled PNG encoder.
+
+---
+
+## Implementation plan (recommended: meta injection + Option C)
+
+### Part 1 — Meta-tag injection (app worker)
+1. In `packages/app/src/worker/index.ts`, before the `env.ASSETS.fetch` fallback, intercept
+   `GET /` and `/index.html` when `?flame=` or `?s=` is present.
+2. Resolve the payload: `?s=<id>` → `KV_SHORTENER.get(id)`; `?flame=` → use directly.
+3. Decode with the app's **real** `decodeSharePayload` / `decompressJsonPayload` (fixes both original
+   bugs; no drift). Derive title (author/name), description (transform count), absolute URLs.
+4. Fetch the built `index.html` via `env.ASSETS.fetch(request)` and inject/replace `og:*` + `twitter:*`
+   via **`HTMLRewriter`** (do not hardcode HTML — the original referenced dev `/src/index.tsx`).
+5. Absolute URLs only; sensible caching headers.
+
+### Part 2 — Image (Option C)
+6. Add an **R2 bucket** binding (e.g. `OG_IMAGES`) to `wrangler.jsonc` (all envs).
+7. In `ShareLinkModal` (or the share util), read back the rendered flame canvas → downscale to
+   1200×630 → PNG `Blob`.
+8. Extend the shorten endpoint (or add `POST /api/share`) to store payload in KV **and** PNG in R2
+   under the short id.
+9. Worker route `GET /og/:id.png` → stream from R2 with long cache headers; meta `og:image` points here.
+10. **Fallback:** bundle a static `og-default.png`; use it when no stored image exists.
+11. Validate with FB / X / LinkedIn debuggers + Discord/Slack paste before opening the PR.
+
+---
+
+## What to cherry-pick / salvage from `feat/og-meta-tags-image`
+
+- ✅ The **OG/Twitter tag set + title/description heuristics** from `index.ts` `generateHtmlWithOgTags`
+  (reuse the tag list; re-home into `HTMLRewriter`, switch to absolute URLs).
+- ✅ `docs/cloudflare-worker.md` — rewrite for the single-worker model.
+- ⚠️ `renderFlameToPng.ts` — **only if we pick Option A**, and then strip the canvas (manual PNG
+  encoder) and reconcile with the real flame schema. Otherwise drop it.
+- ❌ `base64.ts` / `jsonQueryParam.ts` worker copies — **discard**; reuse app utils.
+- ❌ Standalone `packages/worker/` + its `wrangler.toml` — **discard** (folded into the app worker).
+
+---
+
+## Upstream PR strategy
+
+- Meta injection + Option C is **small and self-contained** → target a **focused PR off
+  `upstream/main`**, *not* riding on the large `feat/server-side-gpu-renderer` branch (auth/Stripe/
+  db-worker/render-worker would bloat the diff).
+- ⚠️ **Branch-base note:** this branch (`feat/og-meta-tags-render-worker`) is cut from the server-side
+  renderer, which only makes sense for **Option B**. If we go with **C/A (recommended)**, re-base the
+  OG work onto `upstream/main` and keep the server-side branch out of the PR.
+- Sequence: (1) meta-tags PR (works with the static fallback image), (2) Option-C image PR. Test each
+  before merge.
+
+---
+
+## Storage cost analysis (Option C) — "why not client-render, upload, store, serve?"
+
+**Yes — that's exactly Option C, and it works.** Flow: browser WebGPU render → read back canvas →
+downscale (low-res, ~600×315 or a compressed ~1200×630) → `POST` to the worker → worker stores in
+**R2** under the short id → `og:image = https://chaos-master.com/og/<id>.png` → crawler fetches it
+back from the worker/R2.
+
+**Use R2, not KV, for the image:**
+
+| | R2 (recommended) | KV |
+|---|---|---|
+| Free storage | 10 GB-month | 1 GB |
+| Free writes | 1M Class A ops/mo (~33k/day) | **1,000/day** (the binding cap) |
+| Free reads | 10M Class B ops/mo | 100k/day |
+| Egress | **Free** (serving `og:image` costs nothing) | Free |
+| Native expiry | Lifecycle rule (auto-delete after N days) | Per-key `expirationTtl` |
+| Binary blobs | First-class | Value ≤ 25 MB; works but not ideal |
+
+**Cost at this scale ≈ $0.** A low-res PNG is ~30–100 KB. Even 10,000 stored images ≈ 0.3–1 GB →
+inside R2's 10 GB free tier; egress is free, so serving previews to crawlers is free; 1 write/share is
+far under R2's 1M/month. KV's **1,000 writes/day** free cap is the only thing that would bite → R2 wins.
+
+**Retention / the capacity idea:** prefer **TTL-based auto-cleanup over a hard N-cap.** An R2 lifecycle
+rule "delete after 7 days" (or 30) bounds storage automatically with zero code — no counter, no
+"stop saving" branch. A hard cap is doable but needs you to track a count and is easy to get wrong;
+TTL is simpler and self-healing.
+
+**Caveat:** if image TTL (a few days) < link TTL (60 days), old links lose the rich preview and fall
+back to the generic card. Usually fine — previews matter most in the first hours/days, and platforms
+(Discord/X/FB) **cache their own copy** on first scrape, so the R2 object only needs to survive until
+the first crawler hit. If links should keep previews forever, either (a) match image TTL to link TTL
+(60 days of images is still well within free tier), or (b) regenerate on demand when an expired image
+is requested. **Net: storage is effectively free here — R2 + a 7–30 day lifecycle rule, no manual cap.**
+
+> Note: Option C largely **sidesteps the A-vs-B decision** for the common (share-flow) path — the image
+> comes from the client's GPU, so no server renderer is needed there. A or B only matter for raw
+> `?flame=` URLs created outside the share flow, or if we don't want to upload from the client.
+
+## Open questions
+
+1. Confirm the in-app flame canvas can be read back to a PNG at share time (it renders on GPU — verify
+   `toBlob`/readback works across browsers, esp. iOS Safari).
+2. R2 public access vs. serving through the worker (`/og/:id.png`)? Worker-served keeps one domain +
+   cache control.
+3. Storage lifecycle: tie OG image TTL to the short-link TTL (currently 60 days) so they expire together.
+4. Decision: do we want raw `?flame=` URLs (no share flow) to also get a real image (→ needs A or B),
+   or is a generic fallback card acceptable for those?

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -12,7 +12,9 @@
     "test": "vitest",
     "analyze-bundle": "VITE_ANALYZE_BUNDLE=true vite build",
     "deploy:dev": "pnpm exec wrangler deploy --env dev",
-    "deploy:prod": "pnpm exec wrangler deploy --env prod"
+    "deploy:prod": "pnpm exec wrangler deploy --env prod",
+    "r2:create:dev": "pnpm exec wrangler r2 bucket create chaos-master-og-images-dev",
+    "r2:create:prod": "pnpm exec wrangler r2 bucket create chaos-master-og-images"
   },
   "license": "AGPL-3.0-only",
   "dependencies": {

--- a/packages/app/src/MainWorkspace.tsx
+++ b/packages/app/src/MainWorkspace.tsx
@@ -783,10 +783,66 @@ export function MainWorkspace(props: AppProps) {
 
   const timeline = createTimelineState()
 
+  /**
+   * Capture the current flame canvas as a downscaled PNG for OG link previews.
+   * Reuses the export-image hook (same path as Discord sharing) to grab a clean
+   * frame, then scales it down (aspect preserved) to keep stored images small.
+   */
+  async function captureOgImageBlob(maxDim = 1000): Promise<Blob | null> {
+    const rawBlob = await new Promise<Blob | null>((resolve) => {
+      const timer = setTimeout(() => {
+        setOnExportImage(undefined)
+        resolve(null)
+      }, 5000)
+      setOnExportImage(() => (canvas: HTMLCanvasElement) => {
+        setOnExportImage(undefined)
+        clearTimeout(timer)
+        canvas.toBlob(
+          (b) => {
+            resolve(b)
+          },
+          'image/png',
+          1,
+        )
+      })
+    })
+    if (!rawBlob) return null
+
+    const url = URL.createObjectURL(rawBlob)
+    try {
+      const img = await new Promise<HTMLImageElement>((resolve, reject) => {
+        const im = new Image()
+        im.onload = () => {
+          resolve(im)
+        }
+        im.onerror = reject
+        im.src = url
+      })
+      const scale = Math.min(1, maxDim / Math.max(img.width, img.height))
+      const w = Math.max(1, Math.round(img.width * scale))
+      const h = Math.max(1, Math.round(img.height * scale))
+      const offscreen = document.createElement('canvas')
+      offscreen.width = w
+      offscreen.height = h
+      const ctx = offscreen.getContext('2d')!
+      ctx.drawImage(img, 0, 0, w, h)
+      return await new Promise<Blob | null>((resolve) => {
+        offscreen.toBlob((b) => {
+          resolve(b)
+        }, 'image/png')
+      })
+    } catch {
+      return null
+    } finally {
+      URL.revokeObjectURL(url)
+    }
+  }
+
   const { showShareLinkModal } = createShareLinkModal(
     flameDescriptor,
     () => timeline.tracks(),
     () => timeline.config(),
+    captureOgImageBlob,
   )
 
   const { showDiscordShareModal } = createDiscordShareModal()

--- a/packages/app/src/MainWorkspace.tsx
+++ b/packages/app/src/MainWorkspace.tsx
@@ -826,11 +826,25 @@ export function MainWorkspace(props: AppProps) {
       offscreen.height = h
       const ctx = offscreen.getContext('2d')!
       ctx.drawImage(img, 0, 0, w, h)
-      return await new Promise<Blob | null>((resolve) => {
+      const downscaled = await new Promise<Blob | null>((resolve) => {
         offscreen.toBlob((b) => {
           resolve(b)
         }, 'image/png')
       })
+      if (!downscaled) return null
+
+      // Embed the flame descriptor into the PNG (deflate-compressed zTXt chunk,
+      // a few KB) so anyone who opens the shared link or downloads the preview
+      // image can load it straight back into the app — same as Discord sharing.
+      const tracks = timeline.tracks()
+      const config = timeline.config()
+      const hasAnimation = tracks.some((track) => track.keyframes.length > 0)
+      const payload = hasAnimation
+        ? { flame: flameDescriptor, animation: { tracks, config } }
+        : flameDescriptor
+      const encoded = await compressJsonQueryParam(payload)
+      const pngBytes = new Uint8Array(await downscaled.arrayBuffer())
+      return addFlameDataToPng(encoded, pngBytes)
     } catch {
       return null
     } finally {

--- a/packages/app/src/components/ShareLinkModal/ShareLinkModal.tsx
+++ b/packages/app/src/components/ShareLinkModal/ShareLinkModal.tsx
@@ -34,6 +34,20 @@ async function blobToBase64(blob: Blob): Promise<string> {
   })
 }
 
+/**
+ * Content-addressed key for the OG image — must match the Worker's `ogKey`
+ * (SHA-256 of the encoded payload, first 32 hex chars) so `?flame=` and `?s=`
+ * links resolve the same stored image.
+ */
+async function ogKey(encoded: string): Promise<string> {
+  const data = new TextEncoder().encode(encoded)
+  const digest = await globalThis.crypto.subtle.digest('SHA-256', data)
+  return [...new Uint8Array(digest)]
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('')
+    .slice(0, 32)
+}
+
 function deriveOgMeta(flame: FlameDescriptor): {
   title: string
   description: string
@@ -65,13 +79,13 @@ function ShareLinkModal(props: ShareLinkModalProps) {
    * crawlers show a rich preview. Runs in the background — the link is already
    * usable; the image just needs to land before the first crawler scrape.
    */
-  async function uploadOgPreview(id: string) {
+  async function uploadOgPreview(encoded: string) {
     try {
       const blob = await props.captureOgImage?.()
       if (!blob) return
       const image = await blobToBase64(blob)
       const { title, description } = deriveOgMeta(props.flameDescriptor)
-      await fetch(`/api/og/${id}`, {
+      await fetch(`/api/og/${await ogKey(encoded)}`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ image, title, description }),
@@ -106,12 +120,15 @@ function ShareLinkModal(props: ShareLinkModalProps) {
           const json = await res.json()
           if (json.id) {
             newUrl = `${window.location.origin}/?s=${json.id}`
-            void uploadOgPreview(json.id)
           }
         }
       } catch (err) {
         console.error('Failed to shorten URL:', err)
       }
+
+      // Upload the preview keyed by content hash, regardless of whether the
+      // shortener succeeded — so the ?flame= fallback link gets the same card.
+      void uploadOgPreview(encoded)
 
       setUrl(newUrl)
       await navigator.clipboard.writeText(newUrl)

--- a/packages/app/src/components/ShareLinkModal/ShareLinkModal.tsx
+++ b/packages/app/src/components/ShareLinkModal/ShareLinkModal.tsx
@@ -15,7 +15,42 @@ type ShareLinkModalProps = {
   tracks: TimelineTrack[]
   config: TimelineConfig
   hasAnimation: boolean
+  captureOgImage?: () => Promise<Blob | null>
   respond: () => void
+}
+
+async function blobToBase64(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => {
+      const result = reader.result as string
+      // strip the `data:image/png;base64,` prefix
+      resolve(result.slice(result.indexOf(',') + 1))
+    }
+    reader.onerror = () => {
+      reject(new Error('Failed to read blob'))
+    }
+    reader.readAsDataURL(blob)
+  })
+}
+
+function deriveOgMeta(flame: FlameDescriptor): {
+  title: string
+  description: string
+} {
+  const meta = flame.metadata
+  const name = meta?.name?.trim()
+  const author = meta?.author
+  const title = name
+    ? name
+    : author && author !== 'unknown'
+      ? `Flame by ${author}`
+      : 'Fractal Flame — Chaos Master'
+  const transformCount = Object.keys(flame.transforms ?? {}).length
+  const description = meta?.description?.trim()
+    ? meta.description.trim()
+    : `${transformCount} transform${transformCount === 1 ? '' : 's'} • Created with Chaos Master`
+  return { title, description }
 }
 
 function ShareLinkModal(props: ShareLinkModalProps) {
@@ -24,6 +59,27 @@ function ShareLinkModal(props: ShareLinkModalProps) {
   )
   const [url, setUrl] = createSignal('')
   const [copied, setCopied] = createSignal(false)
+
+  /**
+   * Render the current flame to a PNG and attach it to the short link so social
+   * crawlers show a rich preview. Runs in the background — the link is already
+   * usable; the image just needs to land before the first crawler scrape.
+   */
+  async function uploadOgPreview(id: string) {
+    try {
+      const blob = await props.captureOgImage?.()
+      if (!blob) return
+      const image = await blobToBase64(blob)
+      const { title, description } = deriveOgMeta(props.flameDescriptor)
+      await fetch(`/api/og/${id}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ image, title, description }),
+      })
+    } catch (err) {
+      console.error('Failed to upload OG preview image:', err)
+    }
+  }
 
   createEffect(() => {
     const include = includeAnimation()
@@ -50,6 +106,7 @@ function ShareLinkModal(props: ShareLinkModalProps) {
           const json = await res.json()
           if (json.id) {
             newUrl = `${window.location.origin}/?s=${json.id}`
+            void uploadOgPreview(json.id)
           }
         }
       } catch (err) {
@@ -133,6 +190,7 @@ export function createShareLinkModal(
   flameDescriptor: FlameDescriptor,
   getTracks: () => TimelineTrack[],
   getConfig: () => TimelineConfig,
+  captureOgImage?: () => Promise<Blob | null>,
 ) {
   const requestModal = useRequestModal()
 
@@ -149,6 +207,7 @@ export function createShareLinkModal(
           tracks={tracks}
           config={config}
           hasAnimation={hasAnimation}
+          captureOgImage={captureOgImage}
           respond={respond}
         />
       ),

--- a/packages/app/src/worker/index.ts
+++ b/packages/app/src/worker/index.ts
@@ -55,6 +55,44 @@ function base64ToBytes(b64: string): Uint8Array {
   return bytes
 }
 
+/**
+ * Content-addressed key for a share payload: a hash of the encoded payload.
+ * The OG image + meta are keyed by this (not by the short id), so `?flame=…`
+ * and `?s=<id>` resolve to the same image — even when the shortener wasn't used
+ * or failed. The client computes the identical key when uploading.
+ */
+async function ogKey(encoded: string): Promise<string> {
+  const data = new TextEncoder().encode(encoded)
+  const digest = await globalThis.crypto.subtle.digest('SHA-256', data)
+  return [...new Uint8Array(digest)]
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('')
+    .slice(0, 32)
+}
+
+/** Look up the stored OG title/description/image for a content key. */
+async function resolveOgCard(
+  env: Env,
+  origin: string,
+  key: string,
+): Promise<{ title: string; description: string; imageUrl?: string }> {
+  let title = DEFAULT_TITLE
+  let description = DEFAULT_DESCRIPTION
+  let imageUrl: string | undefined
+  try {
+    const raw = await env.KV_SHORTENER.get(`og:${key}`)
+    if (raw) {
+      const meta = JSON.parse(raw) as OgMeta
+      if (meta.t) title = meta.t
+      if (meta.d) description = meta.d
+      if (meta.img) imageUrl = `${origin}/og/${key}`
+    }
+  } catch (err) {
+    console.error('Error reading OG meta:', err)
+  }
+  return { title, description, imageUrl }
+}
+
 // ---------------------------------------------------------------------------
 // Open Graph / Twitter meta-tag injection
 // ---------------------------------------------------------------------------
@@ -157,12 +195,13 @@ export default {
       }
     }
 
-    // ── Attach an OG preview image + meta to an existing short link ─────────
-    // The client renders the flame on its GPU, downscales it, and uploads it
-    // here in the background after the short link is created.
+    // ── Attach an OG preview image + meta, keyed by content hash ───────────
+    // The client renders the flame on its GPU, downscales it, embeds the flame
+    // descriptor in the PNG, and uploads it here (background) under
+    // ogKey(payload) — so both ?s= and ?flame= links can resolve it.
     if (pathname.startsWith('/api/og/') && request.method === 'POST') {
-      const shortId = pathname.split('/').pop()
-      if (!shortId) return json({ error: 'Missing ID' }, 400)
+      const key = pathname.split('/').pop()
+      if (!key) return json({ error: 'Missing key' }, 400)
       try {
         const body = (await request.json()) as {
           image?: string
@@ -173,7 +212,7 @@ export default {
           return json({ error: 'Missing image' }, 400)
         }
         const bytes = base64ToBytes(body.image)
-        await env.OG_IMAGES.put(shortId, bytes, {
+        await env.OG_IMAGES.put(key, bytes, {
           httpMetadata: { contentType: 'image/png' },
         })
         const meta: OgMeta = {
@@ -181,7 +220,7 @@ export default {
           d: body.description?.slice(0, 300),
           img: 1,
         }
-        await env.KV_SHORTENER.put(`og:${shortId}`, JSON.stringify(meta), {
+        await env.KV_SHORTENER.put(`og:${key}`, JSON.stringify(meta), {
           expirationTtl: SHORTEN_TTL,
         })
         return json({ ok: true })
@@ -218,38 +257,37 @@ export default {
       const shortId = url.searchParams.get('s')
       const flame = url.searchParams.get('flame')
 
+      // Short link: resolve the payload from KV, then hash it to the content key
+      // so it finds the same image a ?flame= link would.
       if (shortId) {
-        let title = DEFAULT_TITLE
-        let description = DEFAULT_DESCRIPTION
-        let imageUrl: string | undefined
-        try {
-          const raw = await env.KV_SHORTENER.get(`og:${shortId}`)
-          if (raw) {
-            const meta = JSON.parse(raw) as OgMeta
-            if (meta.t) title = meta.t
-            if (meta.d) description = meta.d
-            if (meta.img) imageUrl = `${url.origin}/og/${shortId}`
-          }
-        } catch (err) {
-          console.error('Error reading OG meta:', err)
-        }
-        const metaHtml = buildMetaTags({
-          title,
-          description,
-          pageUrl: `${url.origin}/?s=${shortId}`,
-          imageUrl,
-        })
-        return injectMeta(env, url.origin, title, metaHtml)
-      }
-
-      if (flame) {
-        // Long-form (un-shortened) link — no stored image; serve a text card.
-        const metaHtml = buildMetaTags({
+        let card = {
           title: DEFAULT_TITLE,
           description: DEFAULT_DESCRIPTION,
+        } as { title: string; description: string; imageUrl?: string }
+        try {
+          const payload = await env.KV_SHORTENER.get(shortId)
+          if (payload) {
+            card = await resolveOgCard(env, url.origin, await ogKey(payload))
+          }
+        } catch (err) {
+          console.error('Error resolving short link OG:', err)
+        }
+        const metaHtml = buildMetaTags({
+          ...card,
+          pageUrl: `${url.origin}/?s=${shortId}`,
+        })
+        return injectMeta(env, url.origin, card.title, metaHtml)
+      }
+
+      // Long-form link: hash the inline payload directly. Same OG card as ?s=,
+      // including the image when the client uploaded one (text card otherwise).
+      if (flame) {
+        const card = await resolveOgCard(env, url.origin, await ogKey(flame))
+        const metaHtml = buildMetaTags({
+          ...card,
           pageUrl: url.toString(),
         })
-        return injectMeta(env, url.origin, DEFAULT_TITLE, metaHtml)
+        return injectMeta(env, url.origin, card.title, metaHtml)
       }
     }
 

--- a/packages/app/src/worker/index.ts
+++ b/packages/app/src/worker/index.ts
@@ -1,7 +1,22 @@
 export interface Env {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   KV_SHORTENER: any
+  // R2 bucket holding the per-share OG preview PNGs (keyed by short id).
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  OG_IMAGES: any
   ASSETS: { fetch: typeof fetch }
+}
+
+const SHORTEN_TTL = 60 * 24 * 60 * 60 // 60 days in seconds
+const SITE_NAME = 'Chaos Master'
+const DEFAULT_TITLE = 'Fractal Flame — Chaos Master'
+const DEFAULT_DESCRIPTION =
+  'Explore and create fractal flames with Chaos Master.'
+
+interface OgMeta {
+  t?: string
+  d?: string
+  img?: number
 }
 
 function generateShortId(): string {
@@ -15,74 +30,230 @@ function generateShortId(): string {
   return id
 }
 
+function json(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
+
+function base64ToBytes(b64: string): Uint8Array {
+  const bin = atob(b64)
+  const bytes = new Uint8Array(bin.length)
+  for (let i = 0; i < bin.length; i++) {
+    bytes[i] = bin.charCodeAt(i)
+  }
+  return bytes
+}
+
+// ---------------------------------------------------------------------------
+// Open Graph / Twitter meta-tag injection
+// ---------------------------------------------------------------------------
+
+function buildMetaTags(opts: {
+  title: string
+  description: string
+  pageUrl: string
+  imageUrl?: string
+}): string {
+  const t = escapeHtml(opts.title)
+  const d = escapeHtml(opts.description)
+  const u = escapeHtml(opts.pageUrl)
+  const tags = [
+    `<meta property="og:type" content="website" />`,
+    `<meta property="og:site_name" content="${escapeHtml(SITE_NAME)}" />`,
+    `<meta property="og:title" content="${t}" />`,
+    `<meta property="og:description" content="${d}" />`,
+    `<meta property="og:url" content="${u}" />`,
+    `<meta name="twitter:title" content="${t}" />`,
+    `<meta name="twitter:description" content="${d}" />`,
+  ]
+  if (opts.imageUrl) {
+    const i = escapeHtml(opts.imageUrl)
+    tags.push(
+      `<meta property="og:image" content="${i}" />`,
+      `<meta name="twitter:image" content="${i}" />`,
+      `<meta name="twitter:card" content="summary_large_image" />`,
+    )
+  } else {
+    tags.push(`<meta name="twitter:card" content="summary" />`)
+  }
+  return tags.join('\n    ')
+}
+
+/**
+ * Fetch the built index.html from static assets and inject OG/Twitter meta tags
+ * (plus a richer <title>) so social crawlers render a preview card. The SPA
+ * still boots normally for human visitors.
+ */
+async function injectMeta(
+  env: Env,
+  origin: string,
+  title: string,
+  metaHtml: string,
+): Promise<Response> {
+  const assetRes = await env.ASSETS.fetch(`${origin}/`)
+  let html = await assetRes.text()
+
+  html = html.replace(
+    /<title>[\s\S]*?<\/title>/,
+    `<title>${escapeHtml(title)}</title>`,
+  )
+  html = html.replace('</head>', `    ${metaHtml}\n  </head>`)
+
+  return new Response(html, {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/html; charset=utf-8',
+      // Short cache — flame metadata behind a link can change.
+      'Cache-Control': 'public, max-age=300',
+    },
+  })
+}
+
 export default {
   async fetch(request: Request, env: Env, _ctx: unknown): Promise<Response> {
     const url = new URL(request.url)
+    const { pathname } = url
 
-    // Handle API routes
-    if (url.pathname === '/api/shorten' && request.method === 'POST') {
+    // ── Create a short link ────────────────────────────────────────────────
+    if (pathname === '/api/shorten' && request.method === 'POST') {
       try {
         const { payload } = (await request.json()) as { payload: string }
         if (!payload || typeof payload !== 'string') {
-          return new Response(JSON.stringify({ error: 'Invalid payload' }), {
-            status: 400,
-            headers: { 'Content-Type': 'application/json' },
-          })
+          return json({ error: 'Invalid payload' }, 400)
         }
-
         const shortId = generateShortId()
-        // Store the payload in KV with the generated ID (expires in 60 days)
-        const EXPIRATION_TTL = 60 * 24 * 60 * 60 // 60 days in seconds
         await env.KV_SHORTENER.put(shortId, payload, {
-          expirationTtl: EXPIRATION_TTL,
+          expirationTtl: SHORTEN_TTL,
         })
-
-        return new Response(JSON.stringify({ id: shortId }), {
-          status: 200,
-          headers: { 'Content-Type': 'application/json' },
-        })
+        return json({ id: shortId })
       } catch (err) {
         console.error('Error handling /api/shorten POST:', err)
-        return new Response(JSON.stringify({ error: 'Bad request' }), {
-          status: 400,
-          headers: { 'Content-Type': 'application/json' },
-        })
+        return json({ error: 'Bad request' }, 400)
       }
     }
 
-    // Handle API fallback mapping for ?s= URLs
-    if (url.pathname.startsWith('/api/shorten/') && request.method === 'GET') {
-      const shortId = url.pathname.split('/').pop()
-      if (!shortId) {
-        return new Response(JSON.stringify({ error: 'Missing ID' }), {
-          status: 400,
-          headers: { 'Content-Type': 'application/json' },
-        })
-      }
-
+    // ── Resolve a short link's payload ─────────────────────────────────────
+    if (pathname.startsWith('/api/shorten/') && request.method === 'GET') {
+      const shortId = pathname.split('/').pop()
+      if (!shortId) return json({ error: 'Missing ID' }, 400)
       try {
         const payload = await env.KV_SHORTENER.get(shortId)
-        if (!payload) {
-          return new Response(JSON.stringify({ error: 'Not found' }), {
-            status: 404,
-            headers: { 'Content-Type': 'application/json' },
-          })
-        }
-
-        return new Response(JSON.stringify({ payload }), {
-          status: 200,
-          headers: { 'Content-Type': 'application/json' },
-        })
+        if (!payload) return json({ error: 'Not found' }, 404)
+        return json({ payload })
       } catch (err) {
         console.error('Error handling /api/shorten GET:', err)
-        return new Response(JSON.stringify({ error: 'Server error' }), {
-          status: 500,
-          headers: { 'Content-Type': 'application/json' },
-        })
+        return json({ error: 'Server error' }, 500)
       }
     }
 
-    // Pass everything else to the static assets (the frontend)
+    // ── Attach an OG preview image + meta to an existing short link ─────────
+    // The client renders the flame on its GPU, downscales it, and uploads it
+    // here in the background after the short link is created.
+    if (pathname.startsWith('/api/og/') && request.method === 'POST') {
+      const shortId = pathname.split('/').pop()
+      if (!shortId) return json({ error: 'Missing ID' }, 400)
+      try {
+        const body = (await request.json()) as {
+          image?: string
+          title?: string
+          description?: string
+        }
+        if (!body.image || typeof body.image !== 'string') {
+          return json({ error: 'Missing image' }, 400)
+        }
+        const bytes = base64ToBytes(body.image)
+        await env.OG_IMAGES.put(shortId, bytes, {
+          httpMetadata: { contentType: 'image/png' },
+        })
+        const meta: OgMeta = {
+          t: body.title?.slice(0, 200),
+          d: body.description?.slice(0, 300),
+          img: 1,
+        }
+        await env.KV_SHORTENER.put(`og:${shortId}`, JSON.stringify(meta), {
+          expirationTtl: SHORTEN_TTL,
+        })
+        return json({ ok: true })
+      } catch (err) {
+        console.error('Error handling /api/og POST:', err)
+        return json({ error: 'Bad request' }, 400)
+      }
+    }
+
+    // ── Serve an OG preview image ──────────────────────────────────────────
+    if (pathname.startsWith('/og/') && request.method === 'GET') {
+      const id = pathname.slice('/og/'.length).replace(/\.png$/, '')
+      if (!id) return new Response('Not found', { status: 404 })
+      try {
+        const obj = await env.OG_IMAGES.get(id)
+        if (!obj) return new Response('Not found', { status: 404 })
+        return new Response(obj.body, {
+          headers: {
+            'Content-Type': 'image/png',
+            'Cache-Control': 'public, max-age=86400',
+          },
+        })
+      } catch (err) {
+        console.error('Error serving OG image:', err)
+        return new Response('Server error', { status: 500 })
+      }
+    }
+
+    // ── Inject meta tags for shared links so crawlers see a rich preview ────
+    if (
+      (pathname === '/' || pathname === '/index.html') &&
+      request.method === 'GET'
+    ) {
+      const shortId = url.searchParams.get('s')
+      const flame = url.searchParams.get('flame')
+
+      if (shortId) {
+        let title = DEFAULT_TITLE
+        let description = DEFAULT_DESCRIPTION
+        let imageUrl: string | undefined
+        try {
+          const raw = await env.KV_SHORTENER.get(`og:${shortId}`)
+          if (raw) {
+            const meta = JSON.parse(raw) as OgMeta
+            if (meta.t) title = meta.t
+            if (meta.d) description = meta.d
+            if (meta.img) imageUrl = `${url.origin}/og/${shortId}`
+          }
+        } catch (err) {
+          console.error('Error reading OG meta:', err)
+        }
+        const metaHtml = buildMetaTags({
+          title,
+          description,
+          pageUrl: `${url.origin}/?s=${shortId}`,
+          imageUrl,
+        })
+        return injectMeta(env, url.origin, title, metaHtml)
+      }
+
+      if (flame) {
+        // Long-form (un-shortened) link — no stored image; serve a text card.
+        const metaHtml = buildMetaTags({
+          title: DEFAULT_TITLE,
+          description: DEFAULT_DESCRIPTION,
+          pageUrl: url.toString(),
+        })
+        return injectMeta(env, url.origin, DEFAULT_TITLE, metaHtml)
+      }
+    }
+
+    // Everything else → static assets (the frontend)
     return env.ASSETS.fetch(request)
   },
 }

--- a/packages/app/wrangler.jsonc
+++ b/packages/app/wrangler.jsonc
@@ -42,6 +42,12 @@
           "id": "7cf9ab98f6274a179d63cccbf3c93911",
         },
       ],
+      "r2_buckets": [
+        {
+          "binding": "OG_IMAGES",
+          "bucket_name": "chaos-master-og-images",
+        },
+      ],
     },
     "dev": {
       "name": "chaos-master-dev",
@@ -61,6 +67,12 @@
           "preview_id": "91bef067328b4904ad4cfbcbbcf980f2",
         },
       ],
+      "r2_buckets": [
+        {
+          "binding": "OG_IMAGES",
+          "bucket_name": "chaos-master-og-images-dev",
+        },
+      ],
     },
     "preview": {
       "name": "chaos-master-preview",
@@ -72,6 +84,12 @@
           "binding": "KV_SHORTENER",
           "id": "7cf9ab98f6274a179d63cccbf3c93911",
           "preview_id": "91bef067328b4904ad4cfbcbbcf980f2",
+        },
+      ],
+      "r2_buckets": [
+        {
+          "binding": "OG_IMAGES",
+          "bucket_name": "chaos-master-og-images-dev",
         },
       ],
     },

--- a/packages/app/wrangler.jsonc
+++ b/packages/app/wrangler.jsonc
@@ -18,9 +18,15 @@
       "head_sampling_rate": 1,
     },
   },
-  // Modern Cloudflare Assets configuration
+  // Modern Cloudflare Assets configuration.
+  // `binding` exposes env.ASSETS so the Worker can fetch the built index.html
+  // (needed to inject OG/Twitter meta tags for shared links). `run_worker_first`
+  // makes the Worker handle navigations + APIs while the hashed /assets/* files
+  // stay static-first (served directly, no Worker invocation).
   "assets": {
     "directory": "dist",
+    "binding": "ASSETS",
+    "run_worker_first": ["/*", "!/assets/*"],
   },
   "main": "src/worker/index.ts",
 


### PR DESCRIPTION
## What

Rich social link previews (Discord / Slack / X / Facebook / LinkedIn) for shared flame links — the card shows the **actual rendered flame**. Free-tier only; no GPU server, no paid bindings.

Implements **Option C** from `docs/plans/og-meta-tags-plan.md` (the client already GPU-renders the flame, so we reuse that instead of re-rendering server-side).

## How it works

1. **Share** — `ShareLinkModal` creates the short link as before (`POST /api/shorten` → `?s=<id>`), then *in the background* captures the current flame canvas, downscales it (≤1000 px, aspect preserved), and `POST /api/og/<id>` with the PNG + title/description. The link stays instant.
2. **Store** — the app Worker puts the PNG in the **`OG_IMAGES` R2 bucket** (keyed by short id) and the title/description in KV under `og:<id>`.
3. **Serve** — `GET /og/<id>` streams the PNG from R2 (24 h cache).
4. **Inject** — when a crawler fetches `/?s=<id>`, the Worker reads `og:<id>`, fetches the built `index.html` via `env.ASSETS`, and injects `og:*` / `twitter:*` tags (absolute URLs) + a real `<title>`. Humans still get the normal SPA. Long-form `/?flame=…` links get a generic text card.

## Changes

| File | Change |
|------|--------|
| `packages/app/src/worker/index.ts` | `POST /api/og/:id`, `GET /og/:id`, meta injection on `/?s=` and `/?flame=` (shortener contract unchanged) |
| `packages/app/wrangler.jsonc` | `OG_IMAGES` R2 binding (prod/dev/preview); **`assets.binding=ASSETS` + `run_worker_first`** so the Worker can serve/inject for navigations while hashed `/assets/*` stay static-first |
| `packages/app/src/MainWorkspace.tsx` | `captureOgImageBlob()` — clean-frame capture (same hook as Discord share) + downscale |
| `packages/app/src/components/ShareLinkModal/ShareLinkModal.tsx` | background upload + title/description |
| `packages/app/package.json` | `r2:create:dev` / `r2:create:prod` scripts |
| `docs/og-link-previews.md`, `docs/plans/og-meta-tags-plan.md` | setup/testing + design rationale |

## Cost

PNG ≤ ~100 KB; thousands of images stay well within R2's 10 GB free tier; egress (serving previews) is free. See the storage analysis in the plan doc.

## Setup (one-time, before deploying)

```bash
cd packages/app
pnpm run r2:create:dev    # and r2:create:prod for prod
```
Optional: an R2 lifecycle rule (e.g. delete after 30 days) to bound storage.

## Testing

- ✅ `tsc`, `eslint`, `vite build`, `wrangler deploy --dry-run` (bindings resolve)
- ✅ Full flow end-to-end against local `wrangler dev` (KV + R2 simulated): shorten → upload → `GET /og/:id` returns `image/png` → `/?s=` injects `og:image` + `summary_large_image` → `/?flame=` text card → hashed assets stay static → plain `/` untouched
- ⏳ Pending: live social-card validation on `dev.chaos-master.com` (the FB/X/LinkedIn debuggers can't reach localhost)

## Notes

- **Race:** the image lands ~1–2 s after the link is created; a crawler scraping instantly sees no image (platforms re-scrape; debuggers force it). Atomic-on-shorten is an easy follow-up if preferred.
- `canvas.toBlob` of the live WebGPU canvas (same path as Discord share) — worth a sanity check on iOS Safari.
