### PR TITLE
Timeline UX batch: playhead desync fix, one-row header, track selection, curve value zoom, live drag keyframing (0.9.6)

### DIFF
--- a/packages/app/CHANGELOG.md
+++ b/packages/app/CHANGELOG.md
@@ -47,48 +47,73 @@ developer history lives in `dev.changelog.md`.
 
 ### Fixed
 
-- **Undo now reverts your last action — whatever it was.** The app kept two separate undo histories (flame edits and timeline keyframes); Ctrl+Z used to unwind every keyframe change before any flame edit became reachable, while the toolbar Undo button only ever touched flame edits. Both now share one chronological order, the buttons match Ctrl+Z exactly, and their enabled state reflects everything undoable. Redo replays in the order things happened, and making a new edit after undoing clears redo everywhere.
-- **Undoing "New transform", "Add variation", and "Add symmetry" works.** A long-standing engine bug ran the change twice under the hood, so undo silently did nothing and redo duplicated the transform. Dice rolls also redo to exactly the values you saw.
-- **One action = one undo step.** Randomize/Smart animation, the Colors generator, and animation presets used to record one undo entry per keyframe (dozens per click); value scrubs, the camera orientation gizmo, and 3D wheel-zoom recorded one per pointer-move. All are now single steps.
-- **Undo no longer leaks across flames.** Loading a flame, starting a new one, or switching 2D/3D previously kept the old flame's keyframe history alive — Ctrl+Z could dump a previous flame's animation tracks onto the new one.
-- **Ctrl+Z while typing in number or search fields** (timeline FPS/frames, export size, variation search) now edits the text as expected instead of triggering an app undo behind your back.
-- Exporting an animation no longer floods undo history with one entry per rendered frame, and 3D auto-exposure no longer fights undo after camera zooms.
-- **Keyframe undos are visible**: undoing a keyframe edit now updates the rendered flame immediately (previously the canvas could keep the old value until you played the timeline).
-- **Timeline settings are undoable** — FPS, frame count, speed, loop and loop style (including Seamless quietly extending the timeline) all revert with Ctrl+Z.
-- **Palettes and blends are part of your flame now**: applying/removing a palette and picking/adjusting/clearing a blend flame are all undoable, and both survive saving, sharing, and loading.
-- **Deleting a custom variation is safe(r)**: the app warns when the current flame uses it, and every delete shows an Undo toast that brings the variation back.
+- **Undo/redo overhaul.** Ctrl+Z now reverts your last action — whatever it
+  was. Flame edits and timeline keyframes used to live in two separate
+  histories that undid out of order; they now share one chronological order,
+  and the toolbar buttons match the shortcuts.
+- **Undo covers what it used to miss**: "New transform", "Add variation",
+  "Add symmetry" and dice rolls revert correctly; timeline settings (FPS,
+  frames, speed, loop style) are undoable; and keyframe undos update the
+  rendered flame immediately.
+- **One action = one undo step.** Generators, presets, value scrubs, camera
+  drags and animation exports no longer flood the history with dozens of
+  entries per click or drag.
+- **Undo stays inside your flame.** Loading or starting a new flame can no
+  longer resurrect the previous flame's keyframes, and Ctrl+Z while typing in
+  number/search fields edits the text instead of undoing the app.
+- **Palettes and blends are part of your flame now**: applying or removing
+  them is undoable, and both survive saving, sharing, and loading.
+- **Deleting a custom variation is safe(r)**: the app warns when the current
+  flame still uses it, and an Undo toast brings it back.
 
 ## [0.9.4] - 2026-07-02
 
 ### Added
 
-- **Track changes diamond.** A shiny diamond on the affine editor and color wheel (and in their list views): while it's on, every edit records a keyframe at the current frame — dragging a transform handle, scaling/rotating, scrubbing a value, typing a number, or rolling a dice. Unlike the timeline's Auto mode it also creates the _first_ keyframe, so animating is just: turn on the diamond, move things, step frames, move again.
-- **New Flame button** in the floating actions bar: one click resets to a clean starter flame (2D or 3D, matching your mode). No confirmation needed — undo brings the previous flame back, and unsaved work (including its animation) is stashed into Recent flames first.
-- **Animate button** in the timeline header opens the sidebar's animation generator (Flame Randomizer → Animation Settings) and scrolls straight to it — replacing the old one-shot "Gen" randomizer and its "Subtle" toggle.
-- **Your work is never silently lost.** Closing or reloading the tab with unsaved changes now saves the flame (with its animation) into Recent flames automatically — no prompt. Optional periodic auto-save (asked once via a small toast; configurable under Data Management: on/off + 1/2/5/10 min) keeps one auto-updating entry per editing session. Loading another flame, switching 2D/3D, or starting a new flame stashes unsaved work first. A one-time reminder after a few minutes of editing points to save/export/share, with a "Don't show again".
-- **3D variation browser** now shows the same Affine Editor panel the 2D browser has, so you can position a variation's transform while previewing it.
+- **Track changes diamond** on the affine editor and color wheel: while it's
+  on, every edit — handle drags, scrubs, typed values, dice rolls — records a
+  keyframe at the current frame, including the _first_ one (unlike Auto mode).
+  Animating becomes: turn on the diamond, move things, step frames, repeat.
+- **New Flame button**: one click resets to a clean 2D/3D starter. Undo brings
+  the old flame back, and unsaved work is stashed into Recent flames first.
+- **Animate button** in the timeline header jumps straight to the sidebar's
+  animation generator — replacing the old one-shot "Gen" randomizer.
+- **Your work is never silently lost.** Closing or reloading the tab
+  auto-saves unsaved changes (with their animation) to Recent flames, with
+  optional periodic auto-save (configurable under Data Management) and a
+  one-time save/export reminder.
+- **3D variation browser** now shows the same Affine Editor panel as 2D.
 
 ### Changed
 
-- **The selected transform always renders on top.** Overlapping handles used to hide the selected transform behind later-added ones; the selected handle now paints above the stack and receives the click. Scale/rotate edges also always paint _below_ center dots, so one transform's edges can no longer cover another's grab point.
+- **The selected transform always renders on top** — and receives the click —
+  even in a stack of overlapping handles.
 
 ### Fixed
 
-- Clicking stacked transform handles (e.g. several at the origin) now selects and moves the **selected/targeted** transform instead of whichever was added last.
-- Recording keyframes while scrubbing no longer floods the timeline's undo history — one undo reverts the whole scrub, and the history is bounded.
-- Auto/track-changes recording only happens while animation mode is on — no invisible "ghost" keyframes after leaving animation mode.
+- Recording keyframes while scrubbing no longer floods the timeline's undo
+  history, and Auto/track-changes recording stops once animation mode is off
+  (no more invisible "ghost" keyframes).
 
 ## [0.9.3] - 2026-06-27
 
 ### Added
 
-- **Graceful WebGPU fallback.** If WebGPU isn't available — an unsupported browser, or a GPU driver that crashes mid-session — the app stays usable instead of going blank or freezing. Every fractal preview shows a clear "WebGPU preview unavailable" placeholder with a link to check your browser/device support, while the rest of the studio (sidebar, About, Help, docs, settings) keeps working.
+- **Graceful WebGPU fallback.** If WebGPU is unavailable or the GPU crashes
+  mid-session, the app stays usable instead of going blank: previews show a
+  clear placeholder with a support link, and the rest of the studio keeps
+  working.
 
 ### Fixed
 
-- **The variation gallery no longer runs out of GPU memory while scrolling.** Live previews are now bounded and freed as they scroll off-screen, thumbnail detail is capped to a sane level, a per-preview GPU buffer leak is fixed, and each variation's shader is compiled once instead of repeatedly — together cutting a large gallery from ~1.6 GB of GPU memory to a few hundred MB and removing the "Out of memory" crash (notably on Firefox / Linux / AMD).
-- **Firefox: the variation-picker gallery no longer squeezes, collapses, or hides tiles behind the scrollbar.** Preview tiles use a fixed 16:9 aspect ratio with a height floor — so even a GPU device-loss reflow can't collapse them into a pile of overlapping labels — and both galleries reserve their scrollbar gutter so tiles never slide under the Firefox scrollbar.
-- On a GPU device loss, render loops now stop immediately (no console error flood), and the app falls back to the usable shell within a few seconds instead of hanging when a reload can't re-acquire the GPU.
+- **The variation gallery no longer runs out of GPU memory while scrolling.**
+  Live previews are bounded and freed off-screen, cutting a large gallery from
+  ~1.6 GB of GPU memory to a few hundred MB and removing the "Out of memory"
+  crash (notably on Firefox / Linux / AMD).
+- **Firefox gallery layout**: tiles no longer squeeze, collapse, or hide
+  behind the scrollbar.
+- On a GPU device loss, render loops stop cleanly and the app falls back to
+  the usable shell within a few seconds instead of hanging.
 
 ## [0.9.2] - 2026-06-26
 

--- a/packages/app/CHANGELOG.md
+++ b/packages/app/CHANGELOG.md
@@ -3,6 +3,44 @@
 What's new in Chaos Master. Concise highlights for each release; the full
 developer history lives in `dev.changelog.md`.
 
+## [0.9.6] - 2026-07-03
+
+### Added
+
+- **Curve editor: Ctrl+wheel zooms the value axis** around the cursor, so
+  nudging a diamond precisely up/down no longer means fighting a cramped
+  auto-fitted range. The zoomed range sticks, just like after a drag.
+
+### Changed
+
+- **One-row timeline header.** The dope sheet's separate zoom toolbar is gone;
+  its controls (zoom −/%/+, Fit, Seek, Curve) moved up into the timeline
+  header, organized into labeled clusters — playback, settings, View, Keys —
+  with clearer tooltips on every button. The keyframe inspector row now
+  appears only while a keyframe is selected. Net effect: the timeline spends
+  its height on your tracks, and every control says what it does.
+
+### Fixed
+
+- **The ruler arrowhead and the playhead line can no longer drift apart.**
+  Resizing the timeline panel (drag handle or Ctrl+wheel) rescales the frame
+  ruler; the ruler and the track lanes are separate scroll panes and could
+  clamp their scroll positions differently, leaving the arrow on a different
+  frame than the red line below (clicking Fit was the workaround). Both panes
+  are now re-anchored to the same scroll offset on every scale change. Also
+  fixed a narrow-screen mismatch where the track-name column shrank but the
+  ruler and playhead math didn't, shifting diamonds off the ruler's frame axis
+  on tablets/phones.
+- **Transform and color handle drags animate live.** With the track-changes
+  diamond (or Auto mode) on while viewing a timeline frame, dragging an affine
+  handle or a color-wheel dot used to freeze the fractal until ~0.3 s after
+  release, then jump to the end state — the keyframe was only written on a
+  drag-end debounce. Drags now record the keyframe continuously (still one
+  undo step per drag), so the IFS follows your pointer and what you see is
+  exactly what's keyframed. Auto mode now re-records affine/color drags on
+  already-animated parameters, matching the sliders, and the final transform's
+  handle participates in change tracking too.
+
 ## [0.9.5] - 2026-07-02
 
 ### Fixed

