### PR TITLE
fix(recorder): compact touch controls

### DIFF
--- a/packages/app/src/components/SessionRecorder/SessionLibraryPanel.module.css
+++ b/packages/app/src/components/SessionRecorder/SessionLibraryPanel.module.css
@@ -152,16 +152,23 @@
   .button,
   .entry-name,
   .entry-rename {
-    min-height: 2.75rem;
+    min-height: var(--recorder-coarse-target, 2.25rem);
   }
+}
 
+/* Phones need the action cluster below the recording title; tablets keep the
+   compact single-row layout instead of paying this height on every entry. */
+@media (pointer: coarse) and (max-width: 28rem) {
   .entry {
     align-items: flex-start;
     flex-wrap: wrap;
   }
 
+  .entry-main {
+    flex-basis: 100%;
+  }
+
   .entry-actions {
-    width: 100%;
-    flex-wrap: wrap;
+    margin-left: auto;
   }
 }

--- a/packages/app/src/components/SessionRecorder/SessionRecorderControls.module.css
+++ b/packages/app/src/components/SessionRecorder/SessionRecorderControls.module.css
@@ -108,9 +108,18 @@
 }
 
 @media (pointer: coarse) {
+  .recorder {
+    gap: 0.3rem;
+  }
+
   .icon-button,
   .button {
-    min-width: 2.75rem;
-    min-height: 2.75rem;
+    min-width: var(--recorder-coarse-target, 2.25rem);
+    min-height: var(--recorder-coarse-target, 2.25rem);
+  }
+
+  .icon {
+    width: 1rem;
+    height: 1rem;
   }
 }

