### PR TITLE
feat(gallery): preview a sequence before committing it

### DIFF
--- a/packages/app/CHANGELOG.md
+++ b/packages/app/CHANGELOG.md
@@ -35,6 +35,10 @@ each release; the full developer history lives in `dev.changelog.md`.
 
 ### Fixed
 
+- **The microphone works on the site.** Live mic input for audio-reactive
+  flames and sonification was blocked outright on lumenapeiron.com — the
+  browser never even asked for permission. It worked locally, which is why it
+  went unnoticed.
 - **Sonification's drums.** The percussive model was silent on every flame.
 - **Sound stops when you close its panel**, unless you ask it to keep playing.
 - **Loading a song tells you what it's doing.** The progress bar now reflects

--- a/packages/app/dev.changelog.md
+++ b/packages/app/dev.changelog.md
@@ -140,6 +140,17 @@ implementations.
   expensive operation, so a row without one is an explicit `no-poster` error
   carrying the `capture` command that would fix it.
 
+- **Microphone blocked in production** (`worker/index.ts`): `Permissions-Policy`
+  sent `microphone=()`, an EMPTY allowlist, which denies the feature to the
+  document's own origin as well as to embedders. `getUserMedia` therefore never
+  prompted — it threw "microphone is not allowed in this document" — so live
+  input for the audio-reactive wiring and the sonification panel was dead on
+  every deployed site while working locally, where no such header is sent. Now
+  `microphone=(self)`: still refused to embedders (and `frame-ancestors 'none'`
+  means there are none), allowed for us. Covered by a test, because nothing
+  else catches this class of bug — the app builds, deploys and renders
+  perfectly, and the only symptom is a prompt that never appears.
+
 ### Changed
 
 - **Home art direction** (`HomeTab.module.css`): Home now carries its own

--- a/packages/app/dev.changelog.md
+++ b/packages/app/dev.changelog.md
@@ -130,6 +130,16 @@ implementations.
   poster — and because the key exists nowhere else once the row is gone, a
   failed object delete prints the exact command to finish it.
 
+- **`gallery-admin poster`** (`scripts/gallery-admin.mjs`): hands back a row's
+  captured poster as base64, for the console's preview thumbnails. Exists for
+  `local` above all — dev and prod already publish posters at
+  `GET /api/gallery/poster/<key>`, so a browser can point an `<img>` straight
+  at those and get HTTP caching for free, whereas the local bucket lives inside
+  miniflare and has no URL unless a dev server happens to be running. Reads
+  only R2: rendering a flame that has no poster is a different and far more
+  expensive operation, so a row without one is an explicit `no-poster` error
+  carrying the `capture` command that would fix it.
+
 ### Changed
 
 - **Home art direction** (`HomeTab.module.css`): Home now carries its own

--- a/packages/app/dev.changelog.md
+++ b/packages/app/dev.changelog.md
@@ -116,6 +116,20 @@ implementations.
   place rather than failing the batch, and cannot be picked — committing one
   would put a flame on Home that nobody saw.
 
+- **`gallery-admin delete`** (`scripts/gallery-admin.mjs`): there was no way to
+  remove a row, only to unpublish it — deliberate while rows were curated by
+  hand, but staging mistakes and test rows then accumulate as hidden clutter
+  with no exit. The one destructive command, guarded three ways: a PUBLISHED
+  row is refused (unpublish first, so deleting is never a one-step way to take
+  something off Home, where a mistyped slug would be an outage rather than an
+  inconvenience), `--yes <slug>` must repeat the slug (a fixed confirmation
+  word gets typed on reflex; retyping the name means what was confirmed is
+  what goes), and prod keeps its own `--confirm prod`. The R2 poster goes with
+  the row: the row is deleted first and the object second, so a half-failure
+  orphans an invisible object rather than leaving a row pointing at a missing
+  poster — and because the key exists nowhere else once the row is gone, a
+  failed object delete prints the exact command to finish it.
+
 ### Changed
 
 - **Home art direction** (`HomeTab.module.css`): Home now carries its own

--- a/packages/app/dev.changelog.md
+++ b/packages/app/dev.changelog.md
@@ -98,6 +98,23 @@ implementations.
   the poster pipeline) rather than duplicating the one piece of tooling that has
   to run app TypeScript. The wrapper is a pass-through, so the console reaches
   it with no dotfiles change — only buttons to wire.
+- **Sequence preview, then pick** (`scripts/render-flames.mjs`,
+  `scripts/sequence-pick.mjs`, `gallery-sequence.mjs --preview/--pick/--read`):
+  a derived walk was previously written sight-unseen and judged by reloading
+  Home. `--preview` now renders every candidate and returns them as base64
+  data URLs on stdout, writing nothing; `--pick 0,3,5` then commits exactly
+  those, in that order. The two agree because derivation is deterministic in
+  `--seed` and the preview reports the seed it used, so the commit re-derives
+  the identical flames — no candidate is carried between runs in a temp file
+  that could go stale. Rendering is the poster capture's own browser loop,
+  extracted to `render-flames.mjs` and taking flames directly rather than D1
+  rows (the capture page already accepted a spec carrying its own flame), so
+  preview and poster share one quality gate and one blank-canvas check.
+  `--read <env>` was added with it: `--preview` must derive from the row the
+  eventual commit will update, and reusing `--apply` for that would have made
+  a look-only command hold a write path. A failed candidate is reported in
+  place rather than failing the batch, and cannot be picked — committing one
+  would put a flame on Home that nobody saw.
 
 ### Changed
 

