### PR TITLE
v0.9.9: typecheck CI↔local parity + strict noImplicitAny; UI/export/animation fixes; Smart Animate

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Pre-push gate — runs the same static checks as CI so a push can't fail
+# Pre-push gate - runs the same static checks as CI so a push can't fail
 # typecheck / lint / formatting only after it reaches GitHub (issue #30: keep
 # local and CI in lockstep). Tests and build stay in CI to keep pushes fast.
 #
@@ -7,13 +7,13 @@
 # (git config core.hooksPath .githooks). Bypass in a pinch with: git push --no-verify
 set -e
 
-echo "▶ pre-push: typecheck"
+echo "pre-push: typecheck"
 pnpm typecheck
 
-echo "▶ pre-push: lint"
+echo "pre-push: lint"
 pnpm lint
 
-echo "▶ pre-push: format check"
+echo "pre-push: format check"
 pnpm fmt
 
-echo "✓ pre-push checks passed"
+echo "pre-push: all checks passed"

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,19 @@
+#!/bin/sh
+# Pre-push gate — runs the same static checks as CI so a push can't fail
+# typecheck / lint / formatting only after it reaches GitHub (issue #30: keep
+# local and CI in lockstep). Tests and build stay in CI to keep pushes fast.
+#
+# Installed automatically via the root package.json "prepare" script
+# (git config core.hooksPath .githooks). Bypass in a pinch with: git push --no-verify
+set -e
+
+echo "▶ pre-push: typecheck"
+pnpm typecheck
+
+echo "▶ pre-push: lint"
+pnpm lint
+
+echo "▶ pre-push: format check"
+pnpm fmt
+
+echo "✓ pre-push checks passed"

--- a/docs/plans/typecheck-ci-parity-plan.md
+++ b/docs/plans/typecheck-ci-parity-plan.md
@@ -46,9 +46,9 @@ is marginal — `dist/` is what reliably tips it.)
 `assets/local/valibot-any-mwe/` (gitignored): `node …/run.mjs` prints
 
 ```
-A) real config (dist/ in program)  : any ❌
-B) real config (dist/ removed)     : resolved ✅
-C) real opts + exclude dist/e2e    : resolved ✅
+A) real config (dist/ in program)  : any
+B) real config (dist/ removed)     : resolved
+C) real opts + exclude dist/e2e    : resolved
 ```
 
 `probe-a/b/c.ts` hold the `IsAny` assertions; the runner only greps tsc output

--- a/docs/plans/typecheck-ci-parity-plan.md
+++ b/docs/plans/typecheck-ci-parity-plan.md
@@ -99,33 +99,39 @@ needed.
   `simple3D/types.ts`, `parametric3D/types.ts`). Routing them through `@/valibot`
   removes the duplicate module identity, restores instantiation caching, and adds
   threshold headroom. Low risk.