--- a/packages/app/src/components/SessionRecorder/SessionRecorderDock.module.css
+++ b/packages/app/src/components/SessionRecorder/SessionRecorderDock.module.css
@@ -3,6 +3,11 @@
    SessionRecorderControls.module.css for why nothing floats by default);
    dragged, it becomes fixed so the bar does not keep a hole where it was. */
 .dock {
+  /* The recorder is a compact floating instrument rather than a page-level
+     toolbar. On coarse pointers, 2.25rem keeps controls comfortably above the
+     24px WCAG minimum without turning the pill into a 44px button bar. */
+  --recorder-coarse-target: 2.25rem;
+
   position: relative;
   align-self: flex-start;
   display: flex;
@@ -112,15 +117,20 @@
 }
 
 @media (pointer: coarse) {
+  .bar {
+    gap: 0.3rem;
+    padding: 0.24rem 0.4rem;
+  }
+
   .grip,
   .icon-button {
-    min-width: 2.75rem;
-    min-height: 2.75rem;
+    min-width: var(--recorder-coarse-target);
+    min-height: var(--recorder-coarse-target);
   }
 
   .opacity-slider,
   .fade-toggle {
-    min-height: 2.75rem;
+    min-height: var(--recorder-coarse-target);
   }
 
   .fade-toggle input {
@@ -202,6 +212,15 @@
   & input {
     margin: 0;
     accent-color: oklch(60% 0.12 240);
+  }
+}
+
+/* Keep the glyph visually confident while the surrounding touch target stays
+   compact. This must follow the base icon rule above in the cascade. */
+@media (pointer: coarse) {
+  .icon {
+    width: 1rem;
+    height: 1rem;
   }
 }
 

--- a/packages/app/src/components/SessionRecorder/SessionRecorderSizing.test.ts
+++ b/packages/app/src/components/SessionRecorder/SessionRecorderSizing.test.ts
@@ -1,0 +1,83 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+const controlsCss = readFileSync(
+  'src/components/SessionRecorder/SessionRecorderControls.module.css',
+  'utf8',
+)
+const dockCss = readFileSync(
+  'src/components/SessionRecorder/SessionRecorderDock.module.css',
+  'utf8',
+)
+const libraryCss = readFileSync(
+  'src/components/SessionRecorder/SessionLibraryPanel.module.css',
+  'utf8',
+)
+const replayCss = readFileSync(
+  'src/components/SessionRecorder/SessionReplayPanel.module.css',
+  'utf8',
+)
+
+function extractBlock(source: string, marker: string): string {
+  const markerIndex = source.indexOf(marker)
+  if (markerIndex < 0) throw new Error(`Missing CSS marker: ${marker}`)
+
+  const start = source.indexOf('{', markerIndex)
+  if (start < 0) throw new Error(`Missing block for CSS marker: ${marker}`)
+
+  let depth = 0
+  for (let index = start; index < source.length; index += 1) {
+    if (source[index] === '{') depth += 1
+    if (source[index] !== '}') continue
+    depth -= 1
+    if (depth === 0) return source.slice(start + 1, index)
+  }
+
+  throw new Error(`Unclosed block for CSS marker: ${marker}`)
+}
+
+describe('recorder responsive density', () => {
+  it('uses one compact coarse-pointer target across recorder surfaces', () => {
+    const sources = [controlsCss, dockCss, libraryCss, replayCss]
+
+    expect(dockCss).toContain('--recorder-coarse-target: 2.25rem')
+    expect(extractBlock(dockCss, '@media (pointer: coarse)')).toContain(
+      'var(--recorder-coarse-target)',
+    )
+    expect(extractBlock(controlsCss, '@media (pointer: coarse)')).toContain(
+      'var(--recorder-coarse-target, 2.25rem)',
+    )
+    expect(extractBlock(libraryCss, '@media (pointer: coarse)')).toContain(
+      'var(--recorder-coarse-target, 2.25rem)',
+    )
+    expect(extractBlock(replayCss, '@media (pointer: coarse)')).toContain(
+      'var(--recorder-coarse-target, 2.25rem)',
+    )
+    for (const source of sources) expect(source).not.toContain('2.75rem')
+  })
+
+  it('grows the touch glyphs without growing the desktop controls', () => {
+    expect(extractBlock(controlsCss, '\n.icon-button {')).toContain(
+      'width: 1.55rem',
+    )
+    expect(extractBlock(controlsCss, '\n.icon {')).toContain('width: 0.94rem')
+    expect(extractBlock(controlsCss, '@media (pointer: coarse)')).toContain(
+      'width: 1rem',
+    )
+    expect(extractBlock(dockCss, '\n.icon-button {')).toContain(
+      'width: 1.55rem',
+    )
+  })
+
+  it('wraps recording actions only on narrow coarse-pointer screens', () => {
+    const tabletBlock = extractBlock(libraryCss, '@media (pointer: coarse) {')
+    const phoneBlock = extractBlock(
+      libraryCss,
+      '@media (pointer: coarse) and (max-width: 28rem)',
+    )
+
+    expect(tabletBlock).not.toContain('flex-wrap: wrap')
+    expect(phoneBlock).toContain('flex-wrap: wrap')
+    expect(phoneBlock).toContain('flex-basis: 100%')
+  })
+})

--- a/packages/app/src/components/SessionRecorder/SessionReplayPanel.module.css
+++ b/packages/app/src/components/SessionRecorder/SessionReplayPanel.module.css
@@ -285,12 +285,16 @@
   .step-edit,
   .note-input,
   .hold-input {
-    min-width: 2.75rem;
-    min-height: 2.75rem;
+    min-height: var(--recorder-coarse-target, 2.25rem);
   }
 
   .transport-icon-button,
   .step-edit {
-    min-width: 2.75rem;
+    min-width: var(--recorder-coarse-target, 2.25rem);
+  }
+
+  .button-icon {
+    width: 1rem;
+    height: 1rem;
   }
 }


### PR DESCRIPTION
## Summary

- reduce coarse-pointer recorder targets from 44px to a compact 36px middle ground
- keep 16px glyphs while tightening tablet gaps and bar padding
- keep recording actions inline on tablets, with a narrow-phone wrap fallback
- apply the same density to replay transport and step controls
- add a CSS density ratchet to prevent blanket 44px controls from returning

## Root cause

The icon polish added 44px coarse-pointer targets across the recorder dock, library, and replay surfaces. The glyphs themselves stayed around 14–15px, so most of the perceived bulk was empty button area. The library also wrapped every row's actions on all coarse devices, more than doubling row height.

Desktop sizing and the existing library/replay panel bounds remain unchanged.

## Validation

- Prettier check on all changed files
- targeted ESLint on the density ratchet
- 4 recorder test files / 25 tests passed serially
- app TypeScript typecheck passed
- UI anti-pattern detector returned no findings
- `git diff --check` passed