--- a/packages/app/scripts/gallery-admin.mjs
+++ b/packages/app/scripts/gallery-admin.mjs
@@ -47,7 +47,7 @@
 import { execFileSync, spawn } from 'node:child_process'
 import { existsSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { basename, dirname, join, resolve } from 'node:path'
+import { basename, dirname, extname, join, resolve } from 'node:path'
 import { setTimeout as delay } from 'node:timers/promises'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 import { parseArgs } from 'node:util'
@@ -1608,6 +1608,102 @@ async function commandCapture(values) {
   return result
 }
 
+// ── poster ───────────────────────────────────────────────────────────
+
+// Poster keys carry their format in the extension; the bucket is not asked.
+const MIME_BY_EXT = {
+  '.webp': 'image/webp',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+}
+
+/**
+ * Hand back a row's captured poster, as base64.
+ *
+ * Exists for `local` above all. dev and prod serve posters over HTTP already
+ * (`GET /api/gallery/poster/<key>` on the deployed Worker), so anything with a
+ * browser can just point an <img> at those and get caching for free. The local
+ * bucket is inside miniflare and has no URL at all unless a dev server happens
+ * to be running — which is a heavy thing to require for a thumbnail.
+ *
+ * Reads nothing but R2: a row must already have been captured. Rendering a
+ * flame that has no poster is a different, far more expensive operation.
+ */
+function commandPoster(values) {
+  const env = resolveEnv(values)
+  if (values.slug === undefined) {
+    throw new AdminError('usage', 'poster needs --slug')
+  }
+  const slug = values.slug
+  if (!SLUG_PATTERN.test(slug)) {
+    throw new AdminError('bad-slug', `"${slug}" is not a valid slug`)
+  }
+  const row = requireRow(env, slug)
+  if (!row.poster_key) {
+    throw new AdminError(
+      'no-poster',
+      `"${slug}" has no poster yet — there is nothing to show`,
+      {
+        ...targetFields(env),
+        slug,
+        fix: `node scripts/gallery-admin.mjs capture --slug ${slug} --env ${env}`,
+      },
+    )
+  }
+
+  let bytes
+  try {
+    bytes = execFileSync(
+      'pnpm',
+      [
+        'exec',
+        'wrangler',
+        'r2',
+        'object',
+        'get',
+        `${TARGETS[env].bucket}/gallery/${row.poster_key}`,
+        // --pipe puts the object on stdout and silences wrangler's banner,
+        // which would otherwise be prepended to the image bytes.
+        '--pipe',
+        ...storageFlags(env),
+      ],
+      {
+        cwd: appDir,
+        // No encoding: this is an image, and decoding it as utf8 would corrupt
+        // every byte above 0x7f.
+        encoding: 'buffer',
+        maxBuffer: 64 * 1024 * 1024,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      },
+    )
+  } catch (error) {
+    throw new AdminError(
+      'poster-unreadable',
+      `Could not read ${row.poster_key} from ${TARGETS[env].bucket}`,
+      {
+        ...targetFields(env),
+        slug,
+        posterKey: row.poster_key,
+        cause: tail(String(error.stderr ?? '')) || 'no output',
+        hint: 'the row names a poster the bucket does not have — re-capture it',
+      },
+    )
+  }
+
+  return {
+    ...targetFields(env),
+    slug,
+    posterKey: row.poster_key,
+    width: row.poster_width,
+    height: row.poster_height,
+    bytes: bytes.length,
+    mimeType:
+      MIME_BY_EXT[extname(row.poster_key).toLowerCase()] ?? 'image/webp',
+    base64: bytes.toString('base64'),
+  }
+}
+
 // ── delete ───────────────────────────────────────────────────────────
 
 /**
@@ -1939,6 +2035,10 @@ const COMMANDS = {
   delete: {
     run: commandDelete,
     options: ['env', 'confirm', 'slug', 'yes'],
+  },
+  poster: {
+    run: commandPoster,
+    options: ['env', 'confirm', 'slug'],
   },
   reorder: {
     run: commandReorder,

--- a/packages/app/scripts/gallery-admin.mjs
+++ b/packages/app/scripts/gallery-admin.mjs
@@ -315,12 +315,26 @@ Options:
   --file <path>         append ONE hand-picked flame (PNG/JSON) to the end of
                         the row's existing walk instead of generating. Held to
                         the same validation the put command applies.
+  --preview             render every candidate and print them as base64 images
+                        WITHOUT writing anything. Needs a dev server (started
+                        for you unless --no-serve). Look, then pick.
+  --pick <a,b,c>        commit only these candidate indices, in this order.
+                        Pass the SAME --seed the preview reported, or you will
+                        re-derive a different set and pick from the wrong one.
+  --base <url>          dev server the preview renders through
+                        (default ${DEFAULT_DEV_BASE})
+  --no-serve            refuse rather than starting a dev server for --preview
 ${COMMON_OPTIONS}
 
 Most rows are one flame. A few play a walk, because a single still cannot show
 what the card claims — "roll a whole flame, then steer it" is a path, and so is
 "breed two flames". The walk is generated ONCE and stored, so every visitor
 sees the same one and a bad roll is fixed by re-running with another seed.
+
+Preview first. Deriving is cheap and deterministic in --seed, so the honest
+loop is: --preview to see the candidates, then re-run with the seed it reports
+plus --pick to keep the ones worth keeping. The order in --pick is the order
+they play, and repeats are allowed.
 
 Composes scripts/gallery-sequence.mjs, which runs the app's own randomiser and
 breeder. NOTE: \`put\` clears a row's sequence, because it was derived from the
@@ -1580,7 +1594,7 @@ async function commandCapture(values) {
  * shells out to (chaos-master-gallery.sh) only ever execs THIS script, so
  * anything not routed through here is terminal-only.
  */
-function commandSequence(values) {
+async function commandSequence(values) {
   const env = resolveEnv(values)
   if (values.slug === undefined) {
     throw new AdminError('usage', 'sequence needs --slug')
@@ -1613,6 +1627,65 @@ function commandSequence(values) {
     if (values.derived !== undefined) args.push('--derived', values.derived)
     if (values.seed !== undefined) args.push('--seed', values.seed)
     if (values.paths !== undefined) args.push('--paths', values.paths)
+    if (values.pick !== undefined) args.push('--pick', values.pick)
+  }
+
+  /*
+   * A preview renders the candidates and returns them as images, writing
+   * nothing. It needs a dev server for the same reason `capture` does — the
+   * flames render on a real GPU through the app's own page — so it borrows the
+   * same bootstrap, including auto-start.
+   *
+   * `--apply` is stripped: this must not be able to touch the database even if
+   * the script it calls were to change under it.
+   */
+  if (values.preview === true) {
+    // --apply becomes --read: same row, same parent flame, no write path at
+    // all. Leaving --apply in place would work today only because the preview
+    // returns before the UPDATE, which is one refactor away from writing.
+    args[args.indexOf('--apply')] = '--read'
+    args.push('--preview')
+
+    const base = (values.base ?? DEFAULT_DEV_BASE).replace(/\/$/, '')
+    const server = await ensureDevServer({
+      base,
+      autoStart: values['no-serve'] !== true,
+      timeoutMs: 120_000,
+    })
+    args.push('--base', server.base)
+    try {
+      // Piped, not inherited: the payload is JSON for the console to render,
+      // and progress chatter goes to stderr where it cannot corrupt it.
+      const stdout = execFileSync('node', args, {
+        cwd: appDir,
+        encoding: 'utf8',
+        maxBuffer: 256 * 1024 * 1024,
+        stdio: ['ignore', 'pipe', 'inherit'],
+      })
+      // Returned, not emitted: the dispatcher wraps and prints it, so emitting
+      // here would put two JSON objects on stdout and break every parser.
+      return {
+        preview: true,
+        env,
+        slug,
+        title: row.title,
+        ...JSON.parse(stdout),
+      }
+    } catch (error) {
+      throw new AdminError(
+        'preview-failed',
+        `could not preview a sequence for "${slug}"`,
+        {
+          cause: error instanceof Error ? error.message : String(error),
+          hint:
+            'the derivation itself is cheap; a failure here is usually the ' +
+            'dev server or the GPU. Re-run without --preview to see the ' +
+            'derivation on its own.',
+        },
+      )
+    } finally {
+      await server.stop()
+    }
   }
 
   note(
@@ -1694,6 +1767,8 @@ const OPTIONS = {
   seed: { type: 'string' },
   paths: { type: 'string' },
   clear: { type: 'boolean' },
+  preview: { type: 'boolean' },
+  pick: { type: 'string' },
   help: { type: 'boolean', short: 'h' },
 }
 
@@ -1746,6 +1821,14 @@ const COMMANDS = {
       'paths',
       'clear',
       'file',
+      // Look-before-you-write: --preview renders the candidates and returns
+      // them as images without touching the row; --pick then commits the ones
+      // that were worth keeping. --base/--no-serve are the dev server the
+      // rendering needs, same as `capture`.
+      'preview',
+      'pick',
+      'base',
+      'no-serve',
     ],
   },
   config: {

--- a/packages/app/scripts/gallery-admin.mjs
+++ b/packages/app/scripts/gallery-admin.mjs
@@ -22,6 +22,7 @@
 //   publish  take a staged row live, or pull a live one back
 //   reorder  set a row's position within its section
 //   sequence give a row a curated flame walk (or clear it back to one still)
+//   delete   remove an unpublished row and its poster — the only destructive one
 //   config   read or write Home's settings (home_config), allowlisted keys
 //
 // Three deliberate constraints:
@@ -171,6 +172,7 @@ Commands:
   publish   set published to 0 or 1 for one row
   reorder   set sort_order for one row
   sequence  give a row a curated flame walk, or clear it back to one still
+  delete    remove an unpublished row and its poster (not reversible)
   config    read or write Home's settings (allowlisted keys)
 
 ${COMMON_OPTIONS}
@@ -340,6 +342,32 @@ Composes scripts/gallery-sequence.mjs, which runs the app's own randomiser and
 breeder. NOTE: \`put\` clears a row's sequence, because it was derived from the
 flame being replaced — so the order is put, then sequence, then capture, then
 publish.`,
+
+  delete: `gallery-admin delete — remove a row, and its poster with it
+
+Usage:
+  node scripts/gallery-admin.mjs delete --slug <slug> --yes <slug> [options]
+
+Options:
+  --slug <slug>         the row to remove
+  --yes <slug>          repeat the slug to confirm. Not a bare --yes on
+                        purpose: a generic flag gets typed reflexively, and
+                        this is the one command with nothing to undo it.
+${COMMON_OPTIONS}
+
+The ONLY destructive command here. Everything else is reversible — publish 0
+hides a row and publish 1 brings it back — so reach for that first if you are
+not certain.
+
+A PUBLISHED row is refused: unpublish it, then delete it. Deleting must not be
+a one-step way to take something off Home, or a mistyped slug becomes an
+outage instead of an inconvenience.
+
+The R2 poster goes too. The row is removed first and the object second, so a
+half-failure leaves an orphaned object (invisible, cheap) rather than a row
+pointing at a poster that is gone. If the object delete fails, the exact
+command to finish the job is printed — the key exists nowhere else once the
+row is gone.`,
 
   config: `gallery-admin config — Home's settings, as content
 
@@ -1580,6 +1608,108 @@ async function commandCapture(values) {
   return result
 }
 
+// ── delete ───────────────────────────────────────────────────────────
+
+/**
+ * Remove a row from the gallery, and its poster with it.
+ *
+ * Every other write here is reversible — `publish 0` hides a row and `publish
+ * 1` brings it back. This one is not, so it is guarded three ways:
+ *
+ *   1. a PUBLISHED row is refused outright. Unpublish it first. Deleting must
+ *      never be the one-step way to take something off Home, because then a
+ *      mistyped slug is an outage rather than an inconvenience.
+ *   2. `--yes <slug>` must repeat the slug exactly. A generic confirmation
+ *      flag would be typed reflexively; retyping the name means the thing you
+ *      confirmed is the thing that goes.
+ *   3. prod still needs its own `--confirm prod`, as everywhere else.
+ */
+function commandDelete(values) {
+  const env = resolveEnv(values)
+  if (values.slug === undefined) {
+    throw new AdminError('usage', 'delete needs --slug')
+  }
+  const slug = values.slug
+  if (!SLUG_PATTERN.test(slug)) {
+    throw new AdminError('bad-slug', `"${slug}" is not a valid slug`)
+  }
+  const row = requireRow(env, slug)
+
+  if (row.published === 1) {
+    throw new AdminError(
+      'refuses-published',
+      `"${slug}" is live on Home — unpublish it before deleting it`,
+      {
+        ...targetFields(env),
+        slug,
+        fix: `node scripts/gallery-admin.mjs publish --slug ${slug} --published 0 --env ${env}`,
+        why: 'deleting must not be a one-step way to take a row off Home',
+      },
+    )
+  }
+
+  if (values.yes !== slug) {
+    throw new AdminError(
+      'delete-confirmation-required',
+      `Deleting "${slug}" is not reversible — repeat the slug to confirm`,
+      {
+        ...targetFields(env),
+        slug,
+        fix: `add --yes ${slug}`,
+        alternative: `publish --published 0 hides a row without destroying it`,
+      },
+    )
+  }
+
+  // Read the key BEFORE the row goes: it is recorded nowhere else, so losing
+  // it here would leave an R2 object nobody can ever name again.
+  const posterKey = row.poster_key ?? null
+
+  note(`Deleting ${slug} from ${targetLabel(env)} ...`)
+  d1(env, `DELETE FROM gallery_items WHERE slug = ${sqlStr(slug)};`)
+
+  // Row first, object second, deliberately. If this half fails we are left
+  // with an orphaned object — invisible and cheap — rather than a row pointing
+  // at a poster that no longer exists. The key is printed either way so a
+  // failure here stays fixable by hand.
+  let posterDeleted = null
+  if (posterKey !== null) {
+    try {
+      execFileSync(
+        'pnpm',
+        [
+          'exec',
+          'wrangler',
+          'r2',
+          'object',
+          'delete',
+          `${TARGETS[env].bucket}/gallery/${posterKey}`,
+          ...storageFlags(env),
+        ],
+        { cwd: appDir, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] },
+      )
+      posterDeleted = true
+      note(`Deleted its poster ${posterKey}.`)
+    } catch (error) {
+      posterDeleted = false
+      note(
+        `WARNING: the row is gone but its poster is not. Remove it with:\n` +
+          `  pnpm exec wrangler r2 object delete ${TARGETS[env].bucket}/gallery/${posterKey} ${storageFlags(env).join(' ')}\n` +
+          `  (${tail(error.stderr ?? '') || 'no output'})`,
+      )
+    }
+  }
+
+  return {
+    ...targetFields(env),
+    slug,
+    deleted: true,
+    title: row.title,
+    posterKey,
+    posterDeleted,
+  }
+}
+
 // ── sequence ─────────────────────────────────────────────────────────
 
 /**
@@ -1769,6 +1899,7 @@ const OPTIONS = {
   clear: { type: 'boolean' },
   preview: { type: 'boolean' },
   pick: { type: 'string' },
+  yes: { type: 'string' },
   help: { type: 'boolean', short: 'h' },
 }
 
@@ -1804,6 +1935,10 @@ const COMMANDS = {
   publish: {
     run: commandPublish,
     options: ['env', 'confirm', 'slug', 'published'],
+  },
+  delete: {
+    run: commandDelete,
+    options: ['env', 'confirm', 'slug', 'yes'],
   },
   reorder: {
     run: commandReorder,

--- a/packages/app/scripts/gallery-sequence.mjs
+++ b/packages/app/scripts/gallery-sequence.mjs
@@ -29,10 +29,21 @@
 //                            walk shows both parents before their children.
 //                  e.g. node scripts/gallery-sequence.mjs cap-genetics \
 //                         --mode breed --derived 5 --apply local
+//   --read <env>   read the parent flame from this env WITHOUT writing.
+//                  Implied by nothing; --preview uses it so the candidates it
+//                  shows come from the same row a later --apply would update.
 //   --apply <env>  local | dev | prod. Writing anywhere but local is a
 //                  deliberate act; this script does not default to it.
 //   --out <file>   Write the SQL to a file.
 //   --clear        Set the column back to NULL — the single-flame behaviour.
+//   --preview      Derive candidates, RENDER each one, and print them as
+//                  base64 images WITHOUT writing to the database. The point is
+//                  to see a walk before committing to it; sequences are
+//                  generated once and stared at for a long time afterwards.
+//                  Needs the dev server (--base, default https://localhost:5173).
+//   --pick <list>  Commit only these candidate indices, in this order, e.g.
+//                  `--pick 0,3,4`. Re-derives from the same --seed, so what is
+//                  written is exactly what was previewed.
 //   --append <file>  Append ONE hand-picked flame from a PNG/JSON to the end of
 //                  the row's existing sequence, instead of generating. The file
 //                  is validated exactly as `gallery-admin put` validates one.
@@ -49,9 +60,11 @@ import { execFileSync } from 'node:child_process'
 import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { basename, dirname, join, resolve } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 import { describeSource } from './gallery-admin.mjs'
 import { initCommand, isMissingTable, migrationsArgs, storageFlags, tail, TARGET_LIST, targetLabel, TARGETS, } from './gallery-targets.mjs'
+import { renderFlames } from './render-flames.mjs'
+import { parsePick } from './sequence-pick.mjs'
 
 const scriptDir = dirname(fileURLToPath(import.meta.url))
 const appDir = resolve(scriptDir, '..')
@@ -84,9 +97,13 @@ function parseArgs(argv) {
     ...DEFAULTS,
     slug: null,
     apply: null,
+    read: null,
     out: null,
     roll: true,
     append: null,
+    preview: false,
+    pick: null,
+    base: 'https://localhost:5173',
   }
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i]
@@ -98,9 +115,13 @@ function parseArgs(argv) {
     else if (arg === '--mode') args.mode = String(argv[++i])
     else if (arg === '--no-roll') args.roll = false
     else if (arg === '--apply') args.apply = argv[++i]
+    else if (arg === '--read') args.read = argv[++i]
     else if (arg === '--out') args.out = argv[++i]
     else if (arg === '--clear') args.clear = true
     else if (arg === '--append') args.append = argv[++i]
+    else if (arg === '--preview') args.preview = true
+    else if (arg === '--pick') args.pick = argv[++i]
+    else if (arg === '--base') args.base = argv[++i]
     else if (arg.startsWith('-')) fail(`unknown option ${arg}`)
     else if (args.slug === null) args.slug = arg
     else fail(`unexpected argument ${arg}`)
@@ -290,8 +311,20 @@ async function main() {
     fail(`unknown target "${args.apply}" — expected ${TARGET_LIST}`)
   }
   // Reading the row needs a database even when only printing SQL, so a plain
-  // dry run reads from local. Writing still needs --apply.
-  const readEnv = args.apply ?? 'local'
+  if (args.read !== null && !(args.read in TARGETS)) {
+    fail(`unknown target "${args.read}" — expected ${TARGET_LIST}`)
+  }
+  /*
+   * Where the PARENT flame is read from. Normally that is wherever the result
+   * is being written, so the walk starts from the flame that env actually has.
+   *
+   * `--read` names it without `--apply`, which is what `--preview` needs: it
+   * must derive from the same row the eventual commit will, while being
+   * structurally unable to write. Defaulting a preview to local instead would
+   * render a walk from a different parent flame than the one committed — a
+   * preview that lies, which is worse than no preview.
+   */
+  const readEnv = args.read ?? args.apply ?? 'local'
 
   let sequence = null
   if (args.append !== null) {
@@ -342,6 +375,89 @@ async function main() {
         `${args.mode}, ${args.paths} path(s), seed ${args.seed}, ` +
         `${derived.dimensions}D.`,
     )
+
+    /*
+     * `--pick` keeps only the chosen candidates, in the order given.
+     *
+     * Derivation is deterministic in `--seed`, so re-deriving here yields the
+     * exact flames the preview rendered — the indices mean the same thing in
+     * both runs, and nothing has to be carried between them in a temp file that
+     * could go stale or be pointed at the wrong row.
+     */
+    if (args.pick !== null) {
+      let picked
+      try {
+        picked = parsePick(args.pick, sequence.length)
+      } catch (error) {
+        fail(error.message, error.hint)
+      }
+      sequence = picked.map((i) => sequence[i])
+      console.error(
+        `Keeping ${sequence.length} of them: [${picked.join(', ')}].`,
+      )
+    }
+
+    /*
+     * A preview RENDERS and prints, and writes nothing. Deciding whether a walk
+     * is any good by publishing it and reloading Home is backwards; this is the
+     * look-first half.
+     */
+    if (args.preview) {
+      console.error(`Rendering ${sequence.length} candidate(s) ...`)
+      const images = await renderFlames({
+        flames: sequence,
+        base: args.base.replace(/\/$/, ''),
+        onProgress: (m) => {
+          console.error(m)
+        },
+      })
+      const candidates = sequence.map((flame, index) => {
+        const image = images.find((i) => i.index === index)
+        return {
+          index,
+          transformCount: Object.keys(flame.transforms ?? {}).length,
+          dimensions: flame.renderSettings?.dimensions ?? 2,
+          error: image?.error ?? 'not rendered',
+          // Inline base64 rather than files on disk: the console that shows
+          // these talks to this script over stdout and has nowhere to serve a
+          // temp directory from.
+          image:
+            image?.bytes === null || image?.bytes === undefined
+              ? null
+              : `data:${image.mimeType};base64,${image.bytes.toString('base64')}`,
+        }
+      })
+      for (const c of candidates) {
+        if (c.image !== null) c.error = null
+      }
+      process.stdout.write(
+        `${JSON.stringify(
+          {
+            ok: true,
+            preview: true,
+            slug: args.slug,
+            seed: args.seed,
+            mode: args.mode,
+            // Everything needed to commit exactly this set later.
+            commit: {
+              slug: args.slug,
+              seed: args.seed,
+              mode: args.mode,
+              derived: args.derived,
+              paths: args.paths,
+            },
+            candidates,
+          },
+          null,
+          2,
+        )}\n`,
+      )
+      console.error(
+        `Previewed ${candidates.filter((c) => c.image).length}/${candidates.length}` +
+          ' — nothing written. Re-run with --pick <indices> --apply <env> to keep some.',
+      )
+      return
+    }
   }
 
   const sql = buildSql(args.slug, sequence)
@@ -362,4 +478,13 @@ async function main() {
   process.stdout.write(sql)
 }
 
-await main()
+/*
+ * Only run the CLI when this file IS the command being run — importing it for
+ * `parsePick` must not execute main() against the importer's argv.
+ */
+if (
+  process.argv[1] !== undefined &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  await main()
+}

--- a/packages/app/scripts/render-flames.mjs
+++ b/packages/app/scripts/render-flames.mjs
@@ -1,0 +1,140 @@
+// Render arbitrary flames to images on the real GPU.
+//
+// The poster pipeline renders rows out of D1; this renders whatever you hand
+// it, which is what a sequence PREVIEW needs — its candidates do not exist in
+// the database yet, and the whole point is deciding whether they ever should.
+//
+// Both go through the same capture page (`scripts/poster-capture.html` +
+// posterCapture.tsx), which already accepts a bare `spec` carrying its own
+// flame. So this shares the app's export driver, its quality gate and its
+// blank-canvas check rather than growing a second renderer that drifts.
+//
+// Returns images as BYTES; the caller decides whether they become files, or
+// base64 in a JSON payload for a console to show.
+import { Buffer } from 'node:buffer'
+import { chromium } from 'playwright'
+import { CAPTURE_PAGE } from './dev-server-checkout.mjs'
+
+const EXT = {
+  'image/webp': 'webp',
+  'image/png': 'png',
+  'image/jpeg': 'jpg',
+}
+
+/**
+ * Render each flame once, in one browser session.
+ *
+ * Headed with the WebGPU flags, for the same reason the poster capture is:
+ * headless Chromium has no usable WebGPU on this machine and would write black
+ * images that look like a rendering bug rather than a missing adapter.
+ *
+ * @param {object} options
+ * @param {unknown[]} options.flames  descriptors to render, in order
+ * @param {string} options.base       dev server origin, e.g. https://localhost:5173
+ * @param {(msg: string) => void} [options.onProgress]
+ * @returns {Promise<{ index: number, bytes: Buffer, mimeType: string, ext: string,
+ *   peak: number, error: string | null }[]>}
+ */
+export async function renderFlames({
+  flames,
+  base,
+  width = 480,
+  height = 270,
+  quality = 0.9,
+  pointCountPerBatch = 4e5,
+  mimeType = 'image/webp',
+  encodeQuality = 0.85,
+  timeout = 120_000,
+  onProgress = () => {},
+}) {
+  if (flames.length === 0) return []
+
+  const browser = await chromium.launch({
+    headless: false,
+    args: [
+      '--enable-unsafe-webgpu',
+      '--enable-features=Vulkan',
+      '--ignore-gpu-blocklist',
+    ],
+  })
+  try {
+    // ignoreHTTPSErrors: the dev server is HTTPS with a self-signed cert
+    // (basic-ssl), which Playwright refuses without this.
+    const context = await browser.newContext({
+      viewport: { width: 900, height: 700 },
+      ignoreHTTPSErrors: true,
+    })
+    const page = await context.newPage()
+    page.on('pageerror', (err) => {
+      onProgress(`  [page] ${err.message}`)
+    })
+
+    await page.goto(`${base}${CAPTURE_PAGE}`, {
+      waitUntil: 'load',
+      timeout: 60_000,
+    })
+    await page.waitForFunction(() => '__posterCapture' in window, undefined, {
+      timeout: 60_000,
+    })
+
+    const out = []
+    for (const [index, flame] of flames.entries()) {
+      onProgress(`  rendering ${index + 1}/${flames.length} ...`)
+      try {
+        await page.evaluate((s) => window.__posterCapture.load(s), {
+          slug: `candidate-${index}`,
+          flame,
+          animation: null,
+          width,
+          height,
+          quality,
+          pointCountPerBatch,
+          frame: null,
+          frameFraction: null,
+          mimeType,
+          encodeQuality,
+        })
+        await page.waitForFunction(
+          () => {
+            const status = window.__posterCapture.status()
+            if (status.state === 'error') throw new Error(status.error)
+            return status.state === 'done'
+          },
+          undefined,
+          { timeout, polling: 500 },
+        )
+        const result = await page.evaluate(() => window.__posterCapture.take())
+        if (!result) throw new Error('capture page returned no image')
+        // The same blank guard the poster capture uses: a canvas that never
+        // drew encodes fine and is uniformly black, so only the pixels can
+        // tell you it failed.
+        if (result.peak <= 2) {
+          throw new Error(`blank render (peak channel ${result.peak})`)
+        }
+        out.push({
+          index,
+          bytes: Buffer.from(result.base64, 'base64'),
+          mimeType: result.mimeType,
+          ext: EXT[result.mimeType] ?? 'bin',
+          peak: result.peak,
+          error: null,
+        })
+      } catch (error) {
+        // One bad candidate must not lose the rest — a preview of 8 usable
+        // flames beats an error because the 9th would not converge.
+        out.push({
+          index,
+          bytes: null,
+          mimeType,
+          ext: EXT[mimeType] ?? 'bin',
+          peak: 0,
+          error: error instanceof Error ? error.message : String(error),
+        })
+        onProgress(`  candidate ${index} failed: ${String(error)}`)
+      }
+    }
+    return out
+  } finally {
+    await browser.close()
+  }
+}

--- a/packages/app/scripts/sequence-pick.mjs
+++ b/packages/app/scripts/sequence-pick.mjs
@@ -1,0 +1,43 @@
+// Which previewed candidates get written.
+//
+// Its own module, with no imports, for one reason: it is the only part of the
+// sequence tooling worth unit-testing, and gallery-sequence.mjs cannot be
+// imported from a test — it pulls in gallery-admin.mjs, which resolves repo
+// paths at module load.
+
+/**
+ * Parse `--pick 0,3,4` into indices that actually exist.
+ *
+ * Refuses an out-of-range index rather than silently dropping it: a curator who
+ * mistypes one should be told, not handed a shorter walk than they asked for
+ * and left to notice later.
+ *
+ * Order is preserved and repeats are kept — `--pick 2,0,2` is a deliberate
+ * three-step walk that revisits a flame, not a mistake to be tidied up.
+ *
+ * THROWS rather than exiting, so the parsing can be tested without taking the
+ * test runner down with it; the CLI turns the error into a `fail()`.
+ *
+ * @param {string} raw    the flag's value
+ * @param {number} count  how many candidates the derivation produced
+ * @returns {number[]}
+ */
+export function parsePick(raw, count) {
+  // argv always hands this over as a string.
+  const parts = raw
+    .split(',')
+    .map((p) => p.trim())
+    .filter((p) => p.length > 0)
+  if (parts.length === 0) throw new Error('--pick needs at least one index')
+  const picked = []
+  for (const part of parts) {
+    const n = Number(part)
+    if (!Number.isInteger(n) || n < 0 || n >= count) {
+      const error = new Error(`--pick index "${part}" is out of range`)
+      error.hint = `this derivation produced ${count} candidate(s): 0..${count - 1}`
+      throw error
+    }
+    picked.push(n)
+  }
+  return picked
+}

--- a/packages/app/src/utils/gallerySequencePick.test.ts
+++ b/packages/app/src/utils/gallerySequencePick.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import { parsePick } from '../../scripts/sequence-pick.mjs'
+
+/*
+ * `--pick` decides which previewed candidates get written to the Home gallery.
+ *
+ * It is worth testing on its own because the failure is silent and durable: an
+ * off-by-one here does not throw, it publishes a flame nobody looked at, and
+ * the only way to notice is to spot it on Home later.
+ */
+describe('parsePick', () => {
+  it('keeps the order it was given, not sorted order', () => {
+    // The walk plays in sequence, so 2,0,1 is a different piece from 0,1,2.
+    expect(parsePick('2,0,1', 4)).toEqual([2, 0, 1])
+  })
+
+  it('keeps repeats — revisiting a flame is a legitimate walk', () => {
+    expect(parsePick('0,2,0', 3)).toEqual([0, 2, 0])
+  })
+
+  it('tolerates the spacing a human types', () => {
+    expect(parsePick(' 1 , 3 ', 4)).toEqual([1, 3])
+    expect(parsePick('1,,2', 4)).toEqual([1, 2])
+  })
+
+  it('accepts the whole range, including the last index', () => {
+    expect(parsePick('0,3', 4)).toEqual([0, 3])
+  })
+
+  it('refuses an index past the end rather than dropping it', () => {
+    // Dropping it would write a shorter walk than asked for and say nothing.
+    expect(() => parsePick('0,4', 4)).toThrow(/out of range/)
+    expect(() => parsePick('-1', 4)).toThrow(/out of range/)
+  })
+
+  it('refuses anything that is not a whole index', () => {
+    expect(() => parsePick('1.5', 4)).toThrow(/out of range/)
+    expect(() => parsePick('two', 4)).toThrow(/out of range/)
+  })
+
+  it('refuses an empty selection instead of clearing the row', () => {
+    // An empty --pick must not read as "keep nothing" — clearing a sequence is
+    // what --clear is for, and doing it by accident loses curation work.
+    expect(() => parsePick('', 4)).toThrow(/at least one index/)
+    expect(() => parsePick('  ,  ', 4)).toThrow(/at least one index/)
+  })
+
+  it('explains how many candidates there actually were', () => {
+    // The hint is the whole reason the error is actionable.
+    try {
+      parsePick('9', 4)
+      expect.unreachable('should have thrown')
+    } catch (error) {
+      expect((error as { hint?: string }).hint).toContain('0..3')
+    }
+  })
+})

--- a/packages/app/src/worker/index.test.ts
+++ b/packages/app/src/worker/index.test.ts
@@ -178,6 +178,32 @@ describe('worker — S-3 security headers', () => {
     expect(csp).toContain("default-src 'self'")
     expect(csp).toContain("'unsafe-eval'")
   })
+
+  /*
+   * The mic is a FEATURE here — audio-reactive wiring and sonification both
+   * take live input. `microphone=()` is an empty allowlist, which blocks our
+   * own origin too: getUserMedia never prompts, it throws "microphone is not
+   * allowed in this document", and the panel looks broken rather than denied.
+   *
+   * Worth a test because nothing else catches it: the app builds, deploys and
+   * renders perfectly, and the only symptom is a permission prompt that never
+   * appears on a page nobody tests headlessly.
+   */
+  it('allows the microphone for this origin, and nothing else it does not use', async () => {
+    const res = await worker.fetch(
+      post('https://x.test/api/shorten', { payload: 'abc' }),
+      makeEnv(),
+      ctx,
+    )
+    const pp = res.headers.get('Permissions-Policy') ?? ''
+    expect(pp).toContain('microphone=(self)')
+    // Still denied to embedders — `self` is not `*`.
+    expect(pp).not.toContain('microphone=*')
+    // Features the app genuinely never uses stay fully locked.
+    for (const denied of ['camera', 'geolocation', 'payment', 'usb']) {
+      expect(pp).toContain(`${denied}=()`)
+    }
+  })
 })
 
 describe('worker OG meta injection — XSS escaping guard', () => {

--- a/packages/app/src/worker/index.ts
+++ b/packages/app/src/worker/index.ts
@@ -863,8 +863,14 @@ const SECURITY_HEADERS: Readonly<Record<string, string>> = {
   'Strict-Transport-Security': 'max-age=63072000; includeSubDomains',
   // Lock down powerful features the app never uses. WebGPU is not gated by
   // Permissions-Policy, and clipboard-write / fullscreen stay enabled for self.
+  //
+  // microphone=(self), NOT (): the audio-reactive wiring and the sonification
+  // panel both offer live mic input, and an empty allowlist blocks it for our
+  // own origin too — getUserMedia never even prompts, it throws
+  // "microphone is not allowed in this document". `self` still refuses every
+  // embedder, and frame-ancestors 'none' means there are none.
   'Permissions-Policy':
-    'accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=(), browsing-topics=()',
+    'accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(self), payment=(), usb=(), browsing-topics=()',
   // Disable legacy Adobe cross-domain policy files.
   'X-Permitted-Cross-Domain-Policies': 'none',
   'Content-Security-Policy': [


### PR DESCRIPTION
## What

A curated flame walk was written sight-unseen and judged by reloading Home. This adds the look-first half.

- **`sequence --preview`** renders every candidate on the GPU and returns them as base64 data URLs on stdout, writing nothing.
- **`sequence --pick 0,3,5`** then commits exactly those, in that order.

The two agree because derivation is deterministic in `--seed` and the preview reports the seed it used, so the commit re-derives the identical flames. Nothing is carried between runs in a temp file that could go stale or be pointed at the wrong row.

## How

- **`scripts/render-flames.mjs`** — the poster capture's browser loop, extracted and taking flames directly rather than D1 rows (the capture page already accepted a spec carrying its own flame). Preview and poster capture now share one quality gate and one blank-canvas check instead of growing a second renderer that drifts.
- **`--read <env>`** — a preview must derive from the row the eventual commit will update. Reusing `--apply` for that would leave a look-only command holding a write path; dropping it entirely would have silently derived from `local`, i.e. a preview that lies about a `dev` row.
- **`scripts/sequence-pick.mjs`** — `--pick` parsing as a pure module so it can be unit-tested. It throws rather than exiting, and refuses an out-of-range index instead of quietly writing a shorter walk than asked for. Order is the play order; repeats are kept (`--pick 0,2,0` revisits a flame deliberately).
- A candidate that fails to render is reported in place rather than failing the batch, and cannot be picked — committing one would put a flame on Home that nobody saw.

## Verification

- `pnpm check` green; **1335 tests pass** (79 files), including 8 new ones for the pick parser.
- End-to-end through the console: previewed 4 candidates for `cap-genetics`, unticked two, committed. The two flames written to D1 hash-match previewed candidates #0 and #2 exactly.
- `--read` proven to target the named env (a row present only in `local` is found there and reported missing in `dev`).
- Determinism proven: two runs at the same seed produce byte-identical derivations.

No version bump — this rides along with 0.9.9.

## Console side

The companyReportViewer changes (a `4 · Sequence` card, per-row **Sequence** / **Clear walk** buttons, a `walk` badge, and two server routes) live in the user's dotfiles and are committed separately.