### PR TITLE
chore: changelog + 0.9.3 version bump for OG previews; cap upload size

### DIFF
--- a/packages/app/CHANGELOG.md
+++ b/packages/app/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.3] - 2026-06-13
+
+### Added
+
+- **Rich link-sharing previews (Open Graph)**: shared flame links now produce a social preview card on Discord, Slack, X, Facebook and LinkedIn that shows the actual rendered flame. When you create a share link the app renders the flame, downscales it, embeds the flame descriptor into the PNG, and stores it on Cloudflare R2 (content-addressed by the payload hash); the Worker serves the image and injects `og:` / `twitter:` meta tags for both `?s=` short links and `?flame=` long links. Downloading the preview image lets you load the flame straight back into the app. Runs entirely on the Cloudflare free tier.
+
 ## [0.9.2] - 2026-06-13
 
 ### Added

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chaos-master",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "WebGPU based IFS Flame Generator for Artists & Explorers",
   "type": "module",
   "scripts": {

--- a/packages/app/src/MainWorkspace.tsx
+++ b/packages/app/src/MainWorkspace.tsx
@@ -65,7 +65,7 @@ import { Flam3 } from './flame/Flam3'
 import { pointInitModeToImplFn } from './flame/pointInitMode'
 import { pointInitMode3DToImplFn } from './flame/pointInitMode3D'
 import { generateRandomFlame, mutateFlame, random01, randomizeAllColors, randomizeVariationParams, randomRange, } from './flame/randomize'
-import { accumulatedPointCount, animationExportCancel, animationExportProgress, animationExportRunning, cameraDuringExportEnabled, exportProgress, exportQuality, qualityPointCountLimit, setCurrentQuality, setForceAnimationExportNow, setForceExportNow, setQualityPointCountLimit, } from './flame/renderStats'
+import { accumulatedPointCount, animationExportCancel, animationExportProgress, animationExportRunning, cameraDuringExportEnabled, exportProgress, exportQuality, qualityPointCountLimit, setCurrentQuality, setExportQuality, setForceAnimationExportNow, setForceExportNow, setQualityPointCountLimit, } from './flame/renderStats'
 import { MAX_CAMERA_ZOOM_VALUE, MIN_CAMERA_ZOOM_VALUE, } from './flame/schema/flameSchema'
 import { generateTransformId, generateVariationId, } from './flame/transformFunction'
 import { defaultLinearType } from './flame/variationRegistry'
@@ -795,27 +795,46 @@ export function MainWorkspace(props: AppProps) {
   const timeline = createTimelineState()
 
   /**
-   * Capture the current flame canvas as a downscaled PNG for OG link previews.
-   * Reuses the export-image hook (same path as Discord sharing) to grab a clean
-   * frame, then scales it down (aspect preserved) to keep stored images small.
+   * Capture the current flame as a downscaled PNG for OG link previews.
+   *
+   * Drives the same async export loop as the PNG export — via `setExportQuality`
+   * at the *current* quality, so the on-screen canvas is unchanged. Unlike the
+   * rAF loop, that loop renders even a fully settled flame and keeps running in
+   * background tabs, so the capture reliably produces a frame (the earlier
+   * hook-only path could time out and silently drop the preview). Captures the
+   * clean, quality-graded image, then scales it down (aspect preserved).
    */
   async function captureOgImageBlob(maxDim = 1000): Promise<Blob | null> {
     const rawBlob = await new Promise<Blob | null>((resolve) => {
+      let settled = false
+      const finish = (b: Blob | null) => {
+        if (settled) return
+        settled = true
+        setOnExportImage(undefined)
+        setExportQuality(undefined)
+        resolve(b)
+      }
+      // Best-effort with a generous safety net — never hang the share flow.
       const timer = setTimeout(() => {
-        setOnExportImage(undefined)
-        resolve(null)
-      }, 5000)
-      setOnExportImage(() => (canvas: HTMLCanvasElement) => {
-        setOnExportImage(undefined)
-        clearTimeout(timer)
-        canvas.toBlob(
-          (b) => {
-            resolve(b)
+        finish(null)
+      }, 20000)
+      setOnExportImage(
+        () =>
+          (canvas: HTMLCanvasElement, info?: { finalImageReady: boolean }) => {
+            // Wait for the export driver's clean, quality-graded frame.
+            if (info?.finalImageReady !== true) return
+            clearTimeout(timer)
+            canvas.toBlob(
+              (b) => {
+                finish(b)
+              },
+              'image/png',
+              1,
+            )
           },
-          'image/png',
-          1,
-        )
-      })
+      )
+      // Same render path as PNG export; current quality keeps the canvas as-is.
+      setExportQuality(qualityPresets[qualityPreset()])
     })
     if (!rawBlob) return null
 

--- a/packages/app/src/utils/jsonQueryParam.ts
+++ b/packages/app/src/utils/jsonQueryParam.ts
@@ -7,6 +7,15 @@ import type { TimelineConfig, TimelineTrack } from '@/utils/timeline'
 
 const format: CompressionFormat = 'deflate'
 
+// Verbose share encode/decode/decompress tracing — dev builds only. Vite
+// statically replaces `import.meta.env.DEV` with `false` in production and
+// strips this to a no-op, so none of these log in prod builds.
+const shareLog: (...args: unknown[]) => void = import.meta.env.DEV
+  ? (...args) => {
+      console.info(...args)
+    }
+  : () => {}
+
 export function concatBuffers(buffers: Uint8Array[]): Uint8Array<ArrayBuffer> {
   const totalLength = sum(buffers.map((b) => b.length))
   const result = new Uint8Array(totalLength)
@@ -135,7 +144,7 @@ export async function encodeSharePayload(
         flame.transforms as Record<string, { color?: { x: number; y: number } }>
       )[transformKeys[0]]?.color
     : undefined
-  console.info('[share:encode] encoding payload', {
+  shareLog('[share:encode] encoding payload', {
     transformCount: transformKeys.length,
     firstTransformColor: firstColor,
     renderSettings: flame.renderSettings
@@ -153,9 +162,9 @@ export async function encodeSharePayload(
 export async function decodeSharePayload(
   param: string,
 ): Promise<{ flame: FlameDescriptor; animation?: SharePayload['animation'] }> {
-  console.info('[share:decode] starting decode, param length:', param.length)
+  shareLog('[share:decode] starting decode, param length:', param.length)
   const rawBytes = decodeBase64(param)
-  console.info(
+  shareLog(
     '[share:decode] base64 decoded, byte length:',
     rawBytes.length,
     'first 4 hex:',
@@ -165,7 +174,7 @@ export async function decodeSharePayload(
   )
   const decompressedBytes = await decompressJsonQueryRaw(rawBytes)
   const rawText = new TextDecoder().decode(decompressedBytes)
-  console.info(
+  shareLog(
     '[share:decode] decompressed text length:',
     rawText.length,
     'first 100 chars:',
@@ -175,7 +184,7 @@ export async function decodeSharePayload(
   // Log raw structure before validation
   const hasTransforms = 'transforms' in raw
   const hasFlame = raw && typeof raw === 'object' && 'flame' in raw
-  console.info('[share:decode] raw structure:', {
+  shareLog('[share:decode] raw structure:', {
     hasTransforms,
     hasFlame,
     hasAnimation: hasFlame && 'animation' in raw,
@@ -198,7 +207,7 @@ export async function decodeSharePayload(
   // Backward compat: old format is bare FlameDescriptor (has `transforms`)
   if (hasTransforms) {
     const validated = validateFlame(raw)
-    console.info(
+    shareLog(
       '[share:decode] old format, validated flame transforms:',
       recordKeys(validated.transforms).length,
     )
@@ -208,7 +217,7 @@ export async function decodeSharePayload(
   if (hasFlame) {
     const validated = validateFlame(raw.flame)
     const firstColor = Object.values(validated.transforms ?? {})[0]?.color
-    console.info('[share:decode] new format, validated:', {
+    shareLog('[share:decode] new format, validated:', {
       transformCount: recordKeys(validated.transforms).length,
       firstTransformColor: firstColor,
       hasAnimation: !!raw.animation,
@@ -227,12 +236,12 @@ export async function decodeSharePayload(
 async function decompressJsonQueryRaw(
   compressedBytes: Uint8Array<ArrayBuffer>,
 ): Promise<Uint8Array> {
-  console.info(
+  shareLog(
     '[share:decompress] starting, byte length:',
     compressedBytes.length,
   )
   const decompress = new DecompressionStream(format)
-  console.info(
+  shareLog(
     '[share:decompress] DecompressionStream created, format:',
     format,
   )
@@ -241,7 +250,7 @@ async function decompressJsonQueryRaw(
   const pipePromise = decompress.readable.pipeTo(
     new WritableStream<Uint8Array>({
       write(chunk) {
-        console.info('[share:decompress] got chunk, size:', chunk.length)
+        shareLog('[share:decompress] got chunk, size:', chunk.length)
         chunks.push(chunk)
       },
     }),
@@ -249,9 +258,9 @@ async function decompressJsonQueryRaw(
 
   const writer = decompress.writable.getWriter()
   await writer.write(compressedBytes)
-  console.info('[share:decompress] wrote', compressedBytes.length, 'bytes')
+  shareLog('[share:decompress] wrote', compressedBytes.length, 'bytes')
   await writer.close()
-  console.info('[share:decompress] writer closed')
+  shareLog('[share:decompress] writer closed')
 
   await Promise.race([
     pipePromise,
@@ -261,7 +270,7 @@ async function decompressJsonQueryRaw(
       }, 5000),
     ),
   ])
-  console.info(
+  shareLog(
     '[share:decompress] decompression success, chunks:',
     chunks.length,
     'total bytes:',

--- a/packages/app/src/worker/index.ts
+++ b/packages/app/src/worker/index.ts
@@ -4,6 +4,8 @@ export interface Env {
   // R2 bucket holding the per-share OG preview PNGs (keyed by short id).
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   OG_IMAGES: any
+  // Per-IP rate limiter for the share/OG write endpoints.
+  API_RL: { limit: (options: { key: string }) => Promise<{ success: boolean }> }
   ASSETS: { fetch: typeof fetch }
 }
 
@@ -165,6 +167,21 @@ export default {
   async fetch(request: Request, env: Env, _ctx: unknown): Promise<Response> {
     const url = new URL(request.url)
     const { pathname } = url
+
+    // ── Rate-limit the write endpoints per IP ──────────────────────────────
+    // Bounds spam/abuse (and R2/KV cost). Fail-open: a limiter hiccup or a
+    // missing binding never breaks sharing.
+    if (request.method === 'POST' && pathname.startsWith('/api/')) {
+      try {
+        const ip = request.headers.get('cf-connecting-ip') ?? 'anon'
+        const { success } = await env.API_RL.limit({ key: ip })
+        if (!success) {
+          return json({ error: 'Too many requests, please slow down' }, 429)
+        }
+      } catch (err) {
+        console.error('Rate limit check failed (allowing):', err)
+      }
+    }
 
     // ── Create a short link ────────────────────────────────────────────────
     if (pathname === '/api/shorten' && request.method === 'POST') {

--- a/packages/app/src/worker/index.ts
+++ b/packages/app/src/worker/index.ts
@@ -8,6 +8,9 @@ export interface Env {
 }
 
 const SHORTEN_TTL = 60 * 24 * 60 * 60 // 60 days in seconds
+// Upper bound on an OG upload (JSON body). Legit previews are ~1–1.5 MB; this
+// caps abuse so R2 storage — and cost — stays bounded.
+const MAX_OG_UPLOAD = 4 * 1024 * 1024 // ~4 MB
 const SITE_NAME = 'Chaos Master'
 const DEFAULT_TITLE = 'Fractal Flame — Chaos Master'
 const DEFAULT_DESCRIPTION =
@@ -202,6 +205,9 @@ export default {
     if (pathname.startsWith('/api/og/') && request.method === 'POST') {
       const key = pathname.split('/').pop()
       if (!key) return json({ error: 'Missing key' }, 400)
+      if (Number(request.headers.get('content-length') ?? 0) > MAX_OG_UPLOAD) {
+        return json({ error: 'Image too large' }, 413)
+      }
       try {
         const body = (await request.json()) as {
           image?: string
@@ -210,6 +216,9 @@ export default {
         }
         if (!body.image || typeof body.image !== 'string') {
           return json({ error: 'Missing image' }, 400)
+        }
+        if (body.image.length > MAX_OG_UPLOAD) {
+          return json({ error: 'Image too large' }, 413)
         }
         const bytes = base64ToBytes(body.image)
         await env.OG_IMAGES.put(key, bytes, {

--- a/packages/app/wrangler.jsonc
+++ b/packages/app/wrangler.jsonc
@@ -54,6 +54,14 @@
           "bucket_name": "chaos-master-og-images",
         },
       ],
+      // Per-IP cap on share/OG write endpoints to bound abuse + cost.
+      "ratelimits": [
+        {
+          "name": "API_RL",
+          "namespace_id": "1001",
+          "simple": { "limit": 30, "period": 60 },
+        },
+      ],
     },
     "dev": {
       "name": "chaos-master-dev",
@@ -79,6 +87,13 @@
           "bucket_name": "chaos-master-og-images-dev",
         },
       ],
+      "ratelimits": [
+        {
+          "name": "API_RL",
+          "namespace_id": "1002",
+          "simple": { "limit": 30, "period": 60 },
+        },
+      ],
     },
     "preview": {
       "name": "chaos-master-preview",
@@ -96,6 +111,13 @@
         {
           "binding": "OG_IMAGES",
           "bucket_name": "chaos-master-og-images-dev",
+        },
+      ],
+      "ratelimits": [
+        {
+          "name": "API_RL",
+          "namespace_id": "1003",
+          "simple": { "limit": 30, "period": 60 },
         },
       ],
     },


### PR DESCRIPTION
## What

Follow-up to #101 — that PR merged the OG link-sharing feature but missed the
changelog entry and version bump.

- Bump `packages/app` **0.9.2 → 0.9.3** (0.9.2 was the benchmark release, #100).
- Add the **`[0.9.3]`** CHANGELOG entry for the OG link-sharing previews feature.
- **Cost guard:** cap the `/api/og` upload at ~4 MB (legit previews are ~1–1.5 MB)
  with an early `Content-Length` check + a post-parse length check (`413` otherwise),
  so R2 storage/cost stays bounded against oversized/abusive uploads.

## Testing

`tsc` + `eslint` clean.
