### PR TITLE
fix(scripts): say which command could not be started, and why

### DIFF
--- a/packages/app/scripts/capture-gallery-posters.mjs
+++ b/packages/app/scripts/capture-gallery-posters.mjs
@@ -67,7 +67,7 @@ import { createRequire } from 'node:module'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { CAPTURE_PAGE, checkoutFailure, verifyServedCheckout, } from './dev-server-checkout.mjs'
-import { initCommand, isMissingTable, storageFlags, TARGET_LIST, targetLabel, TARGETS, } from './gallery-targets.mjs'
+import { couldNotRun, couldNotRunLines, initCommand, isMissingTable, storageFlags, TARGET_LIST, targetLabel, TARGETS, } from './gallery-targets.mjs'
 
 const require = createRequire(import.meta.url)
 const { chromium } = require('playwright')
@@ -226,6 +226,16 @@ function readRows(env, section, includeUnpublished) {
       },
     )
   } catch (error) {
+    // First: a child that never started has no output, so the branches below
+    // would blame the schema for a `pnpm` that is not on PATH.
+    if (couldNotRun(error)) {
+      const why = couldNotRunLines('pnpm', error)
+        .map((line) => `  ${line}`)
+        .join('\n')
+      throw new Error(
+        `Could not run \`pnpm\` — nothing was read from ${targetLabel(env)}:\n${why}`,
+      )
+    }
     // Under --json the failure comes back on stdout. An empty target is the
     // one failure worth naming: it means the schema is missing, not that the
     // gallery is empty, and gallery-admin is what creates it.

--- a/packages/app/scripts/gallery-admin.mjs
+++ b/packages/app/scripts/gallery-admin.mjs
@@ -53,7 +53,7 @@ import { fileURLToPath, pathToFileURL } from 'node:url'
 import { parseArgs } from 'node:util'
 import { CAPTURE_PAGE, checkoutFailure, probeCapturePage, verifyServedCheckout, } from './dev-server-checkout.mjs'
 import { inspectFlame, isPlainObject, normalizeEnvelope, readFlameChunk, toSlug, transformsHash, } from './extract-flames.mjs'
-import { initCommand, isMissingTable, MIGRATIONS_DIR, migrationsArgs, storageFlags, tail, TARGET_LIST, targetLabel, TARGETS, } from './gallery-targets.mjs'
+import { couldNotRun, couldNotRunDetail, initCommand, isMissingTable, MIGRATIONS_DIR, migrationsArgs, storageFlags, tail, TARGET_LIST, targetLabel, TARGETS, } from './gallery-targets.mjs'
 import { checkConfigEntry, CONFIG_KEY_LIST, CONFIG_KEYS, } from './home-config.mjs'
 
 const scriptDir = dirname(fileURLToPath(import.meta.url))
@@ -444,6 +444,19 @@ function initializeLocal(env) {
       stdio: ['ignore', 'pipe', 'pipe'],
     })
   } catch (error) {
+    if (couldNotRun(error)) {
+      throw new AdminError(
+        'command-not-runnable',
+        `Could not run \`pnpm\` — nothing from ${MIGRATIONS_DIR}/ was applied ` +
+          `to ${targetLabel(env)}`,
+        {
+          ...targetFields(env),
+          ...couldNotRunDetail('pnpm', error),
+          run: initCommand(env),
+          cwd: 'packages/app',
+        },
+      )
+    }
     throw new AdminError(
       'init-failed',
       `Could not create the gallery schema in ${targetLabel(env)}`,
@@ -501,6 +514,21 @@ function d1(env, sql, { initialize = true } = {}) {
       stdio: ['ignore', 'pipe', 'pipe'],
     })
   } catch (error) {
+    // First, because every branch below reads wrangler's output and a child
+    // that never started has none: without this, `pnpm` missing from PATH is
+    // reported as a query that ran and failed, with an empty stdout and an
+    // empty stderr as its entire explanation.
+    if (couldNotRun(error)) {
+      throw new AdminError(
+        'command-not-runnable',
+        `Could not run \`pnpm\` — no query reached ${targetLabel(env)}`,
+        {
+          ...targetFields(env),
+          ...couldNotRunDetail('pnpm', error),
+          cwd: 'packages/app',
+        },
+      )
+    }
     // Under --json wrangler puts the failure on STDOUT, not stderr — both
     // locally and through the API. Reading only stderr reports "it failed"
     // with no reason attached.

--- a/packages/app/scripts/gallery-sequence.mjs
+++ b/packages/app/scripts/gallery-sequence.mjs
@@ -62,7 +62,7 @@ import { tmpdir } from 'node:os'
 import { basename, dirname, join, resolve } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 import { describeSource } from './gallery-admin.mjs'
-import { initCommand, isMissingTable, migrationsArgs, storageFlags, tail, TARGET_LIST, targetLabel, TARGETS, } from './gallery-targets.mjs'
+import { couldNotRun, couldNotRunLines, initCommand, isMissingTable, migrationsArgs, storageFlags, tail, TARGET_LIST, targetLabel, TARGETS, } from './gallery-targets.mjs'
 import { renderFlames } from './render-flames.mjs'
 import { parsePick } from './sequence-pick.mjs'
 
@@ -172,6 +172,14 @@ function d1(env, sql, { initialize = true } = {}) {
       stdio: ['ignore', 'pipe', 'pipe'],
     })
   } catch (error) {
+    // First: a child that never started has no output at all, so every branch
+    // below reads wrangler's silence as a query that ran and failed.
+    if (couldNotRun(error)) {
+      fail(
+        `could not run \`pnpm\` — no query reached ${targetLabel(env)}`,
+        couldNotRunLines('pnpm', error).join('\n'),
+      )
+    }
     // Under --json wrangler reports a failed statement on STDOUT, not stderr.
     const output = `${error.stdout ?? ''}\n${error.stderr ?? ''}`
     if (
@@ -180,10 +188,23 @@ function d1(env, sql, { initialize = true } = {}) {
       TARGETS[env].storage === 'local'
     ) {
       console.error(`Applying migrations to ${targetLabel(env)}…`)
-      execFileSync('pnpm', migrationsArgs(env), {
-        cwd: appDir,
-        stdio: ['ignore', 'ignore', 'inherit'],
-      })
+      try {
+        execFileSync('pnpm', migrationsArgs(env), {
+          cwd: appDir,
+          stdio: ['ignore', 'ignore', 'inherit'],
+        })
+      } catch (migrateError) {
+        // captured: false — this child's stderr is inherited, so it has
+        // already said its piece on the terminal and the empty streams here
+        // mean nothing. Only a spawn error is evidence.
+        if (couldNotRun(migrateError, { captured: false })) {
+          fail(
+            `could not run \`pnpm\` — nothing was applied to ${targetLabel(env)}`,
+            couldNotRunLines('pnpm', migrateError).join('\n'),
+          )
+        }
+        throw migrateError
+      }
       return d1(env, sql, { initialize: false })
     }
     fail(

--- a/packages/app/scripts/gallery-targets.mjs
+++ b/packages/app/scripts/gallery-targets.mjs
@@ -115,3 +115,68 @@ export function tail(text, lines = 12) {
     .filter((line) => line.length > 0)
     .slice(-lines)
 }
+
+/**
+ * Did this failure mean the child never RAN, rather than ran and failed?
+ *
+ * Two shapes, one conclusion. A spawn error — ENOENT for an executable that is
+ * not on PATH, EACCES for one that cannot be executed — never reaches an exit
+ * status at all: node reports `status: null` and captures no streams. And a
+ * real exit code with nothing on either stream (127, typically, from a
+ * launcher that could not resolve what it was asked to run) leaves nothing to
+ * quote back, so reporting THAT as "the query failed" hands the reader the
+ * symptom when the only thing they can act on is the cause.
+ *
+ * The emptiness test is `tail` on purpose: this is true in exactly the cases
+ * where the `stdout` and `stderr` these scripts attach to a failure would both
+ * come out `[]`, which is the report that cannot be acted on.
+ *
+ * `captured` is not optional thinking. A child spawned with an inherited
+ * stderr writes past this process to the terminal, so node captures nothing
+ * and `error.stderr` is null for EVERY failure it can have — emptiness there
+ * is the default, not a signal, and testing it would report a migration that
+ * ran and failed loudly as a command that never started. Those callers get the
+ * spawn-error shape alone, which is the only evidence they actually hold.
+ */
+export function couldNotRun(error, { captured = true } = {}) {
+  if (typeof error?.status !== 'number') return true
+  if (!captured) return false
+  return tail(error.stdout).length === 0 && tail(error.stderr).length === 0
+}
+
+/**
+ * What to say instead, for the detail of the error that replaces the empty one.
+ *
+ * It names the executable and it names PATH, because PATH is essentially
+ * always what is wrong and it is the one thing the reader can check. The
+ * failure is invisible from an interactive shell and total from anywhere else:
+ * a console started from a desktop launcher or a `systemd-run --user` unit
+ * inherits the session environment rather than the login shell's, so a node
+ * installed by nvm — node, pnpm and wrangler all in one version-scoped bin dir
+ * that only ~/.zshrc puts on PATH — is simply not there, and every command
+ * fails at once. Reporting the PATH actually seen makes the hint checkable at
+ * a glance instead of a guess.
+ */
+export function couldNotRunDetail(command, error) {
+  return {
+    command,
+    reason:
+      typeof error?.status === 'number'
+        ? `\`${command}\` exited ${error.status} without writing to stdout or stderr`
+        : `\`${command}\` could not be started (${error?.code ?? 'spawn failed'})`,
+    hint:
+      `PATH must contain the directory holding \`node\` and \`${command}\` — ` +
+      `with nvm that is ~/.nvm/versions/node/<version>/bin, which only an ` +
+      `interactive shell adds. Set PATH explicitly in the launcher or unit.`,
+    searchPath: process.env.PATH ?? '(unset)',
+  }
+}
+
+/**
+ * The same thing as lines, for the scripts whose failures are text rather than
+ * a JSON detail. Derived from `couldNotRunDetail` so the two cannot drift.
+ */
+export function couldNotRunLines(command, error) {
+  const { reason, hint, searchPath } = couldNotRunDetail(command, error)
+  return [reason, hint, `PATH was: ${searchPath}`]
+}

--- a/packages/app/scripts/seed-gallery.mjs
+++ b/packages/app/scripts/seed-gallery.mjs
@@ -24,10 +24,37 @@ import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { migrationsArgs, storageFlags, TARGET_LIST, targetLabel, TARGETS, } from './gallery-targets.mjs'
+import { couldNotRun, couldNotRunLines, migrationsArgs, storageFlags, TARGET_LIST, targetLabel, TARGETS, } from './gallery-targets.mjs'
 
 const scriptDir = dirname(fileURLToPath(import.meta.url))
 const appDir = resolve(scriptDir, '..')
+
+/**
+ * Run a child, and say so plainly when it never started.
+ *
+ * `captured` says whether THIS call piped the child's streams. Where stderr is
+ * inherited node captures nothing, so empty streams are the default rather
+ * than a signal, and only a spawn error proves nothing ran — testing emptiness
+ * there would report a wrangler that failed loudly on the terminal as a
+ * command that could not be found.
+ *
+ * Worth catching at all because the alternative is an ENOENT stack trace
+ * naming node's internals instead of PATH, which is what a run from a desktop
+ * launcher or a systemd unit gets: both inherit a PATH without the nvm bin
+ * dir, and that one directory holds node, pnpm and esbuild alike.
+ */
+function run(command, args, options, { captured, consequence }) {
+  try {
+    return execFileSync(command, args, { cwd: appDir, ...options })
+  } catch (error) {
+    if (!couldNotRun(error, { captured })) throw error
+    console.error(`Could not run \`${command}\` — ${consequence}.`)
+    for (const line of couldNotRunLines(command, error)) {
+      console.error(`  ${line}`)
+    }
+    process.exit(1)
+  }
+}
 
 /**
  * What Home shows, in the order it shows it.
@@ -141,7 +168,7 @@ function parseArgs(argv) {
 function loadContent() {
   const dir = mkdtempSync(join(tmpdir(), 'gallery-seed-'))
   const bundle = join(dir, 'dump.mjs')
-  execFileSync(
+  run(
     'pnpm',
     [
       'exec',
@@ -154,13 +181,16 @@ function loadContent() {
       `--alias:@=${join(appDir, 'src')}`,
       `--outfile=${bundle}`,
     ],
-    { cwd: appDir, stdio: ['ignore', 'ignore', 'inherit'] },
+    { stdio: ['ignore', 'ignore', 'inherit'] },
+    { captured: false, consequence: 'the example flames were never bundled' },
   )
-  const out = execFileSync('node', [bundle], {
-    cwd: appDir,
-    maxBuffer: 256 * 1024 * 1024,
-  })
-  return JSON.parse(out.toString())
+  const out = run(
+    'node',
+    [bundle],
+    { encoding: 'utf8', maxBuffer: 256 * 1024 * 1024 },
+    { captured: true, consequence: 'the bundled examples were never read' },
+  )
+  return JSON.parse(out)
 }
 
 const sqlStr = (v) =>
@@ -274,15 +304,20 @@ function main() {
     // database is a problem to look at, not something a seed script should
     // quietly fix.
     if (target.storage === 'local') {
-      execFileSync('pnpm', migrationsArgs(args.apply), {
-        cwd: appDir,
-        stdio: ['ignore', 'ignore', 'inherit'],
-      })
+      run(
+        'pnpm',
+        migrationsArgs(args.apply),
+        { stdio: ['ignore', 'ignore', 'inherit'] },
+        {
+          captured: false,
+          consequence: `no migrations were applied to ${targetLabel(args.apply)}`,
+        },
+      )
     }
     const dir = mkdtempSync(join(tmpdir(), 'gallery-sql-'))
     const file = join(dir, 'seed.sql')
     writeFileSync(file, sql)
-    execFileSync(
+    run(
       'pnpm',
       [
         'exec',
@@ -293,7 +328,11 @@ function main() {
         ...where,
         `--file=${file}`,
       ],
-      { cwd: appDir, stdio: 'inherit' },
+      { stdio: 'inherit' },
+      {
+        captured: false,
+        consequence: `no rows reached ${targetLabel(args.apply)}`,
+      },
     )
     console.error(`Applied ${total} rows to ${targetLabel(args.apply)}.`)
     return

--- a/packages/app/scripts/validate-gallery.mjs
+++ b/packages/app/scripts/validate-gallery.mjs
@@ -22,7 +22,7 @@ import { mkdtempSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { isMissingTable, storageFlags, tail, TARGET_LIST, targetLabel, TARGETS, } from './gallery-targets.mjs'
+import { couldNotRun, couldNotRunLines, isMissingTable, storageFlags, tail, TARGET_LIST, targetLabel, TARGETS, } from './gallery-targets.mjs'
 
 const scriptDir = dirname(fileURLToPath(import.meta.url))
 const appDir = resolve(scriptDir, '..')
@@ -66,6 +66,14 @@ function d1(env, sql) {
       stdio: ['ignore', 'pipe', 'pipe'],
     })
   } catch (error) {
+    // First: a child that never started has no output, and "nothing to
+    // validate" is a badly wrong thing to tell someone whose PATH is broken.
+    if (couldNotRun(error)) {
+      fail(
+        `could not run \`pnpm\` — nothing was read from ${targetLabel(env)}`,
+        couldNotRunLines('pnpm', error).join('\n'),
+      )
+    }
     const output = `${error.stdout ?? ''}\n${error.stderr ?? ''}`
     if (isMissingTable(output)) {
       fail(`no gallery tables in ${targetLabel(env)} — nothing to validate`)


### PR DESCRIPTION
A gallery command whose child process never ran reported that the query ran and failed. `pnpm` missing from PATH came back as:

```json
"code": "d1-failed",
"message": "wrangler d1 execute failed against chaos-master-content-dev (local)",
"detail": { "stdout": [], "stderr": [] }
```

There was no output to quote because nothing was ever executed, and the report named nothing to act on.

## Why it matters

That is the normal case away from a terminal. A console started from a desktop launcher or a `systemd-run --user` unit inherits the session environment rather than the login shell's, so a node installed by nvm — node, pnpm, wrangler and esbuild all in one version-scoped bin dir that only `~/.zshrc` puts on PATH — is simply not there. Every gallery command then fails identically, with nothing to tell them apart. It works from an interactive shell, which is why this stayed invisible.

Repro: run the admin console from `systemd-run --user --unit=x --collect node serve.mjs` and hit `/api/gallery/list?env=local`.

## The change

`couldNotRun` in `gallery-targets.mjs` separates "the child never started" from "it ran and failed":

- a spawn error (ENOENT, EACCES) never reaches an exit status at all — node reports `status: null` and captures no streams;
- a real exit code with nothing on either stream (127, typically) leaves nothing to report.

Its emptiness test is `tail`, so it is true in exactly the cases where the detail these scripts print would come out `[]` and `[]`. Callers now name the executable, the PATH actually seen, and the fix:

```json
"code": "command-not-runnable",
"message": "Could not run `pnpm` — no query reached chaos-master-content-dev (local)",
"detail": {
  "command": "pnpm",
  "reason": "`pnpm` could not be started (ENOENT)",
  "hint": "PATH must contain the directory holding `node` and `pnpm` — with nvm that is ~/.nvm/versions/node/<version>/bin, which only an interactive shell adds. Set PATH explicitly in the launcher or unit.",
  "searchPath": "/usr/bin:/bin"
}
```

`captured` is the part worth reading twice. Where stderr is inherited node captures nothing, so `error.stderr` is null for **every** failure that call can have — emptiness is the default rather than a signal, and testing it would report a wrangler that failed loudly on the terminal as a command that could not be found. Those callers get the spawn-error shape alone, which is the only evidence they hold.

## Sites

| Site | streams captured | reports via |
| --- | --- | --- |
| `gallery-admin.mjs` `d1()` | yes | `AdminError` (`command-not-runnable`) |
| `gallery-admin.mjs` `initializeLocal()` | yes | `AdminError` (`command-not-runnable`) |
| `gallery-sequence.mjs` `d1()` | yes | `fail()` |
| `gallery-sequence.mjs` migrations | no | `fail()`, new try/catch |
| `validate-gallery.mjs` `d1()` | yes | `fail()` |
| `seed-gallery.mjs` `loadContent` esbuild | no | `run()` helper |
| `seed-gallery.mjs` `loadContent` node | yes | `run()` helper |
| `seed-gallery.mjs` migrations | no | `run()` helper |
| `seed-gallery.mjs` execute | no | `run()` helper |
| `capture-gallery-posters.mjs` `readRows()` | yes | `throw Error` |

`seed-gallery`'s two `loadContent` spawns run *before* its wrangler steps, so guarding only the latter would have left the undiagnosable crash first in line. Its two wrangler calls had no error handling at all.

The text-shaped scripts print the same content as the JSON detail through `couldNotRunLines`, derived from `couldNotRunDetail` so the two cannot drift.

## Verification

Per site, by hand:

- PATH stripped to `/usr/bin:/bin` — every script names `pnpm`, the reason, and the PATH it saw, instead of an empty `d1-failed` or a raw ENOENT stack trace.
- A stub `pnpm` exiting non-zero **with** stderr — still the original error with its output quoted (`wrangler d1 execute failed against ... / boom: something wrangler said`).
- A stub printing `no such table: gallery_items` — the `isMissingTable` branch is still reached.
- A genuine non-zero exit at an uncaptured site — rethrown, not misreported as "could not run".
- Happy path unchanged on `gallery-admin list` and `validate-gallery`.

`capture-gallery-posters` was reached through a stub dev server, since its checkout probe gates `readRows`.

Typecheck, lint and Prettier clean.