--- a/packages/app/CHANGELOG.md
+++ b/packages/app/CHANGELOG.md
@@ -17,8 +17,10 @@ developer history lives in `dev.changelog.md`.
   its controls (zoom −/%/+, Fit, Seek, Curve) moved up into the timeline
   header, organized into labeled clusters — playback, settings, View, Keys —
   with clearer tooltips on every button. The keyframe inspector row now
-  appears only while a keyframe is selected. Net effect: the timeline spends
-  its height on your tracks, and every control says what it does.
+  appears only while a keyframe is selected, and the dope sheet sits flush
+  with the header — no more rounded floating-card border or side inset. Net
+  effect: the timeline spends its height on your tracks, and every control
+  says what it does.
 
 ### Fixed
 

--- a/packages/app/CHANGELOG.md
+++ b/packages/app/CHANGELOG.md
@@ -7,41 +7,30 @@ developer history lives in `dev.changelog.md`.
 
 ### Added
 
-- **Curve editor: Ctrl+wheel zooms the value axis** around the cursor, so
-  nudging a diamond precisely up/down no longer means fighting a cramped
-  auto-fitted range. The zoomed range sticks, just like after a drag.
+- **Curve editor: Ctrl+wheel zooms the value axis** around the cursor, for
+  precise vertical keyframe moves. The zoomed range sticks, like after a drag.
+- **Click a track to select it.** Clicking a lane or its name highlights the
+  track, points the curve editor (when open) at it, and aims keyboard inserts
+  (I) at it — no need to hunt for a keyframe diamond.
 
 ### Changed
 
-- **One-row timeline header.** The dope sheet's separate zoom toolbar is gone;
-  its controls (zoom −/%/+, Fit, Seek, Curve) moved up into the timeline
-  header, organized into labeled clusters — playback, settings, View, Keys —
-  with clearer tooltips on every button. The keyframe inspector row now
-  appears only while a keyframe is selected, and the dope sheet sits flush
-  with the header — no more rounded floating-card border or side inset. Net
-  effect: the timeline spends its height on your tracks, and every control
-  says what it does.
+- **One-row timeline header.** Zoom −/%/+, Fit, Seek and Curve moved up into
+  the header, grouped into labeled clusters (playback, settings, View, Keys)
+  with clearer tooltips. The keyframe inspector appears only while a keyframe
+  is selected, and the dope sheet sits flush with the header — more height for
+  your tracks.
 
 ### Fixed
 
-- **The ruler arrowhead and the playhead line can no longer drift apart.**
-  Resizing the timeline panel (drag handle or Ctrl+wheel) rescales the frame
-  ruler; the ruler and the track lanes are separate scroll panes and could
-  clamp their scroll positions differently, leaving the arrow on a different
-  frame than the red line below (clicking Fit was the workaround). Both panes
-  are now re-anchored to the same scroll offset on every scale change. Also
-  fixed a narrow-screen mismatch where the track-name column shrank but the
-  ruler and playhead math didn't, shifting diamonds off the ruler's frame axis
-  on tablets/phones.
-- **Transform and color handle drags animate live.** With the track-changes
-  diamond (or Auto mode) on while viewing a timeline frame, dragging an affine
-  handle or a color-wheel dot used to freeze the fractal until ~0.3 s after
-  release, then jump to the end state — the keyframe was only written on a
-  drag-end debounce. Drags now record the keyframe continuously (still one
-  undo step per drag), so the IFS follows your pointer and what you see is
-  exactly what's keyframed. Auto mode now re-records affine/color drags on
-  already-animated parameters, matching the sliders, and the final transform's
-  handle participates in change tracking too.
+- **The ruler arrowhead and the playhead line can no longer drift apart**
+  after resizing or zooming the timeline — both panes stay locked to the same
+  scroll offset (clicking Fit was the old workaround). Also fixed diamonds
+  sitting off the ruler's frame axis on narrow screens.
+- **Transform and color handle drags animate live.** With track-changes (or
+  Auto mode) on while viewing a timeline frame, drags used to freeze the
+  fractal until ~0.3 s after release; keyframes now record continuously during
+  the drag (still one undo step), so the IFS follows your pointer.
 
 ## [0.9.5] - 2026-07-02
 

--- a/packages/app/dev.changelog.md
+++ b/packages/app/dev.changelog.md
@@ -20,6 +20,21 @@ curve value-axis zoom, and live keyframing for affine/color handle drags.
   clamped to [1e-6, 1e9]). `stopPropagation` keeps the workspace's Ctrl+wheel
   panel-resize from firing on the same gesture; Alt+wheel (frame zoom) and
   plain wheel (scroll) are untouched.
+- **Track selection** (`DopeSheet.tsx`): a `selectedTrack` signal lives
+  alongside `selectedKeyframe` — lane/name clicks select the track only
+  (clearing the keyframe selection, so the inspector stays hidden), diamond
+  clicks select both, and `lastAddedKeyframe`/keyframe drags keep them in
+  sync. The curve editor graphs `selectedTrack` (its selected-node highlight
+  still keys off `selectedKeyframe`), and the keyboard-target effect
+  (`setTargetedParameter`/`setSelectedKeyframePath`) follows the track, so a
+  lane click aims the I-insert shortcut. A guard effect drops selections
+  whose track was removed (context-menu delete, orphan cleanup, flame load).
+  The current row is styled via `.trackRowSelected` (accent inset bar +
+  tinted name + row wash, overriding the even-row/hover backgrounds).
+- **About-panel changelog parser** (`Changelog.tsx`) folds hard-wrapped
+  bullet continuation lines into the previous item — it used to keep only
+  the first line of each `- ` bullet. The user-facing 0.9.3–0.9.5 entries
+  were also condensed to outcome-level highlights; the detail lives here.
 
 ### Changed
 
@@ -35,9 +50,9 @@ curve value-axis zoom, and live keyframing for affine/color handle drags.
   collapsed timeline hides the View group. `KeyframeInspector` renders only
   while a keyframe is selected instead of holding an empty 32px placeholder
   row. The dope sheet container lost its floating-card chrome (8px top radius
-  - 1px border) and the `.content` wrapper its 4px inset, so the sheet joins
-    the header seamlessly and spans the panel edge-to-edge. All
-    `data-testid`/`data-tour-target` hooks preserved.
+  and 1px border) and the `.content` wrapper its 4px inset, so the sheet
+  joins the header seamlessly and spans the panel edge-to-edge. All
+  `data-testid`/`data-tour-target` hooks preserved.
 - **Affine/color drags keyframe per pointer-move** (`AffineEditor.tsx`,
   `FlameColorEditor.tsx`): handle drags now call `keyframeEditedParams` after
   every `setTransform`/`setColor` — the same contract as the sliders (Auto
@@ -60,9 +75,10 @@ curve value-axis zoom, and live keyframing for affine/color handle drags.
   handle driving `containerHeight`) let the browser clamp each `scrollLeft`
   independently — shifting the ruler arrowhead off the tracks playhead until a
   Fit/zoom-out reset both. A new effect re-anchors on every `frameWidth`
-  change: the frame at the lane's left edge is kept stable (`scrollLeft *
-ratio`) and the same value — clamped to the smaller of the two scroll
-  ranges — is written to both panes; the ruler wrapper's own scroll is pinned
+  change: the frame at the lane's left edge is kept stable (scrollLeft scales
+  by the width ratio) and the same value — clamped to the smaller of the two
+  scroll ranges — is written to both panes; the ruler wrapper's own scroll is
+  pinned
   to 0. `useScrollSync` swaps its broken re-entrancy flag (programmatic
   scrolls fire their events asynchronously, so the flag never covered the
   echo) for idempotent value-guarded writes.
@@ -73,6 +89,8 @@ ratio`) and the same value — clamped to the smaller of the two scroll
   the ruler's frame axis on tablets. The width is now a single reactive
   `matchMedia` signal consumed by the cells and all offset math; the CSS
   media-query width overrides are gone.
+
+## [0.9.5] - 2026-07-02
 
 Undo/redo overhaul, driven by a full audit of both undo systems (flame
 change-history + timeline snapshots). Each area landed as its own commit with