-- **F2 — Strictness, incrementally.** Baseline (`noImplicitAny:true`): **90
-  errors** (was ~2354 with valibot poisoned), 88 TS7053 (implicit-any dynamic
-  index) + 1 TS2352 + 1 TS2322.
-  - **Done:** `sortedTransformEntries` made generic over its key type so the
-    branded `TransformId` flows through instead of widening to `string`. One
-    clean change cleared **29** errors (all 23 in `MainWorkspace.tsx` + 3 in
-    `AffineListEditor` + 3 in `ColorListEditor`), no casts, no behaviour change.
-    Count now **61**.
-  - **Remaining 61:** `flame/variations/utils.ts` (54 — the variation-registry
-    dynamic indexing of `allTransformVariations[…]`; likely needs typed key
-    unions and may keep a couple of the file's existing load-bearing factory
-    casts), `VariationSelector.tsx` (3 — 1 index + 2 generic `U`→tuple type
-    errors around the camera3D target setter), `DopeSheet.tsx` (3 — ids parsed
-    out of a `parameterPath` string; brand with the `tid()`/`vid()` helpers),
-    `randomize.ts` (1).
-  - **Caution — it cascades.** Tightening a value from `any` to its real type
-    exposes *latent* bugs, not just missing annotations. Example: converting
-    `randomize.ts`'s transform loop to `recordEntries` typed `t`, which revealed
-    the `mutateVariations: 'all'` path rebuilds variations via a local
-    `VariationInstance` type that drops `visible` (a real bug). So F2 is a
-    bug-fixing effort, not a mechanical typing pass — budget accordingly.
-  - **Then:** flip `noImplicitAny: true`; re-enable `@typescript-eslint/no-unsafe-*`
-    (5 rules, one at a time, measure each); drop the per-line `no-explicit-any`
-    disables once the remaining `as any` are gone (the variation-factory casts
-    are load-bearing — revisit last).
-  Note: the old eslint comment attributing ~1900 implicit-anys to TypeGPU/Solid
-  was measured under the poisoned-valibot state; re-measure governs the real plan.
+- **F2 — Strictness. `noImplicitAny: true` is now ON and the build is green.**
+  Baseline was 90 errors (88 TS7053 implicit-any dynamic index + 1 TS2352 + 1
+  TS2322; was ~2354 with valibot poisoned). Fixed in order:
+  - `sortedTransformEntries` made generic over its key type so the branded
+    `TransformId` flows through instead of widening to `string` — one clean
+    change cleared **29** (all 23 in `MainWorkspace.tsx` + the affine/color list
+    editors), no casts.
+  - `variations/utils.ts` — the preview-id cache (`transformPreviewIds`) was
+    typed `{ tid: string; vid: string }`, widening the branded ids returned by
+    `generateTransformId`/`generateVariationId`. Branding the cache type fixed
+    **53** of the file's indexing errors at once. The two remaining
+    (`getParamsEditor` editor access, `getVariationDefault`) keep a bounded `as`
+    assertion (only parametric variations carry an editor/params).
+  - `VariationSelector.tsx` — `setFlameTarget3D` wrote a wgpu-matrix `Vec3` into
+    the schema's `[number,number,number]` tuple; replaced the (now-erroring) `as`
+    cast with a real `Vec3 → tuple` conversion.
+  - `DopeSheet.tsx` — ids parsed out of a `parameterPath` string branded with a
+    `TransformId`/`VariationId` assertion at the parse boundary.
+  - `randomize.ts` — the transform loop now uses `recordEntries`; the variation
+    paths view `t.variations` through one shared loose `RandomVariation` type
+    (randomize perturbs weights/params generically, which the precise
+    per-variation unions can't express) with a single boundary cast on the
+    `'all'` rebuild.
+  - **Lesson (kept for the next strict step):** tightening `any`→real-type
+    cascades into *latent* bugs, not just annotations — e.g. the old
+    `mutateVariations:'all'` path rebuilt variations via a local type that
+    dropped `visible`. Budget the no-unsafe-* re-enable as a bug-fixing effort.
+  - **Remaining strict tail (separate):** re-enable the five
+    `@typescript-eslint/no-unsafe-*` rules one at a time (measure each), then
+    drop the per-line `no-explicit-any` disables once the remaining `as any` are
+    gone (the variation-factory casts in `variations/*/types.ts` are
+    load-bearing — revisit last). The old eslint note blaming ~1900 implicit-anys
+    on TypeGPU/Solid was measured under poisoned valibot; re-measure first.
 - **F3 (optional) — Typecheck config files separately.** `vite.config.ts`,
   `vitest.config.ts`, `playwright.config.ts` are no longer in the main typecheck
   (they were never `src`). Add a small `tsconfig.node.json` if you want them

--- a/docs/plans/typecheck-ci-parity-plan.md
+++ b/docs/plans/typecheck-ci-parity-plan.md
@@ -1,0 +1,124 @@
+# Typecheck CI↔Local parity (issue #30) — root cause, fix, follow-ups
+
+Branch: `feat/typecheck-ci-parity`.
+
+## TL;DR
+
+Local `pnpm typecheck` could pass while CI failed on the **same commit** (and
+`as any` casts had crept in). Root cause: the typecheck program was ingesting the
+built `dist/` bundles, which pushed TypeScript over a complexity threshold where
+it **silently widens valibot's `v.InferOutput<…>` to `any`** — so local
+type-checking went blind. Fixed by excluding build output from the typecheck.
+After the fix, `noImplicitAny:true` drops from ~2354 errors to **90**, so real
+strictness is now tractable.
+
+## Root cause (proven)
+
+- `packages/app/tsconfig.json` had **no `exclude`** and `allowJs: true`. The
+  default file glob therefore pulled in the built bundles
+  `dist/assets/index-*.js` (~2.8 MB) + `tex-svg-*.js` (~1.8 MB) of *minified* JS.
+- ~4.6 MB of minified JS pushes the program over an internal TypeScript checker
+  complexity threshold. Past it, tsc **silently widens** deep generic
+  instantiations — all of valibot's `InferOutput` — to `any`. No error, no
+  `TS2589`.
+- Verified with an exact-any probe (`type IsAny<T> = 0 extends 1 & T`):
+  - the same tsconfig resolves valibot correctly for a 1-file program but yields
+    `any` for the full program → it's **scale**, not valibot, not schema size
+    (a 2-field toy schema is `any` too), not `noImplicitAny`/`skipLibCheck`
+    (both tested — no effect);
+  - **with `dist/` → reliably `any`; without `dist/` → resolves.** Excluding
+    `dist`/`e2e` makes the full program resolve reliably (5/5 under stress).
+- A secondary contributor: the app mixes `@/valibot` (20 files) and direct
+  `valibot` (4 files); the two module identities defeat instantiation caching and
+  add load (see follow-up F1).
+
+### Why local ≠ CI
+
+CI (`.github/workflows/node.js.yml`) runs **`typecheck` before `build`**, so CI
+has **no `dist/`** at typecheck time → valibot resolves → CI catches real type
+errors. Locally a stale `dist/` from a prior build pushes you over the threshold
+→ `any` → local typecheck passes blind. It was never nondeterministic; it was
+`dist/` presence. (The project sits close to the threshold, so near it the result
+is marginal — `dist/` is what reliably tips it.)
+
+### Reproduce it
+
+`assets/local/valibot-any-mwe/` (gitignored): `node …/run.mjs` prints
+
+```
+A) real config (dist/ in program)  : any ❌
+B) real config (dist/ removed)     : resolved ✅
+C) real opts + exclude dist/e2e    : resolved ✅
+```
+
+`probe-a/b/c.ts` hold the `IsAny` assertions; the runner only greps tsc output
+for the probe filenames (0 probe errors ⇒ valibot is `any`).
+
+## The fix (applied)
+
+`packages/app/tsconfig.json`:
+
+```jsonc
+"exclude": ["dist", "e2e", "node_modules"]
+```
+
+Build output must never be in the typecheck. `exclude` overrides tsc's default,
+so `node_modules` is listed explicitly. After this, the idiomatic
+`type X = v.InferOutput<typeof Schema>` (valibot's recommended pattern) resolves
+locally and matches CI — no hand-written interfaces or runtime parity tests
+needed.
+
+## Also landed on this branch
+
+- **Single source of truth for `FlameDescriptor`** — deleted the hand-written
+  duplicate `interface FlameDescriptor` in `utils/timeline.ts` (it had silently
+  drifted: missing `plotsPerChain`/`autoExposure3D*`, and put `edgeFadeColor` at
+  the **wrong nesting level** — top-level instead of under `renderSettings`).
+  `timeline.ts` now re-exports the schema's type. **Keep.**
+- **`edgeFadeColor` bugfix** (exposed once the typecheck stopped widening to
+  `any`): the timeline `edgeFadeColor` track and two animation-export lines
+  wrote to a dead top-level `flame.edgeFadeColor`; the renderer reads
+  `flame.renderSettings.edgeFadeColor`. The animated edge fade never applied.
+  Fixed to the canonical path.
+- **Unsafe-cast cleanup** — `src/types/browser.d.ts` ambient augmentation
+  replaces ~10 `(navigator/performance/info as any).field` casts; the
+  `FlameDescriptor` `JSON.parse(JSON.stringify())` bridges → `deepClone`;
+  `applyTimelineToFlameAtFrame` narrowed to `Pick<TimelineState,'tracks'|'config'>`
+  (drops an `as any` stub). Load-bearing valibot variation-factory casts left
+  as-is.
+- **Pre-push hook** — `.githooks/pre-push` runs `typecheck + lint + fmt`,
+  auto-installed via root `package.json` `"prepare"` (`core.hooksPath`).
+- **Reverted** the explicit `RenderSettings`/`CameraObj`/`Camera3DObj` interfaces
+  + runtime parity test back to idiomatic `InferOutput` — they were a workaround
+  for the now-root-caused problem.
+
+## Follow-ups
+
+- **F1 — Standardize valibot imports on `@/valibot`.** 4 files import direct
+  `valibot` (`flame/variations/parametric/types.ts`, `simple/types.ts`,
+  `simple3D/types.ts`, `parametric3D/types.ts`). Routing them through `@/valibot`
+  removes the duplicate module identity, restores instantiation caching, and adds
+  threshold headroom. Low risk.
+- **F2 — Strictness, incrementally.** Post-fix measurement (`noImplicitAny:true`):
+  **90 errors** (was ~2354 with valibot poisoned), of which **88 are TS7053**
+  (implicit-any dynamic index access), concentrated in `flame/variations/utils.ts`
+  (54) and `MainWorkspace.tsx` (23), plus 1 TS2352 + 1 TS2322. Plan:
+  1. Type the dynamic index sites in `variations/utils.ts` + `MainWorkspace.tsx`
+     (index signatures / `recordEntries` / branded keys) to clear the TS7053s.
+  2. Flip `noImplicitAny: true` in the app tsconfig.
+  3. Re-enable the `@typescript-eslint/no-unsafe-*` rules (currently 5 off) one at
+     a time; measure each.
+  4. Drop the per-line `@typescript-eslint/no-explicit-any` disables once the
+     remaining `as any` are gone (only the load-bearing variation-factory casts
+     should remain — revisit those last).
+  Note: the old eslint comment attributing ~1900 implicit-anys to TypeGPU/Solid
+  was measured under the poisoned-valibot state; re-measure governs the real plan.
+- **F3 (optional) — Typecheck config files separately.** `vite.config.ts`,
+  `vitest.config.ts`, `playwright.config.ts` are no longer in the main typecheck
+  (they were never `src`). Add a small `tsconfig.node.json` if you want them
+  covered.
+
+## References
+
+- valibot recommends `type X = v.InferOutput<typeof Schema>` — <https://valibot.dev/guides/infer-types/>
+- `allowJs` ingesting `dist` is a documented gotcha — <https://www.typescriptlang.org/tsconfig/#exclude>

--- a/docs/plans/typecheck-ci-parity-plan.md
+++ b/docs/plans/typecheck-ci-parity-plan.md
@@ -126,12 +126,21 @@ needed.
     cascades into *latent* bugs, not just annotations — e.g. the old
     `mutateVariations:'all'` path rebuilt variations via a local type that
     dropped `visible`. Budget the no-unsafe-* re-enable as a bug-fixing effort.
-  - **Remaining strict tail (separate):** re-enable the five
-    `@typescript-eslint/no-unsafe-*` rules one at a time (measure each), then
-    drop the per-line `no-explicit-any` disables once the remaining `as any` are
-    gone (the variation-factory casts in `variations/*/types.ts` are
-    load-bearing — revisit last). The old eslint note blaming ~1900 implicit-anys
-    on TypeGPU/Solid was measured under poisoned valibot; re-measure first.
+  - **no-unsafe-* rules — measured, kept OFF (decision).** Re-enabling the five
+    `@typescript-eslint/no-unsafe-*` rules now reports **~214** errors. These are
+    NOT a valibot regression (noImplicitAny is on and clean); they're genuine
+    `any` boundaries: dynamic keyframe-path member access (MainWorkspace),
+    env/config values (defaults.ts), JSON.parse / payload results
+    (ShareLinkModal, App), allowJs `.js` files (public/crashHandler.js), and
+    test mocks. Fixing them would mostly add casts or targeted disables, so the
+    rules stay off (see the eslint.config.js comment). The rules predate this
+    work (turned off 2025-03 / 2025-05) for the same reason; the earlier scare
+    number (~1900/2354) was the *noImplicitAny* axis under poisoned valibot,
+    which is now resolved — these 214 are a separate, real axis.
+  - **Still worth doing later:** drop the per-line `no-explicit-any` disables
+    once the remaining `as any` are gone — the browser-API ones are already
+    handled; the variation-factory casts in `variations/*/types.ts` are
+    load-bearing, revisit last.
 - **F3 (optional) — Typecheck config files separately.** `vite.config.ts`,
   `vitest.config.ts`, `playwright.config.ts` are no longer in the main typecheck
   (they were never `src`). Add a small `tsconfig.node.json` if you want them

--- a/docs/plans/typecheck-ci-parity-plan.md
+++ b/docs/plans/typecheck-ci-parity-plan.md
@@ -99,18 +99,31 @@ needed.
   `simple3D/types.ts`, `parametric3D/types.ts`). Routing them through `@/valibot`
   removes the duplicate module identity, restores instantiation caching, and adds
   threshold headroom. Low risk.
-- **F2 — Strictness, incrementally.** Post-fix measurement (`noImplicitAny:true`):
-  **90 errors** (was ~2354 with valibot poisoned), of which **88 are TS7053**
-  (implicit-any dynamic index access), concentrated in `flame/variations/utils.ts`
-  (54) and `MainWorkspace.tsx` (23), plus 1 TS2352 + 1 TS2322. Plan:
-  1. Type the dynamic index sites in `variations/utils.ts` + `MainWorkspace.tsx`
-     (index signatures / `recordEntries` / branded keys) to clear the TS7053s.
-  2. Flip `noImplicitAny: true` in the app tsconfig.
-  3. Re-enable the `@typescript-eslint/no-unsafe-*` rules (currently 5 off) one at
-     a time; measure each.
-  4. Drop the per-line `@typescript-eslint/no-explicit-any` disables once the
-     remaining `as any` are gone (only the load-bearing variation-factory casts
-     should remain — revisit those last).
+- **F2 — Strictness, incrementally.** Baseline (`noImplicitAny:true`): **90
+  errors** (was ~2354 with valibot poisoned), 88 TS7053 (implicit-any dynamic
+  index) + 1 TS2352 + 1 TS2322.
+  - **Done:** `sortedTransformEntries` made generic over its key type so the
+    branded `TransformId` flows through instead of widening to `string`. One
+    clean change cleared **29** errors (all 23 in `MainWorkspace.tsx` + 3 in
+    `AffineListEditor` + 3 in `ColorListEditor`), no casts, no behaviour change.
+    Count now **61**.
+  - **Remaining 61:** `flame/variations/utils.ts` (54 — the variation-registry
+    dynamic indexing of `allTransformVariations[…]`; likely needs typed key
+    unions and may keep a couple of the file's existing load-bearing factory
+    casts), `VariationSelector.tsx` (3 — 1 index + 2 generic `U`→tuple type
+    errors around the camera3D target setter), `DopeSheet.tsx` (3 — ids parsed
+    out of a `parameterPath` string; brand with the `tid()`/`vid()` helpers),
+    `randomize.ts` (1).
+  - **Caution — it cascades.** Tightening a value from `any` to its real type
+    exposes *latent* bugs, not just missing annotations. Example: converting
+    `randomize.ts`'s transform loop to `recordEntries` typed `t`, which revealed
+    the `mutateVariations: 'all'` path rebuilds variations via a local
+    `VariationInstance` type that drops `visible` (a real bug). So F2 is a
+    bug-fixing effort, not a mechanical typing pass — budget accordingly.
+  - **Then:** flip `noImplicitAny: true`; re-enable `@typescript-eslint/no-unsafe-*`
+    (5 rules, one at a time, measure each); drop the per-line `no-explicit-any`
+    disables once the remaining `as any` are gone (the variation-factory casts
+    are load-bearing — revisit last).
   Note: the old eslint comment attributing ~1900 implicit-anys to TypeGPU/Solid
   was measured under the poisoned-valibot state; re-measure governs the real plan.
 - **F3 (optional) — Typecheck config files separately.** `vite.config.ts`,

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -79,14 +79,13 @@ export default defineConfig(
       '@typescript-eslint/no-unsafe-member-access': 'off',
       '@typescript-eslint/no-unsafe-return': 'off',
       '@typescript-eslint/restrict-template-expressions': 'off',
-      // Types that resolve to `any` (due to noImplicitAny: false) make unions
-      // like `SomeType | null` appear as `any | null`, triggering this rule.
       '@typescript-eslint/no-redundant-type-constituents': 'off',
-      // noImplicitAny is false in the app tsconfig because TypeGPU's tgpu.fn()
-      // and SolidJS reactive wrappers break contextual typing for ~1900+
-      // callback parameters.  Every other no-unsafe-* rule is already off;
-      // allow `any` in arithmetic too so restrict-plus-operands stays useful
-      // for catching actual string+number mismatches without false positives.
+      // noImplicitAny is now ON (strict) in the app tsconfig — issue #30. The
+      // no-unsafe-* rules above stay off pending the incremental re-enable in
+      // docs/plans/typecheck-ci-parity-plan.md (F2): TypeGPU's tgpu.fn() and
+      // SolidJS reactive wrappers still surface `any`-typed values those rules
+      // would flag. allowAny keeps restrict-plus-operands useful for catching
+      // real string+number mismatches without false positives meanwhile.
       '@typescript-eslint/restrict-plus-operands': [
         'error',
         { allowAny: true },

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -73,6 +73,14 @@ export default defineConfig(
       '@typescript-eslint/no-dynamic-delete': 'off',
       '@typescript-eslint/no-misused-promises': 'off',
       '@typescript-eslint/no-non-null-assertion': 'off',
+      // The five no-unsafe-* rules stay off deliberately. noImplicitAny is now ON
+      // (issue #30), which removed the valibot-driven `any` flood, but
+      // re-enabling these still reports ~214 errors that are genuine `any`
+      // boundaries, not a regression: dynamic keyframe-path member access
+      // (MainWorkspace), env/config values (defaults.ts), JSON.parse / payload
+      // results, allowJs .js files (public/crashHandler.js) and test mocks.
+      // Fixing them would mostly mean casts/targeted disables, so they're kept
+      // off. See docs/plans/typecheck-ci-parity-plan.md (F2 tail).
       '@typescript-eslint/no-unsafe-argument': 'off',
       '@typescript-eslint/no-unsafe-assignment': 'off',
       '@typescript-eslint/no-unsafe-call': 'off',
@@ -80,12 +88,8 @@ export default defineConfig(
       '@typescript-eslint/no-unsafe-return': 'off',
       '@typescript-eslint/restrict-template-expressions': 'off',
       '@typescript-eslint/no-redundant-type-constituents': 'off',
-      // noImplicitAny is now ON (strict) in the app tsconfig — issue #30. The
-      // no-unsafe-* rules above stay off pending the incremental re-enable in
-      // docs/plans/typecheck-ci-parity-plan.md (F2): TypeGPU's tgpu.fn() and
-      // SolidJS reactive wrappers still surface `any`-typed values those rules
-      // would flag. allowAny keeps restrict-plus-operands useful for catching
-      // real string+number mismatches without false positives meanwhile.
+      // allowAny keeps restrict-plus-operands useful for catching real
+      // string+number mismatches without false positives from the `any` above.
       '@typescript-eslint/restrict-plus-operands': [
         'error',
         { allowAny: true },

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "license": "AGPL-3.0-only",
   "packageManager": "pnpm@10.32.1+sha512.a706938f0e89ac1456b6563eab4edf1d1faf3368d1191fc5c59790e96dc918e4456ab2e67d613de1043d2e8c81f87303e6b40d4ffeca9df15ef1ad567348f2be",
   "scripts": {
+    "prepare": "git config core.hooksPath .githooks || true",
     "fmt": "prettier packages --check",
     "fmt:fix": "prettier packages --write --log-level warn",
     "lint": "eslint",

--- a/packages/app/CHANGELOG.md
+++ b/packages/app/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.9] - 2026-06-19
+
+### Added
+
+- **Smart Animate**: a one-click animation generator that combines a curated preset from each category (camera, render, color, affine) into a full, designed-feeling loop — alongside the existing pick-the-aspects **Randomize Animation**.
+- A **Clear existing keyframes first** toggle for the animation randomizer (on by default) — turn it off to layer a new animation onto your existing keyframes.
+
+### Changed
+
+- The variation browser's large preview now renders at full quality on capable (high/ultra) GPUs instead of a heavily throttled mode that looked noisy/over-bright and updated jerkily.
+
+### Fixed
+
+- Selecting a variation in the browser no longer over-brightens the preview — the flame keeps its own exposure (variation thumbnails stay bright only for legibility).
+- The timeline/dope-sheet **resize handle now works on touch devices** (e.g. iPhone), not just larger screens.
+- The dope-sheet **Curve** and **Seek** toggles now reflect their on/off state immediately when tapped.
+- **Animation export**: the per-frame point counter no longer reads "0 / 0" for 2D flames, and the finished-export thumbnail shows the real first frame instead of a blank/green rectangle.
+- Animated **edge-fade colour** now actually applies during playback/export (the keyframe track was writing to the wrong place).
+
+### Internal
+
+- Resolved a long-standing case where local `pnpm typecheck` could pass while CI failed on the same commit: the build output (`dist/`) was being type-checked, which silently widened the validation (valibot) types to `any`. The type-check now excludes build output, strict `noImplicitAny` is enabled, and a pre-push hook keeps local and CI in lockstep.
+
 ## [0.9.8] - 2026-06-19
 
 ### Added

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chaos-master",
-  "version": "0.9.8",
+  "version": "0.9.9",
   "description": "WebGPU based IFS Flame Generator for Artists & Explorers",
   "type": "module",
   "scripts": {

--- a/packages/app/src/App.module.css
+++ b/packages/app/src/App.module.css
@@ -1309,7 +1309,10 @@
   }
 
   .timeline-container {
-    height: var(--timeline-height-mobile, 160px);
+    /* Same --timeline-height the resize handle/wheel write (MainWorkspace), just
+       a smaller mobile default. The old --timeline-height-mobile var was never
+       set by anything, so the handle/drag did nothing on phones. */
+    height: var(--timeline-height, 160px);
     max-height: 45vh;
   }
 }

--- a/packages/app/src/MainWorkspace.tsx
+++ b/packages/app/src/MainWorkspace.tsx
@@ -52,6 +52,7 @@ import { Slider } from './components/Sliders/Slider'
 import { SoftwareVersion } from './components/SoftwareVersion/SoftwareVersion'
 import { SpotlightTour } from './components/SpotlightTour/SpotlightTour'
 import { KeyframeDiamond } from './components/Timeline/KeyframeDiamond'
+import { smartRandomAnimation } from './components/Timeline/presets'
 import { TimelineSection } from './components/Timeline/TimelineSection'
 import { createVariationSelector } from './components/VariationSelector/VariationSelector'
 import { ViewControls } from './components/ViewControls/ViewControls'
@@ -1592,6 +1593,22 @@ export function MainWorkspace(props: AppProps) {
       }
 
       timeline.setAnimationEnabled(true)
+      setShowTimeline(true)
+    } finally {
+      setTimeout(() => {
+        isRandomizingAnimation = false
+      }, 200)
+    }
+  }
+
+  // Smart animation: apply a random curated preset from each category for a full
+  // multi-aspect loop (vs the selected-items random tracks above). Honors the
+  // same clear-first toggle.
+  const handleSmartAnimation = (clearFirst: boolean) => {
+    isRandomizingAnimation = true
+    try {
+      if (clearFirst) timeline.clearAllTracks()
+      smartRandomAnimation(flameDescriptor, timeline)
       setShowTimeline(true)
     } finally {
       setTimeout(() => {
@@ -3144,6 +3161,7 @@ export function MainWorkspace(props: AppProps) {
                             onLoadHistory={handleLoadHistory}
                             onClearHistory={handleClearHistory}
                             onRandomizeAnimation={handleRandomizeAnimation}
+                            onSmartAnimation={handleSmartAnimation}
                             onUpdateRenderSettings={handleUpdateRenderSettings}
                             onApplyCandidate={(flame) => {
                               history.replace(

--- a/packages/app/src/MainWorkspace.tsx
+++ b/packages/app/src/MainWorkspace.tsx
@@ -2445,7 +2445,10 @@ export function MainWorkspace(props: AppProps) {
     const startHeight = container.offsetHeight
 
     function setHeight(px: number) {
-      const clamped = Math.max(100, Math.min(window.innerHeight * 0.55, px))
+      // Cap matches the CSS max-height (55vh desktop, 45vh on mobile) so the
+      // handle and the rendered panel height stay in sync.
+      const maxPx = window.innerHeight * (isMobile() ? 0.45 : 0.55)
+      const clamped = Math.max(100, Math.min(maxPx, px))
       container!.style.setProperty('--timeline-height', `${clamped}px`)
     }
 
@@ -2729,7 +2732,7 @@ export function MainWorkspace(props: AppProps) {
                       const newHeight = Math.max(
                         100,
                         Math.min(
-                          window.innerHeight * 0.55,
+                          window.innerHeight * (isMobile() ? 0.45 : 0.55),
                           currentHeight + delta,
                         ),
                       )

--- a/packages/app/src/MainWorkspace.tsx
+++ b/packages/app/src/MainWorkspace.tsx
@@ -1474,12 +1474,15 @@ export function MainWorkspace(props: AppProps) {
     history.replace(deepClone(entry.flame), 'Load History Flame')
   }
 
-  const handleRandomizeAnimation = (presetIds: string[]) => {
+  const handleRandomizeAnimation = (
+    presetIds: string[],
+    clearFirst: boolean,
+  ) => {
     if (presetIds.length === 0) return
 
     isRandomizingAnimation = true
     try {
-      timeline.clearAllTracks()
+      if (clearFirst) timeline.clearAllTracks()
 
       const start = timeline.config().startFrame
       const end = timeline.config().endFrame

--- a/packages/app/src/components/BenchmarkModal/BenchmarkModal.tsx
+++ b/packages/app/src/components/BenchmarkModal/BenchmarkModal.tsx
@@ -55,9 +55,7 @@ async function getGPUDeviceInformation() {
     powerPreference: 'high-performance',
   })
   const { info, limits } = adapter
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const memoryHeaps: { size: number }[] | undefined = (info as any).memoryHeaps
-  const heaps = memoryHeaps?.map((m) => m.size)
+  const heaps = info.memoryHeaps?.map((m) => m.size)
 
   return {
     description: info.description,
@@ -96,8 +94,7 @@ function gatherBenchmarkLog(
   if (n.hardwareConcurrency) {
     lines.push(`CPU      : ${n.hardwareConcurrency} cores`)
   }
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const deviceMemory = (n as any).deviceMemory as number | undefined
+  const deviceMemory = n.deviceMemory
   if (deviceMemory !== undefined) {
     lines.push(`RAM      : ~${deviceMemory} GB`)
   }
@@ -415,10 +412,7 @@ function BenchmarkModal(props: { respond: () => void; autoStart?: boolean }) {
     if (globalThis.navigator.hardwareConcurrency) {
       sysParts.push(`${globalThis.navigator.hardwareConcurrency} CPU cores`)
     }
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const deviceMemory = (globalThis.navigator as any).deviceMemory as
-      | number
-      | undefined
+    const deviceMemory = globalThis.navigator.deviceMemory
     if (deviceMemory !== undefined) {
       sysParts.push(`~${deviceMemory} GB RAM`)
     }

--- a/packages/app/src/components/ErrorHandling/ErrorHandling.tsx
+++ b/packages/app/src/components/ErrorHandling/ErrorHandling.tsx
@@ -53,8 +53,8 @@ function gatherDeviceMetadata(): MetadataEntry[] {
   // Browser / OS
   entries.push({ label: 'User Agent', value: navigator.userAgent })
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  entries.push({ label: 'Platform', value: (navigator as any).platform })
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
+  entries.push({ label: 'Platform', value: navigator.platform })
   entries.push({ label: 'Language', value: navigator.language })
 
   // Screen
@@ -75,14 +75,8 @@ function gatherDeviceMetadata(): MetadataEntry[] {
   })
 
   // Memory (Chrome-only)
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any, no-restricted-globals
-  const mem = (performance as any).memory as
-    | {
-        jsHeapSizeLimit: number
-        usedJSHeapSize: number
-        totalJSHeapSize: number
-      }
-    | undefined
+  // eslint-disable-next-line no-restricted-globals
+  const mem = performance.memory
   if (mem) {
     const mb = (n: number) => `${(n / 1024 / 1024).toFixed(0)} MB`
     entries.push({
@@ -90,8 +84,7 @@ function gatherDeviceMetadata(): MetadataEntry[] {
       value: `${mb(mem.usedJSHeapSize)} / ${mb(mem.totalJSHeapSize)} (limit ${mb(mem.jsHeapSizeLimit)})`,
     })
   }
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const deviceMemory = (navigator as any).deviceMemory as number | undefined
+  const deviceMemory = navigator.deviceMemory
   if (deviceMemory !== undefined) {
     entries.push({ label: 'Device Memory', value: `~${deviceMemory} GB` })
   }

--- a/packages/app/src/components/ExportJobs/ExportJobTracker.tsx
+++ b/packages/app/src/components/ExportJobs/ExportJobTracker.tsx
@@ -197,7 +197,14 @@ function JobCard(props: { job: ExportJob }) {
                 <img class={ui.thumb} src={result.blobUrl} alt={job.name} />
               }
             >
-              <video class={ui.thumb} src={result.blobUrl} muted playsinline />
+              <video
+                class={ui.thumb}
+                src={result.blobUrl}
+                poster={result.posterUrl}
+                preload="metadata"
+                muted
+                playsinline
+              />
             </Show>
             <div class={ui.doneInfo}>
               <div class={ui.metaLine}>

--- a/packages/app/src/components/ExportJobs/OffscreenAnimationRender.tsx
+++ b/packages/app/src/components/ExportJobs/OffscreenAnimationRender.tsx
@@ -99,6 +99,7 @@ export function OffscreenAnimationRender(props: { job: AnimationJob }) {
   let lastProgressMs = 0
   let accumulated = 0
   let limitAccessor: () => number = () => 0
+  let posterUrl: string | undefined
   let encoder: Awaited<ReturnType<typeof createVideoEncoder>> | undefined
 
   onCleanup(() => {
@@ -145,6 +146,7 @@ export function OffscreenAnimationRender(props: { job: AnimationJob }) {
         width: resizeWidth,
         height: resizeHeight,
         frames: frameIndex,
+        posterUrl,
       })
     } catch (err) {
       setJobError(job.id, err instanceof Error ? err.message : String(err))
@@ -155,6 +157,14 @@ export function OffscreenAnimationRender(props: { job: AnimationJob }) {
     if (!encoder) {
       capturing = false
       return
+    }
+    if (frameIndex === 0) {
+      // Poster of the first rendered frame for the tracker thumbnail — a
+      // poster-less <video> shows a blank/green undecoded frame. Best-effort
+      // and async; if it isn't ready by finish() the video just has no poster.
+      canvas.toBlob((blob) => {
+        if (blob && !disposed) posterUrl = URL.createObjectURL(blob)
+      }, 'image/png')
     }
     const bitmap = await globalThis.createImageBitmap(canvas, {
       resizeWidth,
@@ -234,7 +244,12 @@ export function OffscreenAnimationRender(props: { job: AnimationJob }) {
                 edgeFadeColor={vec4f(0)}
                 palette={() => job.palette}
                 onExportImage={handleExport}
-                onAccumulatedPointCount={() => {}}
+                onAccumulatedPointCount={(c) => {
+                  accumulated = c
+                }}
+                setQualityPointCountLimit={(fn) => {
+                  limitAccessor = fn
+                }}
               />
             </WheelZoomCamera2D>
           }

--- a/packages/app/src/components/ExportPngDialog/FramePreviewGallery.tsx
+++ b/packages/app/src/components/ExportPngDialog/FramePreviewGallery.tsx
@@ -6,6 +6,7 @@ import { AutoCanvas } from '@/lib/AutoCanvas'
 import { Camera2D } from '@/lib/Camera2D'
 import { Default3DPreviewCamera } from '@/lib/Camera3D'
 import { Root } from '@/lib/Root'
+import { deepClone } from '@/utils/clone'
 import { resolveAspectRatio } from '@/utils/exportDimensions'
 import { applyTimelineToFlameAtFrame } from '@/utils/timeline'
 import ui from './FramePreviewGallery.module.css'
@@ -148,13 +149,10 @@ export function FramePreviewGallery(props: Props) {
 
   function flameForFrame(frameIdx: number): FlameDescriptor {
     const frame = props.config.startFrame + frameIdx
-    const clone: FlameDescriptor = JSON.parse(
-      JSON.stringify(props.flameDescriptor),
-    )
+    const clone = deepClone(props.flameDescriptor)
 
     applyTimelineToFlameAtFrame(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      { tracks: () => props.tracks, config: () => props.config } as any,
+      { tracks: () => props.tracks, config: () => props.config },
       clone,
       frame,
     )

--- a/packages/app/src/components/FlameRandomizerCard/FlameRandomizerCard.tsx
+++ b/packages/app/src/components/FlameRandomizerCard/FlameRandomizerCard.tsx
@@ -70,6 +70,7 @@ export interface FlameRandomizerCardProps {
   onLoadHistory: (entry: RandomizerHistoryEntry) => void
   onClearHistory: () => void
   onRandomizeAnimation: (presetIds: string[], clearFirst: boolean) => void
+  onSmartAnimation: (clearFirst: boolean) => void
   onUpdateRenderSettings: (
     settings: Partial<FlameDescriptor['renderSettings']>,
   ) => void
@@ -203,10 +204,10 @@ export function FlameRandomizerCard(props: FlameRandomizerCardProps) {
   const [animVib, setAnimVib] = createSignal(false)
   const [animOrbit, setAnimOrbit] = createSignal(true)
   const [animFT, setAnimFT] = createSignal(false)
-  // When off (default), Randomize Animation layers onto existing keyframes
-  // (re-running overwrites the same frames but preserves hand-made ones on other
-  // frames/paths); when on, it wipes all tracks first for a clean slate.
-  const [animClearFirst, setAnimClearFirst] = createSignal(false)
+  // When on (default), Randomize/Smart Animate wipe all tracks first (the
+  // original behaviour); turn off to layer onto existing keyframes (re-running
+  // overwrites the same frames but preserves hand-made ones on other paths).
+  const [animClearFirst, setAnimClearFirst] = createSignal(true)
 
   // Render settings randomizer signals
   const [renderSettingsExpanded, setRenderSettingsExpanded] =
@@ -368,6 +369,10 @@ export function FlameRandomizerCard(props: FlameRandomizerCardProps) {
     if (animFT()) presetIds.push('finalTransform')
 
     props.onRandomizeAnimation(presetIds, animClearFirst())
+  }
+
+  const handleSmartAnimation = () => {
+    props.onSmartAnimation(animClearFirst())
   }
 
   const [paletteExpanded, setPaletteExpanded] = createSignal(false)
@@ -977,6 +982,19 @@ export function FlameRandomizerCard(props: FlameRandomizerCardProps) {
                 <polygon points="5 3 19 12 5 21 5 3" />
               </svg>
               Randomize Animation
+            </Button>
+            <Button class={ui.secondaryButton} onClick={handleSmartAnimation}>
+              <svg
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                stroke-width="2"
+                fill="none"
+                class={ui.btnIcon}
+              >
+                <path d="M12 3l1.9 5.1L19 10l-5.1 1.9L12 17l-1.9-5.1L5 10l5.1-1.9z" />
+                <path d="M19 15l.7 1.8L21.5 17.5 19.7 18.2 19 20l-.7-1.8L16.5 17.5 18.3 16.8z" />
+              </svg>
+              Smart Animate
             </Button>
           </div>
         </div>

--- a/packages/app/src/components/FlameRandomizerCard/FlameRandomizerCard.tsx
+++ b/packages/app/src/components/FlameRandomizerCard/FlameRandomizerCard.tsx
@@ -69,7 +69,7 @@ export interface FlameRandomizerCardProps {
   ) => void
   onLoadHistory: (entry: RandomizerHistoryEntry) => void
   onClearHistory: () => void
-  onRandomizeAnimation: (presetIds: string[]) => void
+  onRandomizeAnimation: (presetIds: string[], clearFirst: boolean) => void
   onUpdateRenderSettings: (
     settings: Partial<FlameDescriptor['renderSettings']>,
   ) => void
@@ -203,6 +203,10 @@ export function FlameRandomizerCard(props: FlameRandomizerCardProps) {
   const [animVib, setAnimVib] = createSignal(false)
   const [animOrbit, setAnimOrbit] = createSignal(true)
   const [animFT, setAnimFT] = createSignal(false)
+  // When off (default), Randomize Animation layers onto existing keyframes
+  // (re-running overwrites the same frames but preserves hand-made ones on other
+  // frames/paths); when on, it wipes all tracks first for a clean slate.
+  const [animClearFirst, setAnimClearFirst] = createSignal(false)
 
   // Render settings randomizer signals
   const [renderSettingsExpanded, setRenderSettingsExpanded] =
@@ -363,7 +367,7 @@ export function FlameRandomizerCard(props: FlameRandomizerCardProps) {
     if (is3D() && animOrbit()) presetIds.push('orbit')
     if (animFT()) presetIds.push('finalTransform')
 
-    props.onRandomizeAnimation(presetIds)
+    props.onRandomizeAnimation(presetIds, animClearFirst())
   }
 
   const [paletteExpanded, setPaletteExpanded] = createSignal(false)
@@ -872,6 +876,13 @@ export function FlameRandomizerCard(props: FlameRandomizerCardProps) {
                     <span>Final Transf. Spin</span>
                   </label>
                 </div>
+                <label class={ui.checkboxField}>
+                  <Checkbox
+                    checked={animClearFirst()}
+                    onChange={setAnimClearFirst}
+                  />
+                  <span>Clear existing keyframes first</span>
+                </label>
               </div>
             </Show>
           </div>

--- a/packages/app/src/components/HelpModal/HelpModal.tsx
+++ b/packages/app/src/components/HelpModal/HelpModal.tsx
@@ -81,8 +81,8 @@ const cameraControls: ShortcutDescriptor[] = [
 const { navigator: nav } = globalThis
 
 function isMac() {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return (nav as any).platform.indexOf('Mac') !== -1
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
+  return nav.platform.indexOf('Mac') !== -1
 }
 
 const ctrlKey = isMac() ? '\u2318 ' : 'Ctrl + '
@@ -103,9 +103,7 @@ async function getGPUDeviceInformation() {
     powerPreference: 'high-performance',
   })
   const { info, limits } = adapter
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const memoryHeaps: { size: number }[] | undefined = (info as any).memoryHeaps
-  const heaps = memoryHeaps?.map((m) => m.size)
+  const heaps = info.memoryHeaps?.map((m) => m.size)
 
   return {
     description: info.description,
@@ -130,8 +128,8 @@ function gatherFullDeviceInfo(
 
   lines.push(`App Version : ${VERSION}${GIT_SHA ? ` (${GIT_SHA})` : ''}`)
   lines.push(`User Agent  : ${n.userAgent}`)
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  lines.push(`Platform    : ${(n as any).platform}`)
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
+  lines.push(`Platform    : ${n.platform}`)
   lines.push(`Language    : ${n.language}`)
 
   lines.push(
@@ -143,8 +141,7 @@ function gatherFullDeviceInfo(
   if (n.hardwareConcurrency) {
     lines.push(`CPU Cores   : ${n.hardwareConcurrency}`)
   }
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const deviceMemory = (n as any).deviceMemory as number | undefined
+  const deviceMemory = n.deviceMemory
   lines.push(
     `Device RAM  : ${
       deviceMemory !== undefined

--- a/packages/app/src/components/Timeline/DopeSheet.tsx
+++ b/packages/app/src/components/Timeline/DopeSheet.tsx
@@ -34,7 +34,7 @@ const TRACK_NAME_WIDTH = 130
 
 import { DopeSheetGrid } from './DopeSheetGrid'
 import { KeyframeInspector } from './KeyframeInspector'
-import type { FlameDescriptor } from '@/flame/schema/flameSchema'
+import type { FlameDescriptor, TransformId, VariationId, } from '@/flame/schema/flameSchema'
 
 export interface DopeSheetProps {
   formatTrackLabel?: (path: string) => string
@@ -148,7 +148,9 @@ export function DopeSheet(props: DopeSheetProps) {
         const parts = t.parameterPath.split('.')
         if (flame) {
           if (parts[0] === 'transform' && parts.length >= 2) {
-            const tid = parts[1]!
+            // Brand the id parsed out of the parameterPath so it can index the
+            // TransformId-keyed transforms record.
+            const tid = parts[1]! as TransformId
             // Handle global transform.color.x vs transform.<tid>.probability
             if (tid !== 'color' && !flame.transforms[tid]) {
               isOrphaned = true
@@ -158,9 +160,10 @@ export function DopeSheet(props: DopeSheetProps) {
             // settings, blendWeight, …) — always valid.
             isOrphaned = false
           } else if (parts.length >= 2) {
-            // It's likely <tid>.<vid> or <tid>.<vid>.<param>
-            const tid = parts[0]!
-            const vid = parts[1]!
+            // It's likely <tid>.<vid> or <tid>.<vid>.<param>; brand the ids
+            // parsed out of the path so they can index the branded records.
+            const tid = parts[0]! as TransformId
+            const vid = parts[1]! as VariationId
             if (
               !flame.transforms[tid] ||
               !flame.transforms[tid].variations[vid]

--- a/packages/app/src/components/Timeline/DopeSheet.tsx
+++ b/packages/app/src/components/Timeline/DopeSheet.tsx
@@ -228,16 +228,14 @@ export function DopeSheet(props: DopeSheetProps) {
           Fit
         </button>
         <button
-          class={ui.zoomBtn}
-          classList={{ [ui.zoomBtnActive as string]: seekOnSelect() }}
+          class={`${ui.zoomBtn} ${seekOnSelect() ? ui.zoomBtnActive : ''}`}
           onClick={() => setSeekOnSelect((v) => !v)}
           title="Seek playhead to selected keyframe"
         >
           Seek
         </button>
         <button
-          class={ui.zoomBtn}
-          classList={{ [ui.zoomBtnActive as string]: showCurve() }}
+          class={`${ui.zoomBtn} ${showCurve() ? ui.zoomBtnActive : ''}`}
           onClick={() => setShowCurve((v) => !v)}
           title="Show the value curve for the selected parameter"
         >

--- a/packages/app/src/components/Timeline/presets.ts
+++ b/packages/app/src/components/Timeline/presets.ts
@@ -246,6 +246,29 @@ export function buildPresets(is3D: boolean): PresetDef[] {
   ]
 }
 
+/**
+ * "Smart" animation: apply one random curated preset from each category
+ * (Camera, Render, Color, Affine) for a full, coherent multi-aspect loop.
+ * Categories write disjoint parameter paths (camera.* vs exposure/gamma vs
+ * palette/color vs affine/finalTransform), so one-per-category composes cleanly
+ * without presets fighting over the same keyframes.
+ */
+export function smartRandomAnimation(
+  flame: FlameDescriptor,
+  timeline: TimelineState,
+) {
+  const byCategory = new Map<PresetDef['category'], PresetDef[]>()
+  for (const preset of buildPresets(flame.renderSettings.dimensions === 3)) {
+    const list = byCategory.get(preset.category)
+    if (list) list.push(preset)
+    else byCategory.set(preset.category, [preset])
+  }
+  for (const list of byCategory.values()) {
+    const pick = list[Math.floor(Math.random() * list.length)]
+    pick?.apply(flame, timeline)
+  }
+}
+
 function camera3DPresets(): RawPresetDef[] {
   return [
     {

--- a/packages/app/src/components/VariationSelector/VariationSelector.tsx
+++ b/packages/app/src/components/VariationSelector/VariationSelector.tsx
@@ -9,7 +9,7 @@ import { CompactModeProvider } from '@/contexts/CompactModeContext'
 import { ComputeGate, useComputeGate } from '@/contexts/ComputeGateContext'
 import { KeyframeTargetProvider } from '@/contexts/KeyframeTargetContext'
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { COMPUTE_GATE_CAPACITY, DEFAULT_VARIATION_PREVIEW_POINT_COUNT, DEFAULT_VARIATION_PREVIEW_QUALITY, DEFAULT_VARIATION_PREVIEW_RENDER_INTERVAL_MS, DEFAULT_VARIATION_SHOW_DELAY_MS, } from '@/defaults'
+import { COMPUTE_GATE_CAPACITY, DEFAULT_POINT_COUNT, DEFAULT_RENDER_INTERVAL_MS, DEFAULT_VARIATION_PREVIEW_POINT_COUNT, DEFAULT_VARIATION_PREVIEW_QUALITY, DEFAULT_VARIATION_PREVIEW_RENDER_INTERVAL_MS, DEFAULT_VARIATION_SHOW_DELAY_MS, } from '@/defaults'
 import { Flam3 } from '@/flame/Flam3'
 import { pointInitModeToImplFn } from '@/flame/pointInitMode'
 import { pointInitMode3DToImplFn } from '@/flame/pointInitMode3D'
@@ -71,6 +71,19 @@ export function PreviewFinalFlame(props: {
   const targetQuality = () =>
     props.hardwareTier ? hardwareTierToQuality[props.hardwareTier] : 0.99
 
+  // On capable GPUs (high/ultra) drive the modal preview at the main IFS's full
+  // rate — the main renderer is paused while the modal is open (renderInterval
+  // → Infinity), so the whole GPU budget is free. Lower/unknown tiers keep the
+  // lighter throttled settings so weak hardware stays responsive.
+  const isHighTier = () =>
+    props.hardwareTier === 'high' || props.hardwareTier === 'ultra'
+  const previewPointCount = () =>
+    isHighTier() ? DEFAULT_POINT_COUNT : DEFAULT_VARIATION_PREVIEW_POINT_COUNT
+  const previewInterval = () =>
+    isHighTier()
+      ? DEFAULT_RENDER_INTERVAL_MS
+      : DEFAULT_VARIATION_PREVIEW_RENDER_INTERVAL_MS
+
   return (
     <AutoCanvas class={ui.canvas} pixelRatio={1}>
       <Show
@@ -89,10 +102,10 @@ export function PreviewFinalFlame(props: {
             <Flam3
               animationEnabled={false}
               quality={targetQuality()}
-              pointCountPerBatch={DEFAULT_VARIATION_PREVIEW_POINT_COUNT}
+              pointCountPerBatch={previewPointCount()}
               adaptiveFilterEnabled={true}
               flameDescriptor={props.flame}
-              renderInterval={DEFAULT_VARIATION_PREVIEW_RENDER_INTERVAL_MS}
+              renderInterval={previewInterval()}
               edgeFadeColor={vec4f(0)}
             />
           </WheelZoomCamera2D>
@@ -126,10 +139,10 @@ export function PreviewFinalFlame(props: {
           <Flam3
             animationEnabled={false}
             quality={targetQuality()}
-            pointCountPerBatch={DEFAULT_VARIATION_PREVIEW_POINT_COUNT}
+            pointCountPerBatch={previewPointCount()}
             adaptiveFilterEnabled={true}
             flameDescriptor={props.flame}
-            renderInterval={DEFAULT_VARIATION_PREVIEW_RENDER_INTERVAL_MS}
+            renderInterval={previewInterval()}
             edgeFadeColor={vec4f(0)}
           />
         </WheelZoomCamera3D>
@@ -662,22 +675,13 @@ function ShowVariationSelector(props: VariationSelectorModalProps) {
               if (previewTr !== undefined) {
                 previewTr.preAffine = transform.preAffine
                 previewTr.variations[props.variationId] = variation
-                draft.renderSettings.exposure =
-                  selectedItem.renderSettings.exposure
-                draft.renderSettings.gamma = selectedItem.renderSettings.gamma
-                draft.renderSettings.vibrancy =
-                  selectedItem.renderSettings.vibrancy
-                draft.renderSettings.contrast =
-                  selectedItem.renderSettings.contrast
-                draft.renderSettings.depthColorPower =
-                  selectedItem.renderSettings.depthColorPower
-                draft.renderSettings.lightPower =
-                  selectedItem.renderSettings.lightPower
-                if (selectedItem.renderSettings.lightDirection) {
-                  draft.renderSettings.lightDirection = [
-                    ...selectedItem.renderSettings.lightDirection,
-                  ] as [number, number, number]
-                }
+                // Deliberately DON'T copy the variation preview's render
+                // settings (exposure, gamma, vibrancy, contrast, lighting):
+                // those are floored bright so the thumbnail shape is legible,
+                // and bleeding them in over-exposed the preview flame (and would
+                // mislead vs the applied result). The flame keeps its OWN
+                // brightness — the variation only contributes its shape. The
+                // camera below is preview-only framing (apply doesn't commit it).
 
                 draft.renderSettings.camera.zoom =
                   selectedItem.renderSettings.camera.zoom

--- a/packages/app/src/components/VariationSelector/VariationSelector.tsx
+++ b/packages/app/src/components/VariationSelector/VariationSelector.tsx
@@ -591,17 +591,19 @@ function ShowVariationSelector(props: VariationSelectorModalProps) {
   }
 
   const setFlameTarget3D: Setter<Vec3> = (value) => {
+    // wgpu-matrix Vec3 is array-like; the schema target is a fixed 3-tuple.
+    const toTuple = (v: Vec3): [number, number, number] => [v[0]!, v[1]!, v[2]!]
     if (typeof value === 'function') {
       setPreviewFlame((draft) => {
         if (!draft.renderSettings.camera3D) return
-        draft.renderSettings.camera3D.target = value(
-          new Float32Array(draft.renderSettings.camera3D.target),
-        ) as [number, number, number]
+        draft.renderSettings.camera3D.target = toTuple(
+          value(new Float32Array(draft.renderSettings.camera3D.target)),
+        )
       })
     } else {
       setPreviewFlame((draft) => {
         if (!draft.renderSettings.camera3D) return
-        draft.renderSettings.camera3D.target = value
+        draft.renderSettings.camera3D.target = toTuple(value)
       })
     }
     return new Float32Array(

--- a/packages/app/src/flame/Flam3.tsx
+++ b/packages/app/src/flame/Flam3.tsx
@@ -28,7 +28,6 @@ import type { v4f } from 'typegpu/data'
 import type { Palette } from './colorMap'
 import type { FlameDescriptor } from './schema/flameSchema'
 import type { ExportImageType } from '@/App'
-import type { FlameDescriptor as TimelineFlameDescriptor } from '@/utils/timeline'
 
 const { sqrt } = Math
 const { performance } = globalThis
@@ -135,8 +134,9 @@ export function Flam3(props: Flam3Props) {
       ).length,
   )
 
-  const [animatedFlame, setAnimatedFlame] =
-    createSignal<TimelineFlameDescriptor>(deepClone(props.flameDescriptor))
+  const [animatedFlame, setAnimatedFlame] = createSignal<FlameDescriptor>(
+    deepClone(props.flameDescriptor),
+  )
 
   const backgroundColorFinal = () => {
     const bg = props.flameDescriptor.renderSettings.backgroundColor
@@ -672,13 +672,9 @@ export function Flam3(props: Flam3Props) {
       const flame = animatedFlame()
 
       if (ifsPipeline3D) {
-        ifsPipeline3D.update(flame as FlameDescriptor)
+        ifsPipeline3D.update(flame)
       } else if (ifsPipeline) {
-        ifsPipeline.update(
-          flame as FlameDescriptor,
-          props.blendFlame,
-          props.blendWeight,
-        )
+        ifsPipeline.update(flame, props.blendFlame, props.blendWeight)
       }
     })
 

--- a/packages/app/src/flame/randomize.ts
+++ b/packages/app/src/flame/randomize.ts
@@ -529,6 +529,16 @@ export function mutateFlame(
   const mutated = deepClone(flame)
   const transforms = mutated.transforms
 
+  // Randomize perturbs variation weights/params generically; the precise
+  // per-variation params unions can't express that, so within the loop we view
+  // each transform's variations through this loose shape. Values stay valid
+  // descriptors at runtime (mutated in place, or built via getVariationDefault).
+  type RandomVariation = {
+    type: string
+    weight: number
+    params?: Record<string, number>
+  }
+
   const pool =
     allowedVariations.length > 0
       ? allowedVariations
@@ -536,9 +546,7 @@ export function mutateFlame(
         ? [...variationTypes3D]
         : [...variationTypes]
 
-  for (const tid of Object.keys(transforms)) {
-    const t = transforms[tid]!
-
+  for (const [, t] of recordEntries(transforms)) {
     // 1. Mutate Affine
     if (options.mutateAffine) {
       const mutateOne = (affine: Record<string, number>) => {
@@ -559,8 +567,8 @@ export function mutateFlame(
           }
         }
       }
-      if (t.preAffine) mutateOne(t.preAffine as Record<string, number>)
-      if (t.postAffine) mutateOne(t.postAffine as Record<string, number>)
+      if (t.preAffine) mutateOne(t.preAffine)
+      if (t.postAffine) mutateOne(t.postAffine)
     }
 
     // 2. Mutate Colors
@@ -574,11 +582,10 @@ export function mutateFlame(
     // 3. Mutate Variations
     if (options.mutateVariations === 'modify') {
       if (t.variations) {
-        for (const vid of Object.keys(t.variations)) {
-          const v = t.variations[vid]!
-          const vtype = v.type as
-            | TransformVariationType
-            | TransformVariationType3D
+        const vars = t.variations as Record<string, RandomVariation>
+        for (const vid of Object.keys(vars)) {
+          const v = vars[vid]!
+          const vtype = v.type
           const is3D = isVariationType3D(vtype)
           const isParametric = is3D
             ? isParametricVariationType3D(vtype)
@@ -602,16 +609,10 @@ export function mutateFlame(
         }
       }
     } else if (options.mutateVariations === 'all') {
-      type VariationInstance = {
-        type: string
-        weight: number
-        params?: Record<string, number>
-      }
-      const varEntries = t.variations ? Object.entries(t.variations) : []
-      const currentVars = varEntries.map(([vid, v]) => ({
-        vid,
-        v: v as VariationInstance,
-      }))
+      // Record-level loose view (the VariationId→string key change makes this
+      // cast load-bearing, unlike a per-element widening that lint would strip).
+      const vars = (t.variations ?? {}) as Record<string, RandomVariation>
+      const currentVars = Object.entries(vars).map(([vid, v]) => ({ vid, v }))
 
       for (const item of currentVars) {
         const v = item.v
@@ -640,7 +641,7 @@ export function mutateFlame(
       )
       targetVarCount = Math.min(targetVarCount, pool.length)
 
-      const variations: Record<string, VariationInstance> = {}
+      const variations: Record<string, RandomVariation> = {}
 
       if (currentVars.length > targetVarCount) {
         const sorted = [...currentVars].sort((a, b) => b.v.weight - a.v.weight)
@@ -680,13 +681,13 @@ export function mutateFlame(
             const randomizedParams = randomizeVariationParams(vtype, strength)
             if (randomizedParams) {
               variations[vid] = {
-                ...(base as VariationInstance),
+                ...(base as RandomVariation),
                 params: randomizedParams,
               }
               continue
             }
           }
-          variations[vid] = base as VariationInstance
+          variations[vid] = base as RandomVariation
         }
       }
 
@@ -700,23 +701,22 @@ export function mutateFlame(
           variations[vid]!.weight = variations[vid]!.weight / totalWeight
         }
       }
-      t.variations = variations
+      // The 'all' path rebuilds the variation set dynamically (pick types,
+      // perturb params); the entries are valid descriptors at runtime but TS
+      // can't track the discriminated union through that construction.
+      t.variations = variations as typeof t.variations
     }
 
     if (options.mutateVariations !== 'none' && t.variations) {
-      type VariationInstance = {
-        type: string
-        weight: number
-        params?: Record<string, number>
-      }
-      const nextVarEntries = Object.entries(t.variations)
+      const vars = t.variations as Record<string, RandomVariation>
+      const nextVarEntries = Object.entries(vars)
       const totalWeight = nextVarEntries.reduce(
-        (sum, [, v]) => sum + (v as VariationInstance).weight,
+        (sum, [, v]) => sum + v.weight,
         0,
       )
       if (totalWeight > 0) {
-        for (const vid of Object.keys(t.variations)) {
-          const v = t.variations[vid] as VariationInstance
+        for (const vid of Object.keys(vars)) {
+          const v = vars[vid]!
           v.weight = v.weight / totalWeight
         }
       }

--- a/packages/app/src/flame/variations/parametric/types.ts
+++ b/packages/app/src/flame/variations/parametric/types.ts
@@ -5,9 +5,9 @@ import * as v from '@/valibot'
 import { VariationInfo } from '../simple/types'
 import type { TgpuFn } from 'typegpu'
 import type { BaseData, Infer, v2f, Vec2f, WgslStruct } from 'typegpu/data'
-import type { BooleanSchema, OptionalSchema } from 'valibot'
 import type { VariationCategory } from '../categories'
 import type { EditorFor } from '@/components/Sliders/ParametricEditors/types'
+import type { BooleanSchema, OptionalSchema } from '@/valibot'
 
 type ParametricVariationDescriptor<
   K extends string,

--- a/packages/app/src/flame/variations/parametric3D/types.ts
+++ b/packages/app/src/flame/variations/parametric3D/types.ts
@@ -5,9 +5,9 @@ import * as v from '@/valibot'
 import { VariationInfo3D } from '../simple3D/types'
 import type { TgpuFn } from 'typegpu'
 import type { BaseData, Infer, v3f, Vec3f, WgslStruct } from 'typegpu/data'
-import type { BooleanSchema, OptionalSchema } from 'valibot'
 import type { VariationCategory } from '../categories'
 import type { EditorFor } from '@/components/Sliders/ParametricEditors/types'
+import type { BooleanSchema, OptionalSchema } from '@/valibot'
 
 type ParametricVariation3DDescriptor<
   K extends string,

--- a/packages/app/src/flame/variations/simple/types.ts
+++ b/packages/app/src/flame/variations/simple/types.ts
@@ -4,9 +4,9 @@ import * as v from '@/valibot'
 import { AffineParams } from '../../affineTranform'
 import type { TgpuFn } from 'typegpu'
 import type { Infer, v2f, Vec2f } from 'typegpu/data'
-import type { BooleanSchema, OptionalSchema } from 'valibot'
 // Category union lives in ../categories (single source of truth, incl. 'custom').
 import type { VariationCategory } from '../categories'
+import type { BooleanSchema, OptionalSchema } from '@/valibot'
 
 export type VariationInfo = Infer<typeof VariationInfo>
 export const VariationInfo = struct({

--- a/packages/app/src/flame/variations/simple3D/types.ts
+++ b/packages/app/src/flame/variations/simple3D/types.ts
@@ -4,8 +4,8 @@ import * as v from '@/valibot'
 import { AffineParams3D } from '../../affineTransform3D'
 import type { TgpuFn } from 'typegpu'
 import type { Infer, v3f, Vec3f } from 'typegpu/data'
-import type { BooleanSchema, OptionalSchema } from 'valibot'
 import type { VariationCategory } from '../categories'
+import type { BooleanSchema, OptionalSchema } from '@/valibot'
 
 export type VariationInfo3D = Infer<typeof VariationInfo3D>
 export const VariationInfo3D = struct({

--- a/packages/app/src/flame/variations/utils.ts
+++ b/packages/app/src/flame/variations/utils.ts
@@ -3,7 +3,7 @@ import { defineExample, defineExample3D } from '../examples/util'
 import { generateTransformId, generateVariationId } from '../transformFunction'
 import { isParametricVariationType3D, isVariationType3D, transformVariations3D, } from '../variations3D'
 import { allTransformVariations, isParametricVariationType, transformVariations, } from '.'
-import type { FlameDescriptor } from '../schema/flameSchema'
+import type { FlameDescriptor, TransformId, VariationId, } from '../schema/flameSchema'
 import type { TransformVariationType3D } from '../variations3D'
 import type { TransformVariationDescriptor, TransformVariationType } from '.'
 import type { EditorFor } from '@/components/Sliders/ParametricEditors/types'
@@ -45,7 +45,11 @@ export function getVariationDefault(
 export function getParamsEditor<T extends { type: string; params?: unknown }>(
   variation: T,
 ): { component: EditorFor<T['params']>; value: T['params'] } {
-  const v = allTransformVariations[variation.type]
+  // Only parametric variations (the ones with params) carry an `editor`, which
+  // is exactly what this helper is called for; assert that shape.
+  const v = allTransformVariations[
+    variation.type as keyof typeof allTransformVariations
+  ] as { editor: EditorFor<T['params']> }
   return {
     component: v.editor,
     get value() {
@@ -57,13 +61,16 @@ export function getParamsEditor<T extends { type: string; params?: unknown }>(
 const transformPreviewIds = [
   ...Object.keys(transformVariations),
   ...Object.keys(transformVariations3D),
-].reduce<Record<string, { tid: string; vid: string }>>((acc, type) => {
-  acc[type] = {
-    tid: generateTransformId(type),
-    vid: generateVariationId(),
-  }
-  return acc
-}, {})
+].reduce<Record<string, { tid: TransformId; vid: VariationId }>>(
+  (acc, type) => {
+    acc[type] = {
+      tid: generateTransformId(type),
+      vid: generateVariationId(),
+    }
+    return acc
+  },
+  {},
+)
 export function getTransformPreviewTid(type: AnyVariationType) {
   if (!transformPreviewIds[type]) {
     transformPreviewIds[type] = {

--- a/packages/app/src/types/browser.d.ts
+++ b/packages/app/src/types/browser.d.ts
@@ -1,0 +1,22 @@
+// Ambient augmentations for non-standard browser APIs the app reads defensively
+// (all optional — guarded at every call site). Declaring them here replaces
+// scattered `(x as any).field` casts with typed, optional access.
+
+interface Navigator {
+  /** Device Memory API (Chromium-only). Approximate RAM in GiB, rounded. */
+  readonly deviceMemory?: number
+}
+
+interface Performance {
+  /** Non-standard Chrome heap statistics. */
+  readonly memory?: {
+    readonly jsHeapSizeLimit: number
+    readonly usedJSHeapSize: number
+    readonly totalJSHeapSize: number
+  }
+}
+
+interface GPUAdapterInfo {
+  /** Non-standard Chromium field: per-heap VRAM sizes (bytes). */
+  readonly memoryHeaps?: readonly { readonly size: number }[]
+}

--- a/packages/app/src/utils/animationExport.ts
+++ b/packages/app/src/utils/animationExport.ts
@@ -1,5 +1,6 @@
 import { DEBUG_MODE } from '@/defaults'
 import { accumulatedPointCount, forceAnimationExportNow, qualityPointCountLimit, setAnimationExportCancel, setAnimationExportProgress, setAnimationExportRunning, setExportQuality, setForceAnimationExportNow, } from '@/flame/renderStats'
+import { deepClone } from './clone'
 import { createMetadataPayload, injectMetadataIntoMp4 } from './flameInMp4'
 import { formatPointCount } from './formatPointCount'
 import { logTime } from './logTime'
@@ -7,7 +8,6 @@ import { applyTimelineToFlameAtFrame } from './timeline'
 import { createVideoEncoder } from './videoEncoder'
 import type { FlameDescriptor, TimelineState } from './timeline'
 import type { VideoEncoderConfig } from './videoEncoder'
-import type { FlameDescriptor as SchemaFlameDescriptor } from '@/flame/schema/flameSchema'
 
 const { performance } = globalThis
 
@@ -55,9 +55,7 @@ export function createAnimationExport(
 
   // Snapshot original flame state so we can restore it after export.
   // baseFlame is a reactive store proxy — deep-clone to a plain object.
-  const baseFlameSnapshot = JSON.parse(
-    JSON.stringify(baseFlame),
-  ) as FlameDescriptor
+  const baseFlameSnapshot = deepClone(baseFlame)
 
   const totalFrames = config.frameEnd - config.frameStart + 1
   const totalRenders = totalFrames * config.playCount
@@ -152,9 +150,7 @@ export function createAnimationExport(
         timeline.setCurrentFrame(frame)
 
         // Clone flame and apply timeline for this frame
-        const flameClone = JSON.parse(
-          JSON.stringify(baseFlame),
-        ) as FlameDescriptor
+        const flameClone = deepClone(baseFlame)
         applyTimelineToFlameAtFrame(timeline, flameClone, frame)
 
         // Set flame descriptor to the per-frame clone so Flam3 picks it up
@@ -164,7 +160,8 @@ export function createAnimationExport(
           // Apply transforms
 
           draft.transforms = flameClone.transforms
-          draft.edgeFadeColor = flameClone.edgeFadeColor
+          // edgeFadeColor lives under renderSettings (copied wholesale above);
+          // the old top-level copy was a dead no-op (issue #30 exposed it).
         })
 
         setExportQuality(config.quality)
@@ -264,7 +261,6 @@ export function createAnimationExport(
         setFlameDescriptor((draft) => {
           draft.renderSettings = baseFlameSnapshot.renderSettings
           draft.transforms = baseFlameSnapshot.transforms
-          draft.edgeFadeColor = baseFlameSnapshot.edgeFadeColor
           draft.metadata = baseFlameSnapshot.metadata
         })
       }
@@ -287,7 +283,7 @@ export function createAnimationExport(
           if (config.embedMetadata && !result.usedFallback) {
             const mp4Buffer = await result.blob.arrayBuffer()
             const payload = await createMetadataPayload(
-              baseFlame as SchemaFlameDescriptor,
+              baseFlame,
               timeline.tracks(),
               timeline.config(),
             )

--- a/packages/app/src/utils/exportJobs.ts
+++ b/packages/app/src/utils/exportJobs.ts
@@ -20,6 +20,10 @@ type JobResult = {
   /** Animation only: number of frames actually encoded (may be < total if the
    *  user used Stop & Save). */
   frames?: number
+  /** Animation only: PNG object URL of the first rendered frame, used as the
+   *  <video> poster so the tracker shows a real frame instead of a blank/green
+   *  undecoded video frame. */
+  posterUrl?: string
 }
 
 /** Everything needed to render one image export, snapshotted at enqueue time so
@@ -254,6 +258,7 @@ export function dismissJob(id: string) {
   const job = store.items.find((j) => j.id === id)
   if (job?.result) {
     URL.revokeObjectURL(job.result.blobUrl)
+    if (job.result.posterUrl) URL.revokeObjectURL(job.result.posterUrl)
   }
   setStore('items', (items) => items.filter((j) => j.id !== id))
 }

--- a/packages/app/src/utils/timeline.ts
+++ b/packages/app/src/utils/timeline.ts
@@ -16,9 +16,15 @@ export type EasingCurve =
   | 'elastic'
 
 import type { PointInitMode } from '@/flame/pointInitMode'
-import type { TransformRecord } from '@/flame/schema/flameSchema'
+import type { FlameDescriptor } from '@/flame/schema/flameSchema'
 
-export type { PointInitMode }
+// `FlameDescriptor` is the single source of truth in the schema (derived from
+// the valibot schema). Re-export it here so the timeline helpers and their
+// callers share one type that cannot drift from the schema — the previous
+// hand-written interface silently lagged the schema (missing plotsPerChain /
+// autoExposure3D*, and even put edgeFadeColor at the wrong nesting level),
+// which is exactly what made local and CI typecheck disagree (issue #30).
+export type { FlameDescriptor, PointInitMode }
 
 /**
  * Expandable mapping of variation types to their available parameters.
@@ -277,67 +283,6 @@ export function resolveVariationParameter(
   if (!keyframe) return null
 
   return keyframe.value as number
-}
-
-export interface FlameDescriptor {
-  renderSettings: {
-    exposure: number
-    skipIters: number
-    drawMode: 'light' | 'paint'
-    colorInitMode: 'colorInitZero' | 'colorInitPosition'
-    pointInitMode: PointInitMode
-    vibrancy: number
-    backgroundColor?: [number, number, number]
-    camera?: {
-      zoom: number
-      position: [number, number]
-      rotation?: number
-    }
-    palettePhase?: number
-    paletteSpeed?: number
-    paletteMode?: number
-    densityEstimationQuality?: number
-    estimatorCurve?: number
-    contrast?: number
-    gamma?: number
-    highlightPower: number
-    depthColorPower: number
-    lightPower: number
-    lightDirection?: [number, number, number]
-    camera3D?: {
-      theta: number
-      phi: number
-      radius: number
-      target: [number, number, number]
-      fov: number
-    }
-    dimensions?: number
-    plotsPerChain?: number
-    autoExposure3D?: boolean
-    autoExposure3DStrength?: number
-    autoExposure3DRefRadius?: number
-    autoExposure3DBase?: number
-  }
-  transforms: TransformRecord
-  finalTransform?: {
-    a: number
-    b: number
-    c: number
-    d: number
-    e: number
-    f: number
-    // 3D flames carry a 12-param (a–l) affine; optional so 2D stays a–f.
-    g?: number
-    h?: number
-    i?: number
-    j?: number
-    k?: number
-    l?: number
-  }
-  metadata: {
-    author: string
-  }
-  edgeFadeColor?: [number, number, number, number]
 }
 
 /** Segment interpolation mode (orthogonal to `easing`). See schema/timeline.ts. */
@@ -1471,34 +1416,34 @@ export function applyTracksToFlame(
   // Camera
   if (flame.renderSettings.camera?.position) {
     applyNumber('camera.x', (v) => {
-      flame.renderSettings.camera!.position[0] = v
+      flame.renderSettings.camera.position[0] = v
     })
     applyNumber('camera.y', (v) => {
-      flame.renderSettings.camera!.position[1] = v
+      flame.renderSettings.camera.position[1] = v
     })
   }
   if (flame.renderSettings.camera) {
     applyNumber('camera.zoom', (v) => {
-      flame.renderSettings.camera!.zoom = v
+      flame.renderSettings.camera.zoom = v
     })
     applyNumber('camera.rotation', (v) => {
-      flame.renderSettings.camera!.rotation = v
+      flame.renderSettings.camera.rotation = v
     })
   }
 
   // Camera3D
   if (flame.renderSettings.camera3D) {
     applyNumber('camera3D.theta', (v) => {
-      flame.renderSettings.camera3D!.theta = v
+      flame.renderSettings.camera3D.theta = v
     })
     applyNumber('camera3D.phi', (v) => {
-      flame.renderSettings.camera3D!.phi = v
+      flame.renderSettings.camera3D.phi = v
     })
     applyNumber('camera3D.radius', (v) => {
-      flame.renderSettings.camera3D!.radius = v
+      flame.renderSettings.camera3D.radius = v
     })
     applyNumber('camera3D.fov', (v) => {
-      flame.renderSettings.camera3D!.fov = v
+      flame.renderSettings.camera3D.fov = v
     })
   }
 
@@ -1574,8 +1519,20 @@ export function applyTracksToFlame(
     const track = trackMap.get('edgeFadeColor')
     if (track) {
       const value = resolveLoopValue(track.keyframes, frame, loop)
-      if (value !== null && Array.isArray(value) && value.length === 4) {
-        flame.edgeFadeColor = value
+      if (
+        value !== null &&
+        Array.isArray(value) &&
+        value.length === 4 &&
+        typeof value[0] === 'number' &&
+        typeof value[1] === 'number' &&
+        typeof value[2] === 'number' &&
+        typeof value[3] === 'number'
+      ) {
+        // Lives under renderSettings (the schema's canonical location). The old
+        // top-level `flame.edgeFadeColor` write was a dead prop the renderer
+        // never read, so the animated edge fade never applied (bug exposed once
+        // the typecheck stopped widening the flame type to `any` — issue #30).
+        flame.renderSettings.edgeFadeColor = value
       }
     }
   }
@@ -1730,7 +1687,10 @@ export function applyTimelineToFlame(
  * Applies timeline values to a flame descriptor for a specific frame number.
  */
 export function applyTimelineToFlameAtFrame(
-  timeline: TimelineState,
+  // Only the tracks/config getters are read here, so accept any object that
+  // supplies them (e.g. the lightweight stub the export-preview gallery builds)
+  // rather than forcing a full TimelineState and an `as any` cast at the call.
+  timeline: Pick<TimelineState, 'tracks' | 'config'>,
   flame: FlameDescriptor,
   frame: number,
 ): void {

--- a/packages/app/src/utils/transformOrder.ts
+++ b/packages/app/src/utils/transformOrder.ts
@@ -26,9 +26,9 @@ function displayIndex(tid: string): number {
  * in the order given (the flame's insertion order), so a freshly added transform
  * sorts to the end and a re-added (undone) one keeps its place.
  */
-export function sortedTransformEntries<V>(
-  entries: readonly [string, V][],
-): [string, V][] {
+export function sortedTransformEntries<K extends string, V>(
+  entries: readonly [K, V][],
+): [K, V][] {
   // Register any ids we haven't seen yet, in the given order, BEFORE sorting.
   for (const [tid] of entries) displayIndex(tid)
   return [...entries].sort(([a], [b]) => displayIndex(a) - displayIndex(b))

--- a/packages/app/src/valibot.ts
+++ b/packages/app/src/valibot.ts
@@ -24,9 +24,11 @@ export {
   variant,
 } from 'valibot'
 export type {
+  BooleanSchema,
   InferInput,
   InferOutput,
   LiteralSchema,
   NumberSchema,
   ObjectSchema,
+  OptionalSchema,
 } from 'valibot'

--- a/packages/app/tsconfig.json
+++ b/packages/app/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "allowJs": true,
-    "noImplicitAny": false,
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]

--- a/packages/app/tsconfig.json
+++ b/packages/app/tsconfig.json
@@ -7,5 +7,13 @@
     "paths": {
       "@/*": ["./src/*"]
     }
-  }
+  },
+  // Build output (dist) and e2e specs must never enter the typecheck program:
+  // with allowJs:true the default glob ingested the minified dist/*.js bundles
+  // (~4.6 MB), pushing tsc over a complexity threshold where it SILENTLY widens
+  // valibot's v.InferOutput<…> to `any`. That made local typecheck pass blind
+  // while CI (which typechecks before building, so no dist/) caught real errors
+  // — the root cause of issue #30. Specifying `exclude` overrides tsc's default,
+  // so node_modules must be listed explicitly. See docs/plans/typecheck-ci-parity-plan.md.
+  "exclude": ["dist", "e2e", "node_modules"]
 }


### PR DESCRIPTION
## Summary (v0.9.9)

Started as a fix for the long-standing **local `pnpm typecheck` passes while CI
fails on the same commit** problem, then built on the now-trustworthy typecheck
to tighten types and fix a batch of UI/export/animation issues surfaced by it and
by manual testing.

## Typecheck integrity & strictness

- **Root cause of local ≠ CI**: `packages/app/tsconfig.json` had no `exclude` +
  `allowJs: true`, so the default glob pulled the built `dist/` bundles (~4.6 MB
  of minified JS) into the program. That tips TypeScript over a complexity
  threshold where it **silently widens valibot's `v.InferOutput<…>` to `any`** —
  no error. CI type-checks **before** building (no `dist/`), so it resolved the
  types and caught real errors; locally a stale `dist/` went blind. Fixed by
  `exclude: ["dist","e2e","node_modules"]`. Full write-up + runnable repro in
  `docs/plans/typecheck-ci-parity-plan.md`.
- One source of truth for `FlameDescriptor` (deleted a drifted hand-written
  duplicate that even had `edgeFadeColor` at the wrong nesting).
- Typed ambient augmentation for non-standard browser APIs (replaces scattered
  `(x as any)` casts); all valibot imports routed through the `@/valibot`
  wrapper.
- Enabled strict **`noImplicitAny`** (real count was 90, not the ~2354 measured
  while valibot was poisoned; all fixed). The `no-unsafe-*` eslint rules stay off
  — re-enabling reports ~214 genuine `any` boundaries (dynamic keyframe paths,
  env/config, JSON, allowJs `.js`, test mocks); documented in the plan + eslint
  config.
- Dependency-free **pre-push hook** (`typecheck + lint + fmt`), auto-installed via
  the root `prepare` script, so local and CI stay in lockstep.

## UI / UX fixes

- **Mobile**: the timeline/dope-sheet resize handle now works on touch devices
  (it read a `--timeline-height-mobile` var nothing wrote).
- The dope-sheet **Curve** and **Seek** toggles reflect their state on tap.
- **Variation browser** large preview renders at full quality on high/ultra GPUs
  (was ~100× throttled → noisy/over-bright/jerky), and selecting a variation no
  longer over-brightens the preview (it kept copying the thumbnail's tuned-bright
  exposure into the flame).

## Animation

- **Export fixes**: 2D exports no longer report `0 / 0 pts`; the finished-export
  thumbnail shows the real first frame instead of a blank/green `<video>`.
- Animated **edge-fade colour** now actually applies (track wrote to a dead
  top-level field).
- **Smart Animate**: one-click generator that combines a curated preset from each
  category (camera/render/color/affine) into a full loop, alongside the existing
  selected-items Randomize Animation.
- **Clear existing keyframes first** toggle for the animation randomizer (on by
  default; turn off to layer).

## Release

- Bumped to **0.9.9** with a changelog entry.

## Verification

`pnpm typecheck` (strict) + `pnpm lint` + `pnpm fmt` clean; **246** unit tests
pass. Mobile / export / variation-browser / animation changes verified manually.