--- a/packages/app/dev.changelog.md
+++ b/packages/app/dev.changelog.md
@@ -7,7 +7,69 @@ changelog surfaced in the About panel lives in `CHANGELOG.md`.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.9.5] - 2026-07-02
+## [0.9.6] - 2026-07-03
+
+Timeline UX batch: playhead/ruler desync fix, single-row grouped header,
+curve value-axis zoom, and live keyframing for affine/color handle drags.
+
+### Added
+
+- **Curve editor value-axis zoom** (`CurveEditor.tsx`): a non-passive `wheel`
+  listener on the curve lane handles Ctrl/Cmd+wheel by rescaling the sticky
+  value range around the value under the cursor (`span * exp(deltaY * 0.002)`,
+  clamped to [1e-6, 1e9]). `stopPropagation` keeps the workspace's Ctrl+wheel
+  panel-resize from firing on the same gesture; Alt+wheel (frame zoom) and
+  plain wheel (scroll) are untouched.
+
+### Changed
+
+- **Single-row timeline header** (`TimelineSection.tsx` + module CSS): the
+  dope sheet's zoom toolbar row is dissolved into the header, which now reads
+  as bordered "aisles" — playback (transport + frame counter), settings
+  (FPS/frames/speed/loop), View (zoom −/%/+, Fit, Seek, Curve; labeled), and
+  Keys (Auto, Del; labeled) — via new `.headerGroup`/`.headerGroupLabel`/
+  `.viewBtn` styles (labels hidden ≤480px). `seekOnSelect`/`showCurve` state
+  lifted from `DopeSheet` to `TimelineSection` (same persisted key); the zoom
+  controls stay in `DopeSheet` (they need its refs) and are exposed upward via
+  a `registerViewApi` callback (`DopeSheetViewApi`), cleared on unmount so a
+  collapsed timeline hides the View group. `KeyframeInspector` renders only
+  while a keyframe is selected instead of holding an empty 32px placeholder
+  row. All `data-testid`/`data-tour-target` hooks preserved.
+- **Affine/color drags keyframe per pointer-move** (`AffineEditor.tsx`,
+  `FlameColorEditor.tsx`): handle drags now call `keyframeEditedParams` after
+  every `setTransform`/`setColor` — the same contract as the sliders (Auto
+  re-records animated params; the track-changes diamond records anything,
+  creating first keyframes) — with `breakUndoCoalescing()` on gesture end so a
+  whole drag stays one timeline-undo step. The drag-end
+  `createGestureKeyframer` (300 ms debounce) is removed from
+  `keyframeOnChange.ts` along with both call sites. The final-transform handle
+  now passes `keyframePathBase="finalTransform"` so it participates too.
+  Rationale: while the timeline holds a frame (`isDrivingView`),
+  `applyTimelineToFlame` overrides tracked params every render — deferring the
+  keyframe write to a drag-end debounce froze the rendered IFS for the whole
+  drag, then snapped it to the end state.
+
+### Fixed
+
+- **Ruler/tracks playhead desync on panel resize** (`useZoomGestures.ts`): the
+  seek-ruler lane and the tracks area are separate horizontal scrollers, and
+  any `frameWidth` change (zoom buttons, Alt+wheel, pinch, or the panel resize
+  handle driving `containerHeight`) let the browser clamp each `scrollLeft`
+  independently — shifting the ruler arrowhead off the tracks playhead until a
+  Fit/zoom-out reset both. A new effect re-anchors on every `frameWidth`
+  change: the frame at the lane's left edge is kept stable (`scrollLeft *
+ratio`) and the same value — clamped to the smaller of the two scroll
+  ranges — is written to both panes; the ruler wrapper's own scroll is pinned
+  to 0. `useScrollSync` swaps its broken re-entrancy flag (programmatic
+  scrolls fire their events asynchronously, so the flag never covered the
+  echo) for idempotent value-guarded writes.
+- **Responsive track-name column no longer skews alignment**
+  (`useTrackNameWidth.ts`): CSS shrank `.trackName` to 100px/80px under
+  768px/480px while every JS offset (ruler spacer, tracks-playhead `left`,
+  curve gutter, auto-fit math) used the 130px constant, shifting diamonds off
+  the ruler's frame axis on tablets. The width is now a single reactive
+  `matchMedia` signal consumed by the cells and all offset math; the CSS
+  media-query width overrides are gone.
 
 Undo/redo overhaul, driven by a full audit of both undo systems (flame
 change-history + timeline snapshots). Each area landed as its own commit with

--- a/packages/app/dev.changelog.md
+++ b/packages/app/dev.changelog.md
@@ -34,7 +34,10 @@ curve value-axis zoom, and live keyframing for affine/color handle drags.
   a `registerViewApi` callback (`DopeSheetViewApi`), cleared on unmount so a
   collapsed timeline hides the View group. `KeyframeInspector` renders only
   while a keyframe is selected instead of holding an empty 32px placeholder
-  row. All `data-testid`/`data-tour-target` hooks preserved.
+  row. The dope sheet container lost its floating-card chrome (8px top radius
+  - 1px border) and the `.content` wrapper its 4px inset, so the sheet joins
+    the header seamlessly and spans the panel edge-to-edge. All
+    `data-testid`/`data-tour-target` hooks preserved.
 - **Affine/color drags keyframe per pointer-move** (`AffineEditor.tsx`,
   `FlameColorEditor.tsx`): handle drags now call `keyframeEditedParams` after
   every `setTransform`/`setColor` — the same contract as the sliders (Auto

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chaos-master",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "description": "WebGPU based IFS Flame Generator for Artists & Explorers",
   "type": "module",
   "scripts": {

--- a/packages/app/src/components/AboutPanel/Changelog.tsx
+++ b/packages/app/src/components/AboutPanel/Changelog.tsx
@@ -51,6 +51,11 @@ async function fetchChangelog(): Promise<ChangelogEntry[]> {
         const itemMatch = line.match(/^- (.*)/)
         if (itemMatch) {
           currentSection.items.push(itemMatch[1]!)
+        } else if (currentSection.items.length > 0 && line.trim() !== '') {
+          // Hard-wrapped bullet: fold the continuation line into the previous
+          // item, otherwise everything after the first line is silently lost.
+          currentSection.items[currentSection.items.length - 1] +=
+            ` ${line.trim()}`
         }
       }
     }

--- a/packages/app/src/components/AffineEditor/AffineEditor.tsx
+++ b/packages/app/src/components/AffineEditor/AffineEditor.tsx
@@ -19,7 +19,7 @@ import { createPosition, createZoom, WheelZoomCamera2D, } from '@/lib/WheelZoomC
 import { createAnimationFrame } from '@/utils/createAnimationFrame'
 import { createDragHandler } from '@/utils/createDragHandler'
 import { eventToClip } from '@/utils/eventToClip'
-import { createGestureKeyframer } from '@/utils/keyframeOnChange'
+import { keyframeEditedParams } from '@/utils/keyframeOnChange'
 import { scrollIntoViewAndFocusOnChange } from '@/utils/scrollIntoViewOnChange'
 import { createSelectedLastEntries } from '@/utils/selectedLastEntries'
 import { useIntersectionObserver } from '@/utils/useIntersectionObserver'
@@ -195,8 +195,9 @@ function AffineHandle(props: {
   hidden?: boolean
   onSelect?: () => void
   onDeselect?: () => void
-  /** Timeline path prefix (e.g. `transform.{tid}.preAffine`); when set and the
-   *  track-changes diamond is on, finished drags keyframe the touched coefs. */
+  /** Timeline path prefix (e.g. `transform.{tid}.preAffine`); when set, drags
+   *  keyframe the touched coefs live (track-changes diamond, or Auto mode on
+   *  already-animated coefs). */
   keyframePathBase?: string
   /** Which layer to render: the scale/rotate 'box' or the 'center' dot.
    *  AffineEditor renders each transform twice so ALL boxes paint below ALL
@@ -213,14 +214,22 @@ function AffineHandle(props: {
   const changeHistory = useChangeHistory()
   const timeline = useTimeline()
 
-  // Track-changes: after a drag gesture ends, keyframe the coefs it touches
-  // at the current frame (debounced; full paths captured per gesture so a
-  // pre/post mode switch between gestures can't mislabel earlier coefs).
-  const keyframeGesture = createGestureKeyframer(timeline)
-  const scheduleGestureKeyframes = (coefs: readonly string[]) => {
+  // Keyframe the coefs a drag touches on EVERY pointer move (same contract as
+  // the sliders): with the track-changes diamond on — or Auto mode on and the
+  // coefs already animated — the keyframe at the current frame is rewritten
+  // live, so a held/scrubbed frame renders the drag as it happens instead of
+  // freezing until a drag-end debounce lands. Per-move writes coalesce into
+  // one undo step; recordGestureEnd closes that step when the drag finishes.
+  const keyframeDraggedCoefs = (coefs: readonly string[]) => {
     const base = props.keyframePathBase
     if (!base) return
-    keyframeGesture(coefs.map((coef) => `${base}.${coef}`))
+    keyframeEditedParams(
+      timeline,
+      coefs.map((coef) => `${base}.${coef}`),
+    )
+  }
+  const recordGestureEnd = () => {
+    timeline?.breakUndoCoalescing()
   }
 
   const handleScale = () => Math.max(1, Math.sqrt(zoom()))
@@ -274,10 +283,11 @@ function AffineHandle(props: {
           c: position.x,
           f: position.y,
         })
+        keyframeDraggedCoefs(['c', 'f'])
       },
       onDone() {
         changeHistory.commit()
-        scheduleGestureKeyframes(['c', 'f'])
+        recordGestureEnd()
       },
     }
   })
@@ -314,6 +324,7 @@ function AffineHandle(props: {
           d: yFactor === 0 ? d : (d * cos + e * sin) * ratio * yFactor,
           e: yFactor === 0 ? e : (-d * sin + e * cos) * ratio * yFactor,
         })
+        keyframeDraggedCoefs(['a', 'b', 'd', 'e'])
       }
 
       // immediately respond, as -1 factors are used for flipping axes
@@ -324,7 +335,7 @@ function AffineHandle(props: {
         onPointerMove,
         onDone() {
           changeHistory.commit()
-          scheduleGestureKeyframes(['a', 'b', 'd', 'e'])
+          recordGestureEnd()
         },
       }
     })
@@ -463,10 +474,11 @@ function AffineHandle(props: {
           d: (initialTransform.d ?? 0) + diff.x,
           h: (initialTransform.h ?? 0) + diff.y,
         })
+        keyframeDraggedCoefs(['d', 'h'])
       },
       onDone() {
         changeHistory.commit()
-        scheduleGestureKeyframes(['d', 'h'])
+        recordGestureEnd()
       },
     }
   })
@@ -523,6 +535,13 @@ function AffineHandle(props: {
             k: k * ratio * factor,
           })
         }
+        keyframeDraggedCoefs(
+          axis === 'X'
+            ? ['a', 'e', 'i']
+            : axis === 'Y'
+              ? ['b', 'f', 'j']
+              : ['c', 'g', 'k'],
+        )
       }
 
       onPointerMove(initEvent)
@@ -531,13 +550,7 @@ function AffineHandle(props: {
         onPointerMove,
         onDone() {
           changeHistory.commit()
-          scheduleGestureKeyframes(
-            axis === 'X'
-              ? ['a', 'e', 'i']
-              : axis === 'Y'
-                ? ['b', 'f', 'j']
-                : ['c', 'g', 'k'],
-          )
+          recordGestureEnd()
         },
       }
     })
@@ -992,6 +1005,9 @@ export function AffineEditor(props: {
                     props.setFinalTransform?.(affine)
                   }}
                   is3D={props.is3D}
+                  keyframePathBase={
+                    props.enableChangeTracking ? 'finalTransform' : undefined
+                  }
                 />
               </Show>
             </svg>

--- a/packages/app/src/components/FlameColorEditor/FlameColorEditor.tsx
+++ b/packages/app/src/components/FlameColorEditor/FlameColorEditor.tsx
@@ -17,7 +17,7 @@ import { createPosition, createZoom, WheelZoomCamera2D, } from '@/lib/WheelZoomC
 import { createAnimationFrame } from '@/utils/createAnimationFrame'
 import { createDragHandler } from '@/utils/createDragHandler'
 import { eventToClip } from '@/utils/eventToClip'
-import { createGestureKeyframer } from '@/utils/keyframeOnChange'
+import { keyframeEditedParams } from '@/utils/keyframeOnChange'
 import { scrollIntoViewAndFocusOnChange } from '@/utils/scrollIntoViewOnChange'
 import { createSelectedLastEntries } from '@/utils/selectedLastEntries'
 import { useIntersectionObserver } from '@/utils/useIntersectionObserver'
@@ -149,8 +149,9 @@ function FlameColorHandle(props: {
   hidden?: boolean
   onSelect?: () => void
   onDeselect?: () => void
-  /** Timeline path prefix (`transform.{tid}.color`); when set and the
-   *  track-changes diamond is on, finished drags keyframe x/y. */
+  /** Timeline path prefix (`transform.{tid}.color`); when set, drags keyframe
+   *  x/y live (track-changes diamond, or Auto mode on already-animated
+   *  colours). */
   keyframePathBase?: string
 }) {
   const { theme } = useTheme()
@@ -162,12 +163,14 @@ function FlameColorHandle(props: {
   const changeHistory = useChangeHistory()
   const timeline = useTimeline()
 
-  // Track-changes: keyframe the colour after a finished drag (debounced so
-  // successive nudges land as one write, values read at flush time).
-  const keyframeGesture = createGestureKeyframer(timeline)
-  const scheduleColorKeyframes = () => {
+  // Keyframe the colour on EVERY pointer move (same contract as the sliders
+  // and the affine handles): the keyframe at the current frame is rewritten
+  // live, so a held/scrubbed frame renders the drag as it happens instead of
+  // freezing until a drag-end debounce lands. Per-move writes coalesce into
+  // one undo step, closed by breakUndoCoalescing when the drag finishes.
+  const keyframeDraggedColor = () => {
     const base = props.keyframePathBase
-    if (base) keyframeGesture([`${base}.x`, `${base}.y`])
+    if (base) keyframeEditedParams(timeline, [`${base}.x`, `${base}.y`])
   }
   const clip = createMemo(() => {
     // worldToClip can throw or return NaN before the camera/canvas is
@@ -209,11 +212,12 @@ function FlameColorHandle(props: {
           const diff = sub(position, grabPosition)
           const color = add(initialColor, diff)
           props.setColor(color)
+          keyframeDraggedColor()
         },
         onDone() {
           if (moved) {
             changeHistory.commit()
-            scheduleColorKeyframes()
+            timeline?.breakUndoCoalescing()
           } else if (wasSelected) {
             // A click (no drag) on an already-selected handle deselects it.
             props.onDeselect?.()

--- a/packages/app/src/components/Timeline/CurveEditor/CurveEditor.tsx
+++ b/packages/app/src/components/Timeline/CurveEditor/CurveEditor.tsx
@@ -262,7 +262,9 @@ export function CurveEditor(props: CurveEditorProps) {
       <Show
         when={props.path}
         fallback={
-          <div class={ui.placeholder}>Select a keyframe to edit its curve</div>
+          <div class={ui.placeholder}>
+            Click a track or keyframe to see its curve
+          </div>
         }
       >
         <Show

--- a/packages/app/src/components/Timeline/CurveEditor/CurveEditor.tsx
+++ b/packages/app/src/components/Timeline/CurveEditor/CurveEditor.tsx
@@ -56,8 +56,38 @@ export function CurveEditor(props: CurveEditorProps) {
     measure()
     const ro = new ResizeObserver(measure)
     ro.observe(el)
+    el.addEventListener('wheel', onLaneWheel, { passive: false })
     onCleanup(() => {
       ro.disconnect()
+      el.removeEventListener('wheel', onLaneWheel)
+    })
+  }
+
+  // Ctrl/Cmd+wheel zooms the VALUE axis around the value under the cursor, so
+  // fine vertical keyframe drags don't fight a cramped auto-fitted range. Uses
+  // the sticky range (like a drag does) so the axis stays put afterwards.
+  // Native listener (not JSX): it must be non-passive to preventDefault the
+  // browser page-zoom, and stopPropagation keeps the workspace's Ctrl+wheel
+  // panel-resize from also firing.
+  function onLaneWheel(e: WheelEvent) {
+    if (!(e.ctrlKey || e.metaKey)) return
+    e.preventDefault()
+    e.stopPropagation()
+    if (!laneRef) return
+    const vp = viewport()
+    const range = valueRange()
+    const span = range.max - range.min
+    // Wheel up (negative deltaY) zooms in — the span shrinks.
+    const newSpan = Math.max(
+      1e-6,
+      Math.min(1e9, span * Math.exp(e.deltaY * 0.002)),
+    )
+    if (newSpan === span) return
+    const anchor = vp.yToValue(e.clientY - laneRef.getBoundingClientRect().top)
+    const k = newSpan / span
+    setStickyRange({
+      min: anchor - (anchor - range.min) * k,
+      max: anchor + (range.max - anchor) * k,
     })
   }
 
@@ -266,7 +296,8 @@ export function CurveEditor(props: CurveEditorProps) {
               onDblClick={addKeyframeAtPoint}
             >
               <title>
-                Drag a point up/down to change its value · double-click to add
+                Drag a point up/down to change its value · double-click to add ·
+                Ctrl+wheel to zoom the value axis
               </title>
               {/* Min / max value guide lines */}
               <line

--- a/packages/app/src/components/Timeline/DopeSheet.module.css
+++ b/packages/app/src/components/Timeline/DopeSheet.module.css
@@ -18,96 +18,6 @@
   }
 }
 
-/* ── Zoom toolbar ── */
-.zoomToolbar {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  padding: 2px 8px;
-  background: var(--neutral-50);
-  border-bottom: 1px solid var(--neutral-200);
-  flex-shrink: 0;
-  height: 22px;
-
-  [data-theme='dark'] & {
-    background: var(--neutral-900);
-    border-bottom-color: var(--neutral-800);
-  }
-}
-
-.zoomBtn {
-  padding: 1px 8px;
-  font-size: 10px;
-  font-weight: 600;
-  border: 1px solid var(--neutral-300);
-  border-radius: 4px;
-  background: white;
-  color: var(--neutral-600);
-  cursor: pointer;
-  transition: all 0.1s;
-
-  [data-theme='dark'] & {
-    background: var(--neutral-800);
-    border-color: var(--neutral-600);
-    color: var(--neutral-300);
-  }
-
-  &:hover {
-    background: var(--accent-color, #3b82f6);
-    border-color: var(--accent-color, #3b82f6);
-    color: white;
-  }
-}
-
-.zoomBtnActive {
-  background: var(--accent-color, #3b82f6);
-  border-color: var(--accent-color, #3b82f6);
-  color: white;
-
-  [data-theme='dark'] & {
-    background: var(--accent-color, #3b82f6);
-    border-color: var(--accent-color, #3b82f6);
-    color: white;
-  }
-}
-
-.zoomLabel {
-  font-size: 10px;
-  font-weight: 600;
-  color: var(--neutral-500);
-  font-variant-numeric: tabular-nums;
-
-  [data-theme='dark'] & {
-    color: var(--neutral-400);
-  }
-}
-
-.zoomHint {
-  font-size: 9px;
-  color: var(--neutral-400);
-  margin-left: 2px;
-
-  [data-theme='dark'] & {
-    color: var(--neutral-500);
-  }
-}
-
-.frameIndicator {
-  margin-left: auto;
-  font-size: 10px;
-  font-weight: 600;
-  font-variant-numeric: tabular-nums;
-  color: var(--neutral-700);
-  background: var(--neutral-200);
-  padding: 1px 8px;
-  border-radius: 3px;
-
-  [data-theme='dark'] & {
-    color: var(--neutral-200);
-    background: var(--neutral-700);
-  }
-}
-
 /* ── Seek ruler (top scrub area) ── */
 .seekRuler {
   position: relative;
@@ -252,8 +162,10 @@
   }
 }
 
+/* Width comes from the trackNameWidth inline style (useTrackNameWidth), the
+   same value used for the ruler spacer / playhead offset / curve gutter —
+   never set it here or the lanes shift against the ruler. */
 .trackName {
-  width: 130px;
   flex-shrink: 0;
   padding: 1px 8px;
   font-size: 10px;
@@ -541,20 +453,7 @@
     top: 4px;
   }
 
-  .zoomToolbar {
-    height: 32px;
-    padding: 2px 10px;
-  }
-
-  .zoomBtn {
-    padding: 4px 10px;
-    font-size: 11px;
-    min-height: 28px;
-    min-width: 36px;
-  }
-
   .trackName {
-    width: 100px;
     font-size: 9px;
   }
 
@@ -575,20 +474,7 @@
     height: 32px;
   }
 
-  .zoomToolbar {
-    height: 28px;
-    padding: 2px 6px;
-    gap: 4px;
-  }
-
-  .zoomBtn {
-    padding: 3px 8px;
-    font-size: 10px;
-    min-height: 24px;
-  }
-
   .trackName {
-    width: 80px;
     font-size: 8px;
   }
 

--- a/packages/app/src/components/Timeline/DopeSheet.module.css
+++ b/packages/app/src/components/Timeline/DopeSheet.module.css
@@ -1,3 +1,5 @@
+/* Flush with the header above — no card border/radius/inset, so the dope
+   sheet reads as part of the timeline panel rather than a floating box. */
 .container {
   display: flex;
   flex-direction: column;
@@ -6,15 +8,11 @@
   user-select: none;
   -webkit-user-select: none;
   background: var(--neutral-50);
-  border-radius: 8px 8px 0 0;
-  border: 1px solid var(--neutral-200);
-  border-bottom: none;
   overflow: hidden;
   touch-action: manipulation;
 
   [data-theme='dark'] & {
     background: var(--neutral-900);
-    border-color: var(--neutral-800);
   }
 }
 

--- a/packages/app/src/components/Timeline/DopeSheet.module.css
+++ b/packages/app/src/components/Timeline/DopeSheet.module.css
@@ -160,11 +160,32 @@
   }
 }
 
+/* The current track (curve target / keyboard target): accent bar + tinted
+   name, subtle enough not to fight the keyframe/playhead colors. */
+.trackRowSelected {
+  background: color-mix(in srgb, var(--accent-color, #3b82f6) 7%, transparent);
+
+  &:nth-child(even),
+  &:hover {
+    background: color-mix(
+      in srgb,
+      var(--accent-color, #3b82f6) 10%,
+      transparent
+    );
+  }
+
+  .trackName {
+    color: var(--accent-color, #3b82f6);
+    box-shadow: inset 2px 0 0 var(--accent-color, #3b82f6);
+  }
+}
+
 /* Width comes from the trackNameWidth inline style (useTrackNameWidth), the
    same value used for the ruler spacer / playhead offset / curve gutter —
    never set it here or the lanes shift against the ruler. */
 .trackName {
   flex-shrink: 0;
+  cursor: pointer;
   padding: 1px 8px;
   font-size: 10px;
   font-weight: 500;

--- a/packages/app/src/components/Timeline/DopeSheet.tsx
+++ b/packages/app/src/components/Timeline/DopeSheet.tsx
@@ -1,12 +1,12 @@
-import { createEffect, createMemo, createSignal, For, Show } from 'solid-js'
+import { createEffect, createMemo, createSignal, For, onCleanup, Show, } from 'solid-js'
 import { useKeyframeTarget } from '@/contexts/KeyframeTargetContext'
 import { useTimeline } from '@/contexts/TimelineContext'
-import { persistentSignal } from '@/utils/persistentSignal'
 import { TIMELINE_PARAMETERS } from '@/utils/timeline'
 import { CurveEditor } from './CurveEditor/CurveEditor'
 import ui from './DopeSheet.module.css'
 import { useScrollSync } from './hooks/useScrollSync'
 import { useSeekScrubber } from './hooks/useSeekScrubber'
+import { useTrackNameWidth } from './hooks/useTrackNameWidth'
 import { useZoomGestures } from './hooks/useZoomGestures'
 import { KeyframeContextMenu } from './KeyframeContextMenu'
 import { TrackContextMenu } from './TrackContextMenu'
@@ -30,15 +30,28 @@ function pathLabel(path: string): string {
 
 const BASE_FRAME_WIDTH = 24
 const BASE_TRACK_HEIGHT = 20
-const TRACK_NAME_WIDTH = 130
 
 import { DopeSheetGrid } from './DopeSheetGrid'
 import { KeyframeInspector } from './KeyframeInspector'
 import type { FlameDescriptor, TransformId, VariationId, } from '@/flame/schema/flameSchema'
 
+/** Zoom controls the dope sheet hands up to the timeline header (the buttons
+ *  render there, but the state lives here with the scroll/ruler refs). */
+export interface DopeSheetViewApi {
+  zoomLevel: () => number
+  setZoomLevel: (v: number) => void
+  autoFitZoom: () => void
+}
+
 export interface DopeSheetProps {
   formatTrackLabel?: (path: string) => string
   flameDescriptor?: FlameDescriptor
+  /** Seek the playhead to a keyframe when it's selected (header toggle). */
+  seekOnSelect?: boolean
+  /** Show the value-curve editor for the selected parameter (header toggle). */
+  showCurve?: boolean
+  /** Called on mount with the zoom API consumed by the header's View group. */
+  registerViewApi?: (api: DopeSheetViewApi | undefined) => void
 }
 
 export function DopeSheet(props: DopeSheetProps) {
@@ -48,12 +61,6 @@ export function DopeSheet(props: DopeSheetProps) {
   const totalFrames = () =>
     timeline.config().endFrame - timeline.config().startFrame
 
-  const [seekOnSelect, setSeekOnSelect] = createSignal(false)
-  // Persisted across sessions, but defaults OFF on first load (no stored value).
-  const [showCurve, setShowCurve] = persistentSignal(
-    'timeline-curve-editor',
-    false,
-  )
   // Horizontal scroll of the tracks, mirrored onto the curve graph so it stays
   // pixel-aligned with the diamonds.
   const [scrollLeft, setScrollLeft] = createSignal(0)
@@ -68,6 +75,8 @@ export function DopeSheet(props: DopeSheetProps) {
   let seekRulerRef!: HTMLDivElement
   let seekLaneRef!: HTMLDivElement | undefined
 
+  const trackNameWidth = useTrackNameWidth()
+
   const { zoomLevel, setZoomLevel, frameWidth, trackHeight, autoFitZoom } =
     useZoomGestures(
       () => containerRef,
@@ -77,8 +86,11 @@ export function DopeSheet(props: DopeSheetProps) {
       totalFrames,
       BASE_FRAME_WIDTH,
       BASE_TRACK_HEIGHT,
-      TRACK_NAME_WIDTH,
+      trackNameWidth,
     )
+
+  props.registerViewApi?.({ zoomLevel, setZoomLevel, autoFitZoom })
+  onCleanup(() => props.registerViewApi?.(undefined))
 
   useScrollSync(
     () => tracksScrollRef,
@@ -203,56 +215,13 @@ export function DopeSheet(props: DopeSheetProps) {
 
   return (
     <div class={ui.container} ref={containerRef} data-tour-target="dope-sheet">
-      {/* ── Zoom toolbar ── */}
-      <div class={ui.zoomToolbar}>
-        <button
-          class={ui.zoomBtn}
-          onClick={() => {
-            setZoomLevel(Math.max(0.1, zoomLevel() - 0.2))
-          }}
-          title="Zoom out (condense)"
-        >
-          −
-        </button>
-        <span class={ui.zoomLabel}>{Math.round(zoomLevel() * 100)}%</span>
-        <button
-          class={ui.zoomBtn}
-          onClick={() => {
-            setZoomLevel(Math.min(5, zoomLevel() + 0.2))
-          }}
-          title="Zoom in (expand)"
-        >
-          +
-        </button>
-        <button
-          class={ui.zoomBtn}
-          onClick={autoFitZoom}
-          title="Auto-fit all frames"
-        >
-          Fit
-        </button>
-        <button
-          class={`${ui.zoomBtn} ${seekOnSelect() ? ui.zoomBtnActive : ''}`}
-          onClick={() => setSeekOnSelect((v) => !v)}
-          title="Seek playhead to selected keyframe"
-        >
-          Seek
-        </button>
-        <button
-          class={`${ui.zoomBtn} ${showCurve() ? ui.zoomBtnActive : ''}`}
-          onClick={() => setShowCurve((v) => !v)}
-          title="Show the value curve for the selected parameter"
-        >
-          Curve
-        </button>
-        <span class={ui.zoomHint}>(Alt+wheel or pinch to zoom)</span>
-        <span class={ui.frameIndicator}>Frame {currentFrame()}</span>
-      </div>
-
-      <KeyframeInspector selectedKeyframe={selectedKeyframe()} />
+      {/* ── Keyframe inspector (only while a keyframe is selected) ── */}
+      <Show when={selectedKeyframe()}>
+        <KeyframeInspector selectedKeyframe={selectedKeyframe()} />
+      </Show>
 
       {/* ── Curve editor (selected parameter) ── */}
-      <Show when={showCurve()}>
+      <Show when={props.showCurve}>
         <CurveEditor
           path={selectedKeyframe()?.path ?? null}
           label={curveLabel()}
@@ -264,7 +233,7 @@ export function DopeSheet(props: DopeSheetProps) {
           frameWidth={frameWidth()}
           startFrame={timeline.config().startFrame}
           endFrame={timeline.config().endFrame}
-          trackNameWidth={TRACK_NAME_WIDTH}
+          trackNameWidth={trackNameWidth()}
           scrollLeft={scrollLeft()}
         />
       </Show>
@@ -273,7 +242,7 @@ export function DopeSheet(props: DopeSheetProps) {
       <div class={ui.seekRuler} ref={seekRulerRef}>
         <div
           style={{
-            width: `${TRACK_NAME_WIDTH}px`,
+            width: `${trackNameWidth()}px`,
             'flex-shrink': '0',
           }}
         />
@@ -331,7 +300,7 @@ export function DopeSheet(props: DopeSheetProps) {
         selectedKeyframe={selectedKeyframe()}
         onSelectKeyframe={(path, frame) => {
           setSelectedKeyframe({ path, frame })
-          if (seekOnSelect() && frame !== currentFrame()) {
+          if (props.seekOnSelect && frame !== currentFrame()) {
             timeline.goToFrame(frame)
           }
         }}
@@ -339,7 +308,7 @@ export function DopeSheet(props: DopeSheetProps) {
         onContextMenu={handleContextMenu}
         onTrackContextMenu={handleTrackContextMenu}
         onDeselectKeyframe={() => setSelectedKeyframe(null)}
-        trackNameWidth={TRACK_NAME_WIDTH}
+        trackNameWidth={trackNameWidth()}
       />
 
       {/* ── Context menu ── */}

--- a/packages/app/src/components/Timeline/DopeSheet.tsx
+++ b/packages/app/src/components/Timeline/DopeSheet.tsx
@@ -66,7 +66,7 @@ export function DopeSheet(props: DopeSheetProps) {
   const [scrollLeft, setScrollLeft] = createSignal(0)
 
   const curveLabel = () => {
-    const p = selectedKeyframe()?.path
+    const p = selectedTrack()
     if (!p) return null
     return props.formatTrackLabel ? props.formatTrackLabel(p) : pathLabel(p)
   }
@@ -103,11 +103,37 @@ export function DopeSheet(props: DopeSheetProps) {
     path: string
     frame: number
   } | null>(null)
+  // The "current" track: set by clicking a lane/name OR a keyframe. Drives
+  // the curve editor's graphed parameter and keyboard targeting (I inserts),
+  // so a parameter can be inspected without hunting for a diamond to click.
+  const [selectedTrack, setSelectedTrack] = createSignal<string | null>(null)
+
+  function selectKeyframe(path: string, frame: number) {
+    setSelectedTrack(path)
+    setSelectedKeyframe({ path, frame })
+  }
+
+  /** Lane/name click: make the track current without selecting a keyframe
+   *  (the inspector row stays hidden; an open curve editor retargets). */
+  function selectTrack(path: string) {
+    setSelectedTrack(path)
+    setSelectedKeyframe(null)
+  }
 
   createEffect(() => {
     const added = timeline.lastAddedKeyframe()
     if (added) {
-      setSelectedKeyframe(added)
+      selectKeyframe(added.path, added.frame)
+    }
+  })
+
+  // Drop a selection whose track was removed (track context menu, orphan
+  // cleanup, loading another flame) so the curve editor can't graph a ghost.
+  createEffect(() => {
+    const path = selectedTrack()
+    if (path && !timeline.tracks().some((t) => t.parameterPath === path)) {
+      setSelectedTrack(null)
+      setSelectedKeyframe(null)
     }
   })
 
@@ -140,12 +166,13 @@ export function DopeSheet(props: DopeSheetProps) {
     newFrame: number,
   ) {
     timeline.moveKeyframe(path, oldFrame, newFrame)
-    setSelectedKeyframe({ path, frame: newFrame })
+    selectKeyframe(path, newFrame)
   }
 
+  // Target the current TRACK (not just a clicked keyframe): picking a lane is
+  // enough to aim keyboard inserts (I) and the sidebar highlight at it.
   createEffect(() => {
-    const sel = selectedKeyframe()
-    const path = sel?.path ?? null
+    const path = selectedTrack()
     setTargetedParameter(path)
     setSelectedKeyframePath(path)
   })
@@ -220,15 +247,13 @@ export function DopeSheet(props: DopeSheetProps) {
         <KeyframeInspector selectedKeyframe={selectedKeyframe()} />
       </Show>
 
-      {/* ── Curve editor (selected parameter) ── */}
+      {/* ── Curve editor (selected track) ── */}
       <Show when={props.showCurve}>
         <CurveEditor
-          path={selectedKeyframe()?.path ?? null}
+          path={selectedTrack()}
           label={curveLabel()}
           selectedFrame={selectedKeyframe()?.frame ?? null}
-          onSelectKeyframe={(path, frame) =>
-            setSelectedKeyframe({ path, frame })
-          }
+          onSelectKeyframe={selectKeyframe}
           onContextMenu={handleContextMenu}
           frameWidth={frameWidth()}
           startFrame={timeline.config().startFrame}
@@ -298,16 +323,17 @@ export function DopeSheet(props: DopeSheetProps) {
         endFrame={timeline.config().endFrame}
         currentFrame={currentFrame()}
         selectedKeyframe={selectedKeyframe()}
+        selectedTrack={selectedTrack()}
         onSelectKeyframe={(path, frame) => {
-          setSelectedKeyframe({ path, frame })
+          selectKeyframe(path, frame)
           if (props.seekOnSelect && frame !== currentFrame()) {
             timeline.goToFrame(frame)
           }
         }}
+        onSelectTrack={selectTrack}
         onDragKeyframe={handleDragKeyframe}
         onContextMenu={handleContextMenu}
         onTrackContextMenu={handleTrackContextMenu}
-        onDeselectKeyframe={() => setSelectedKeyframe(null)}
         trackNameWidth={trackNameWidth()}
       />
 

--- a/packages/app/src/components/Timeline/DopeSheetGrid.tsx
+++ b/packages/app/src/components/Timeline/DopeSheetGrid.tsx
@@ -47,6 +47,7 @@ export function DopeSheetGrid(props: DopeSheetGridProps) {
                 isOrphaned={track.isOrphaned}
                 parameterPath={track.path}
                 label={track.label}
+                trackNameWidth={props.trackNameWidth}
                 frameWidth={props.frameWidth}
                 trackHeight={props.trackHeight}
                 startFrame={props.startFrame}

--- a/packages/app/src/components/Timeline/DopeSheetGrid.tsx
+++ b/packages/app/src/components/Timeline/DopeSheetGrid.tsx
@@ -14,11 +14,12 @@ interface DopeSheetGridProps {
   endFrame: number
   currentFrame: number
   selectedKeyframe: { path: string; frame: number } | null
+  selectedTrack: string | null
   onSelectKeyframe: (path: string, frame: number) => void
+  onSelectTrack: (path: string) => void
   onDragKeyframe: (path: string, oldFrame: number, newFrame: number) => void
   onContextMenu: (e: MouseEvent, path: string, frame: number) => void
   onTrackContextMenu?: (e: MouseEvent, path: string) => void
-  onDeselectKeyframe: () => void
   trackNameWidth: number
 }
 
@@ -54,11 +55,12 @@ export function DopeSheetGrid(props: DopeSheetGridProps) {
                 endFrame={props.endFrame}
                 currentFrame={props.currentFrame}
                 selectedKeyframe={props.selectedKeyframe}
+                selected={props.selectedTrack === track.path}
                 onSelectKeyframe={props.onSelectKeyframe}
+                onSelectTrack={props.onSelectTrack}
                 onDragKeyframe={props.onDragKeyframe}
                 onContextMenu={props.onContextMenu}
                 onTrackContextMenu={props.onTrackContextMenu}
-                onDeselectKeyframe={props.onDeselectKeyframe}
               />
             )}
           </For>

--- a/packages/app/src/components/Timeline/DopeSheetTrack.tsx
+++ b/packages/app/src/components/Timeline/DopeSheetTrack.tsx
@@ -16,11 +16,13 @@ type DopeSheetTrackProps = {
   endFrame: number
   currentFrame: number
   selectedKeyframe: { path: string; frame: number } | null
+  /** This row is the current track (curve target / keyboard target). */
+  selected?: boolean
   onSelectKeyframe: (path: string, frame: number) => void
+  onSelectTrack: (path: string) => void
   onDragKeyframe: (path: string, oldFrame: number, newFrame: number) => void
   onContextMenu: (e: MouseEvent, path: string, frame: number) => void
   onTrackContextMenu?: (e: MouseEvent, path: string) => void
-  onDeselectKeyframe: () => void
   isOrphaned?: boolean
 }
 
@@ -118,7 +120,9 @@ export function DopeSheetTrack(props: DopeSheetTrackProps) {
       Math.min(props.endFrame, frame),
     )
     timeline.goToFrame(clampedFrame)
-    props.onDeselectKeyframe()
+    // A lane click also makes this the current track (clearing any keyframe
+    // selection) — the open curve editor retargets without diamond-hunting.
+    props.onSelectTrack(props.parameterPath)
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -129,13 +133,20 @@ export function DopeSheetTrack(props: DopeSheetTrackProps) {
   return (
     <div
       class={`${ui.trackRow} ${props.isOrphaned ? ui.orphanedTrack : ''}`}
+      classList={{ [ui.trackRowSelected as string]: props.selected }}
       style={{ height: `${props.trackHeight}px` }}
       onContextMenu={(e) => {
         e.preventDefault()
         props.onTrackContextMenu?.(e, props.parameterPath)
       }}
     >
-      <div class={ui.trackName} style={{ width: `${props.trackNameWidth}px` }}>
+      <div
+        class={ui.trackName}
+        style={{ width: `${props.trackNameWidth}px` }}
+        onClick={() => {
+          props.onSelectTrack(props.parameterPath)
+        }}
+      >
         {props.isOrphaned && (
           <span
             title="Tracking target is missing. Please check if the target still exists in the flame, or remove these keyframes."

--- a/packages/app/src/components/Timeline/DopeSheetTrack.tsx
+++ b/packages/app/src/components/Timeline/DopeSheetTrack.tsx
@@ -7,6 +7,9 @@ import type { KeyframeData } from '@/utils/timeline'
 type DopeSheetTrackProps = {
   parameterPath: string
   label: string
+  /** Name-column width in px — must match the ruler spacer and playhead
+   *  offset (see useTrackNameWidth), or the lanes shift against the ruler. */
+  trackNameWidth: number
   frameWidth: number
   trackHeight: number
   startFrame: number
@@ -132,7 +135,7 @@ export function DopeSheetTrack(props: DopeSheetTrackProps) {
         props.onTrackContextMenu?.(e, props.parameterPath)
       }}
     >
-      <div class={ui.trackName}>
+      <div class={ui.trackName} style={{ width: `${props.trackNameWidth}px` }}>
         {props.isOrphaned && (
           <span
             title="Tracking target is missing. Please check if the target still exists in the flame, or remove these keyframes."

--- a/packages/app/src/components/Timeline/TimelineSection.module.css
+++ b/packages/app/src/components/Timeline/TimelineSection.module.css
@@ -66,8 +66,101 @@
 .headerRight {
   display: flex;
   align-items: center;
-  gap: 3px;
+  gap: 6px;
   margin-left: auto;
+}
+
+/* ── Header aisles ──
+   Related controls cluster into bordered groups so the single-row header
+   reads as playback | settings | view | keying at a glance. */
+.headerGroup {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding-left: 8px;
+  border-left: 1px solid var(--neutral-200);
+
+  [data-theme='dark'] & {
+    border-left-color: var(--neutral-800);
+  }
+}
+
+.headerGroupLabel {
+  font-size: 0.5rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--neutral-400);
+  user-select: none;
+  margin-right: 2px;
+
+  [data-theme='dark'] & {
+    color: var(--neutral-600);
+  }
+}
+
+/* ── View controls (zoom / fit / seek / curve) ── */
+.viewBtn {
+  padding: 2px 7px;
+  font-size: 0.6rem;
+  font-weight: 600;
+  border: 1px solid var(--neutral-300);
+  border-radius: 4px;
+  background: transparent;
+  color: var(--neutral-500);
+  cursor: pointer;
+  letter-spacing: 0.01em;
+  transition: all 0.15s;
+  height: 22px;
+  line-height: 1;
+
+  [data-theme='dark'] & {
+    border-color: var(--neutral-700);
+    color: var(--neutral-400);
+  }
+
+  &:disabled {
+    opacity: 0.4;
+    cursor: default;
+  }
+
+  &:hover:not(:disabled) {
+    background: var(--accent-color, #3b82f6);
+    border-color: var(--accent-color, #3b82f6);
+    color: white;
+
+    [data-theme='dark'] & {
+      background: var(--accent-color, #3b82f6);
+      border-color: var(--accent-color, #3b82f6);
+      color: white;
+    }
+  }
+}
+
+.viewBtnActive {
+  background: var(--accent-color, #3b82f6);
+  border-color: var(--accent-color, #3b82f6);
+  color: white;
+
+  [data-theme='dark'] & {
+    background: var(--accent-color, #3b82f6);
+    border-color: var(--accent-color, #3b82f6);
+    color: white;
+  }
+}
+
+.zoomLabel {
+  font-size: 0.6rem;
+  font-weight: 600;
+  color: var(--neutral-500);
+  font-variant-numeric: tabular-nums;
+  min-width: 30px;
+  text-align: center;
+  user-select: none;
+
+  [data-theme='dark'] & {
+    color: var(--neutral-400);
+  }
 }
 
 .playDot {
@@ -501,6 +594,15 @@
     gap: 2px 4px;
   }
 
+  .headerGroup {
+    padding-left: 6px;
+  }
+
+  .viewBtn {
+    padding: 4px 8px;
+    min-height: 26px;
+  }
+
   .content {
     padding: 2px;
   }
@@ -524,6 +626,24 @@
 @media (max-width: 480px) {
   .header {
     min-height: 28px;
+  }
+
+  /* The aisles wrap into several short rows here; the labels and borders
+     stop reading as columns, so drop them for space. */
+  .headerGroupLabel {
+    display: none;
+  }
+
+  .headerGroup {
+    padding-left: 4px;
+    border-left: none;
+  }
+
+  .viewBtn {
+    padding: 2px 6px;
+    font-size: 0.55rem;
+    height: 20px;
+    min-height: 0;
   }
 
   .settingsBar {

--- a/packages/app/src/components/Timeline/TimelineSection.module.css
+++ b/packages/app/src/components/Timeline/TimelineSection.module.css
@@ -551,7 +551,6 @@
 
 /* ── Content ── */
 .content {
-  padding: 0 4px 4px 4px;
   display: flex;
   flex-direction: column;
   gap: 0;
@@ -601,10 +600,6 @@
   .viewBtn {
     padding: 4px 8px;
     min-height: 26px;
-  }
-
-  .content {
-    padding: 2px;
   }
 
   .shortcutHint {

--- a/packages/app/src/components/Timeline/TimelineSection.tsx
+++ b/packages/app/src/components/Timeline/TimelineSection.tsx
@@ -1,9 +1,11 @@
 import { createMemo, createSignal, Show } from 'solid-js'
 import { useTimeline } from '@/contexts/TimelineContext'
 import { Cross } from '@/icons'
+import { persistentSignal } from '@/utils/persistentSignal'
 import { AnimationControls, AnimationGenerator } from './AnimationGenerator'
 import { DopeSheet } from './DopeSheet'
 import ui from './TimelineSection.module.css'
+import type { DopeSheetViewApi } from './DopeSheet'
 import type { FlameDescriptor } from '@/flame/schema/flameSchema'
 
 export interface TimelineSectionProps {
@@ -25,6 +27,17 @@ export function TimelineSection(props: TimelineSectionProps) {
   const config = createMemo(() => timeline.config())
   const currentFrame = createMemo(() => timeline.currentFrame())
 
+  // View state for the dope sheet, owned here so its controls can share the
+  // header row. The zoom API is registered by the dope sheet on mount (the
+  // zoom state has to live with its scroll/ruler refs).
+  const [viewApi, setViewApi] = createSignal<DopeSheetViewApi | undefined>()
+  const [seekOnSelect, setSeekOnSelect] = createSignal(false)
+  // Persisted across sessions, but defaults OFF on first load (no stored value).
+  const [showCurve, setShowCurve] = persistentSignal(
+    'timeline-curve-editor',
+    false,
+  )
+
   return (
     <div
       class={ui.section}
@@ -32,24 +45,82 @@ export function TimelineSection(props: TimelineSectionProps) {
       data-testid="timeline-section"
       data-tour-target="timeline-section"
     >
-      {/* Compact transport bar */}
+      {/* Single-row header: playback | settings | view | generators + keying */}
       <div class={ui.header}>
         <div class={ui.headerLeft}>
           <span class={ui.headerTitle}>Timeline</span>
         </div>
 
-        <TransportBar />
-
-        {/* Frame info */}
-        <div class={ui.frameInfo}>
-          <span class={ui.frameDisplay}>
-            <span data-testid="current-frame">{currentFrame()}</span>
-            <span class={ui.frameSep}>/</span>
-            <span data-testid="end-frame">{config().endFrame}</span>
-          </span>
+        <div class={ui.headerGroup} role="group" aria-label="Playback">
+          <TransportBar />
+          {/* Frame info */}
+          <div class={ui.frameInfo}>
+            <span class={ui.frameDisplay}>
+              <span data-testid="current-frame">{currentFrame()}</span>
+              <span class={ui.frameSep}>/</span>
+              <span data-testid="end-frame">{config().endFrame}</span>
+            </span>
+          </div>
         </div>
 
-        <TimelineSettings />
+        <div class={ui.headerGroup} role="group" aria-label="Playback settings">
+          <TimelineSettings />
+        </div>
+
+        <Show when={!collapsed()}>
+          <div class={ui.headerGroup} role="group" aria-label="View">
+            <span class={ui.headerGroupLabel}>View</span>
+            <button
+              class={ui.viewBtn}
+              disabled={!viewApi()}
+              onClick={() => {
+                const api = viewApi()
+                api?.setZoomLevel(Math.max(0.1, api.zoomLevel() - 0.2))
+              }}
+              title="Zoom out (condense frames)"
+            >
+              −
+            </button>
+            <span class={ui.zoomLabel}>
+              {Math.round((viewApi()?.zoomLevel() ?? 1) * 100)}%
+            </span>
+            <button
+              class={ui.viewBtn}
+              disabled={!viewApi()}
+              onClick={() => {
+                const api = viewApi()
+                api?.setZoomLevel(Math.min(5, api.zoomLevel() + 0.2))
+              }}
+              title="Zoom in (expand frames)"
+            >
+              +
+            </button>
+            <button
+              class={ui.viewBtn}
+              disabled={!viewApi()}
+              onClick={() => viewApi()?.autoFitZoom()}
+              title="Fit all frames in view (or zoom with Alt+wheel / pinch)"
+            >
+              Fit
+            </button>
+            <button
+              class={ui.viewBtn}
+              classList={{ [ui.viewBtnActive as string]: seekOnSelect() }}
+              onClick={() => setSeekOnSelect((v) => !v)}
+              title="Seek playhead to a keyframe when selecting it"
+            >
+              Seek
+            </button>
+            <button
+              class={ui.viewBtn}
+              classList={{ [ui.viewBtnActive as string]: showCurve() }}
+              onClick={() => setShowCurve((v) => !v)}
+              title="Show the value curve for the selected parameter (Ctrl+wheel zooms its value axis)"
+            >
+              Curve
+            </button>
+          </div>
+        </Show>
 
         {/* Right buttons */}
         <div class={ui.headerRight}>
@@ -62,30 +133,33 @@ export function TimelineSection(props: TimelineSectionProps) {
               onOpenAnimationGenerator={props.onOpenAnimationGenerator}
             />
           </Show>
-          <button
-            class={ui.autoKeyBtn}
-            classList={{ [ui.active as string]: autoKeyframe() }}
-            data-tour-target="auto-keyframe"
-            onClick={(e) => {
-              e.stopPropagation()
-              timeline.setAutoKeyframe(!autoKeyframe())
-            }}
-            title="Auto-keyframe"
-          >
-            Auto
-          </button>
-          <button
-            class={ui.removeBtn}
-            classList={{ [ui.active as string]: removeMode() }}
-            data-tour-target="del-mode"
-            onClick={(e) => {
-              e.stopPropagation()
-              timeline.setRemoveMode(!removeMode())
-            }}
-            title="Remove mode"
-          >
-            Del
-          </button>
+          <div class={ui.headerGroup} role="group" aria-label="Keyframing">
+            <span class={ui.headerGroupLabel}>Keys</span>
+            <button
+              class={ui.autoKeyBtn}
+              classList={{ [ui.active as string]: autoKeyframe() }}
+              data-tour-target="auto-keyframe"
+              onClick={(e) => {
+                e.stopPropagation()
+                timeline.setAutoKeyframe(!autoKeyframe())
+              }}
+              title="Auto-keyframe: re-record animated parameters as you edit them"
+            >
+              Auto
+            </button>
+            <button
+              class={ui.removeBtn}
+              classList={{ [ui.active as string]: removeMode() }}
+              data-tour-target="del-mode"
+              onClick={(e) => {
+                e.stopPropagation()
+                timeline.setRemoveMode(!removeMode())
+              }}
+              title="Remove mode: click keyframes to delete them"
+            >
+              Del
+            </button>
+          </div>
           <button
             class={ui.collapseBtn}
             onClick={(e) => {
@@ -114,6 +188,9 @@ export function TimelineSection(props: TimelineSectionProps) {
           <DopeSheet
             formatTrackLabel={props.formatTrackLabel}
             flameDescriptor={props.flameDescriptor}
+            seekOnSelect={seekOnSelect()}
+            showCurve={showCurve()}
+            registerViewApi={setViewApi}
           />
         </div>
       </Show>

--- a/packages/app/src/components/Timeline/hooks/useScrollSync.ts
+++ b/packages/app/src/components/Timeline/hooks/useScrollSync.ts
@@ -10,18 +10,20 @@ export function useScrollSync(
     const seekLane = seekLaneRef()
     if (!tracksEl || !seekLane) return
 
-    let syncing = false
+    // Value-guarded, not flag-guarded: a programmatic scrollLeft write fires
+    // its scroll event asynchronously, long after any "syncing" flag has been
+    // reset, so a flag can't stop echoes — and a stale echo can overwrite a
+    // newer position. Comparing values makes the sync idempotent (assigning an
+    // equal scrollLeft fires no event, so the echo chain terminates).
     const syncTracksToLane = () => {
-      if (syncing) return
-      syncing = true
-      seekLane.scrollLeft = tracksEl.scrollLeft
-      syncing = false
+      if (seekLane.scrollLeft !== tracksEl.scrollLeft) {
+        seekLane.scrollLeft = tracksEl.scrollLeft
+      }
     }
     const syncLaneToTracks = () => {
-      if (syncing) return
-      syncing = true
-      tracksEl.scrollLeft = seekLane.scrollLeft
-      syncing = false
+      if (tracksEl.scrollLeft !== seekLane.scrollLeft) {
+        tracksEl.scrollLeft = seekLane.scrollLeft
+      }
     }
 
     tracksEl.addEventListener('scroll', syncTracksToLane, { passive: true })

--- a/packages/app/src/components/Timeline/hooks/useTrackNameWidth.ts
+++ b/packages/app/src/components/Timeline/hooks/useTrackNameWidth.ts
@@ -1,0 +1,36 @@
+import { createSignal, onCleanup } from 'solid-js'
+import type { Accessor } from 'solid-js'
+
+/** Track-name column width per viewport, matching DopeSheet.module.css's
+ *  responsive font sizing. This is the single source of truth for the column:
+ *  every piece of horizontal-alignment math (ruler spacer, tracks playhead
+ *  offset, curve gutter, auto-fit) AND the rendered cells consume this value,
+ *  so the ruler's frame axis can never shift against the lanes when a CSS
+ *  breakpoint kicks in. */
+const WIDTHS = [
+  { query: '(max-width: 480px)', width: 80 },
+  { query: '(max-width: 768px)', width: 100 },
+] as const
+
+const DEFAULT_WIDTH = 130
+
+export function useTrackNameWidth(): Accessor<number> {
+  const lists = WIDTHS.map(({ query, width }) => ({
+    mq: window.matchMedia(query),
+    width,
+  }))
+  const compute = () =>
+    lists.find(({ mq }) => mq.matches)?.width ?? DEFAULT_WIDTH
+
+  const [width, setWidth] = createSignal(compute())
+  const update = () => setWidth(compute())
+  for (const { mq } of lists) {
+    mq.addEventListener('change', update)
+  }
+  onCleanup(() => {
+    for (const { mq } of lists) {
+      mq.removeEventListener('change', update)
+    }
+  })
+  return width
+}

--- a/packages/app/src/components/Timeline/hooks/useZoomGestures.ts
+++ b/packages/app/src/components/Timeline/hooks/useZoomGestures.ts
@@ -10,7 +10,7 @@ export function useZoomGestures(
   totalFrames: Accessor<number>,
   baseFrameWidth: number,
   baseTrackHeight: number,
-  trackNameWidth: number,
+  trackNameWidth: Accessor<number>,
 ) {
   const [containerHeight, setContainerHeight] = createSignal(200)
   const [zoomLevel, setZoomLevel] = createSignal(1)
@@ -41,6 +41,38 @@ export function useZoomGestures(
     onCleanup(() => {
       ro.disconnect()
     })
+  })
+
+  // The ruler lane and the tracks area are SEPARATE horizontal scrollers (only
+  // JS-synced), so any frameWidth change — zoom buttons, Alt+wheel, pinch, or
+  // the panel resize handle driving containerHeight — narrows/widens both
+  // contents and lets the browser clamp each scrollLeft independently. A clamp
+  // on one side shifts the ruler playhead off the tracks playhead. Re-anchor
+  // on every frameWidth change: keep the frame at the lane's left edge stable
+  // (scrollLeft scales linearly with frameWidth) and write the SAME value,
+  // clamped to the smaller of the two scroll ranges, to both panes.
+  let prevFrameWidth: number | undefined
+  createEffect(() => {
+    const fw = frameWidth()
+    const ratio = prevFrameWidth ? fw / prevFrameWidth : 1
+    prevFrameWidth = fw
+    const ts = tracksScrollRef()
+    const sl = seekLaneRef()
+    if (!ts || !sl) return
+    // The ruler wrapper itself must never scroll (it holds the fixed name-
+    // column spacer); reset it in case the browser nudged it.
+    const ruler = seekRulerRef()
+    if (ruler && ruler.scrollLeft !== 0) ruler.scrollLeft = 0
+    const maxShared = Math.max(
+      0,
+      Math.min(
+        ts.scrollWidth - ts.clientWidth,
+        sl.scrollWidth - sl.clientWidth,
+      ),
+    )
+    const target = Math.max(0, Math.min(maxShared, ts.scrollLeft * ratio))
+    ts.scrollLeft = target
+    sl.scrollLeft = target
   })
 
   const startPinch = createPinchHandler((initEvent) => {
@@ -84,7 +116,7 @@ export function useZoomGestures(
   function autoFitZoom() {
     const ruler = seekRulerRef()
     if (!ruler) return
-    const availableWidth = ruler.clientWidth - trackNameWidth - 16
+    const availableWidth = ruler.clientWidth - trackNameWidth() - 16
     if (availableWidth <= 0 || totalFrames() <= 0) return
     const h = containerHeight()
     const containerScale = Math.max(0.8, Math.min(3, h / 140))

--- a/packages/app/src/utils/keyframeOnChange.ts
+++ b/packages/app/src/utils/keyframeOnChange.ts
@@ -1,4 +1,3 @@
-import { onCleanup } from 'solid-js'
 import { persistentSignal } from './persistentSignal'
 import type { TimelineState } from './timeline'
 
@@ -62,33 +61,4 @@ export function keyframeEditedParam(
 ) {
   if (!path) return
   keyframeEditedParams(timeline, [path])
-}
-
-/** Debounced track-changes writer for drag gestures: collects full parameter
- *  paths as gestures finish and keyframes them at the current frame in one
- *  flush. The debounce coalesces nudge bursts (values are resolved at flush
- *  time, i.e. after the last gesture); pending paths flush — not drop — if
- *  the owning component unmounts mid-wait. Create inside a component. */
-export function createGestureKeyframer(
-  timeline: TimelineState | null | undefined,
-  delayMs = 300,
-) {
-  const pending = new Set<string>()
-  let timer: ReturnType<typeof setTimeout> | undefined
-  const flush = () => {
-    clearTimeout(timer)
-    if (!timeline || pending.size === 0) return
-    // One undo entry per flush; no coalescing across flushes — two separate
-    // drags stay two undo steps (the debounce already merges nudge bursts).
-    timeline.addKeyframesAtCurrentFrame([...pending], { coalesce: false })
-    pending.clear()
-  }
-  onCleanup(flush)
-  return (paths: readonly string[]) => {
-    // Same animationEnabled gate as keyframeChangedParams.
-    if (!timeline?.animationEnabled() || !keyframeOnChange()) return
-    for (const path of paths) pending.add(path)
-    clearTimeout(timer)
-    timer = setTimeout(flush, delayMs)
-  }
 }


### PR DESCRIPTION
## Summary

Timeline/animation UX fixes reported from tablet + desktop use, released as 0.9.6.

### 1. Ruler arrowhead no longer drifts off the playhead line (resize regression)
The seek ruler lane and the tracks area are **separate horizontal scrollers** (JS-synced). Any `frameWidth` change — zoom buttons, Alt+wheel, pinch, or the panel **resize handle** (its height drives the frame scale) — resized both contents and let the browser clamp each `scrollLeft` independently, so the arrow could sit on frame 40 while the red line sat on 35 until Fit/zoom-out reset both.
- `useZoomGestures` now re-anchors on every `frameWidth` change: the frame at the lane's left edge stays put (scrollLeft scales by the width ratio) and the **same clamped offset** is written to both panes; the ruler wrapper's own scroll is pinned to 0.
- `useScrollSync` drops its broken re-entrancy flag (programmatic scrolls fire their events **asynchronously**, so the flag guarded nothing) for idempotent value-guarded writes.
- Bonus alignment fix: CSS shrank the track-name column to 100/80px on ≤768/≤480px viewports while all offset math (ruler spacer, playhead `left`, curve gutter, auto-fit) used the 130px constant — skewing diamonds off the ruler's frame axis on tablets. The width is now one reactive `matchMedia` signal (`useTrackNameWidth`) consumed by the cells **and** all the math.

### 2. One-row grouped timeline header, seamless dope sheet
The dope sheet's zoom toolbar row is dissolved into the header, which now reads as labeled aisles — **playback** (transport + frame counter) | **settings** (FPS/frames/speed/loop) | **View** (− % + / Fit / Seek / Curve) | **Keys** (Auto / Del) — with descriptive tooltips on every button. The keyframe inspector renders only while a keyframe is selected instead of holding an empty 32px row, and the dope sheet lost its floating-card chrome (top radius, border, 4px inset) so it joins the header flush and spans the panel edge-to-edge. Zoom state stays in `DopeSheet` (it needs the scroll/ruler refs) and is handed up via a `registerViewApi` callback; `seekOnSelect`/`showCurve` lifted to `TimelineSection` (same persisted key). All `data-testid`/`data-tour-target` hooks preserved.

### 3. Click a track to select it
Clicking a lane (or its name) now makes that track current: the row highlights (accent inset bar + tint), an **open curve editor retargets to it**, and keyboard inserts (I) aim at it — no need to hunt for a keyframe diamond. Diamond clicks still select keyframe + track; a lane click clears the keyframe selection (inspector stays hidden) and keeps seeking as before; name clicks select without seeking. A guard drops the selection when its track is removed. The curve panel deliberately does NOT auto-open on lane clicks (no layout jumps while scrubbing).

### 4. Curve editor: Ctrl+wheel zooms the value axis
Ctrl/Cmd+wheel over the curve lane rescales the value range **around the value under the cursor** (sticky, like after a drag), making precise vertical diamond moves easy on cramped auto-fitted ranges. Non-passive native listener; `stopPropagation` keeps the workspace's Ctrl+wheel panel-resize out of the gesture. Alt+wheel (frame zoom) and plain wheel are untouched.

### 5. Affine/color handle drags animate the IFS live (no more 300 ms freeze)
While the timeline holds a frame (`isDrivingView`), `applyTimelineToFlame` overrides tracked params every render — so deferring keyframe writes to a **drag-end 300 ms debounce** froze the rendered IFS for the entire drag, then snapped it to the end state. Handle drags now record keyframes **per pointer-move** via `keyframeEditedParams` (exactly the sliders' contract: track-changes diamond records anything incl. first keyframes; Auto re-records already-animated params), with `breakUndoCoalescing()` on gesture end so a whole drag is still **one undo step**. Live IFS during the drag *and* the committed keyframe — with zero lag. The drag-end `createGestureKeyframer` is removed; the final-transform handle now participates in change tracking too.

### 6. Changelog housekeeping
User-facing `CHANGELOG.md` entries for 0.9.3–0.9.6 condensed to outcome-level highlights (full detail stays in `dev.changelog.md`), the About-panel parser now folds hard-wrapped bullet continuation lines instead of dropping them, and the dev changelog's `[0.9.5]` header (accidentally swallowed by the 0.9.6 insert) is restored.

## Verification

- `tsc --noEmit`, ESLint on touched areas, and the full unit suite (925 tests) pass.
- Driven end-to-end in a real WebGPU browser (headed Chromium via Playwright):
  - arrow/line alignment Δ = 0.00 px before **and after** multi-stroke panel-resize drags with the lane zoomed + scrolled,
  - lane/name/diamond selection matrix (12 checks: highlight, curve retarget, seek vs no-seek, inspector visibility),
  - Ctrl+wheel rescaled the curve's value axis; new keyframe tracks appeared **mid-drag** on an affine handle,
  - header renders as one grouped row; changelog modal renders wrapped bullets fully.

Version bumped 0.9.5 → 0.9.6; both changelogs updated. Mirrors fork PR Komediruzecki/chaos-master-fp#50 (reviewed and merged there).