### PR TITLE
fix(recorder): polish replay presentation

### DIFF
--- a/packages/app/src/MainWorkspace.tsx
+++ b/packages/app/src/MainWorkspace.tsx
@@ -4600,6 +4600,12 @@ export function MainWorkspace(props: AppProps) {
                         ? 'true'
                         : undefined
                     }
+                    data-replay-region={
+                      recorderReplayPresentation().playing &&
+                      !recorderReplayPresentation().timelineTargeted
+                        ? 'recessed'
+                        : undefined
+                    }
                     style={{
                       'pointer-events':
                         animationExportRunning() || timeline.isPlaying()

--- a/packages/app/src/components/SessionRecorder/ReplaySpotlight.test.tsx
+++ b/packages/app/src/components/SessionRecorder/ReplaySpotlight.test.tsx
@@ -238,21 +238,25 @@ describe('ReplaySpotlight tracking', () => {
     canvas.dataset.replayRegion = 'canvas'
     setBox(canvas, 0, 0, 800, 600)
 
-    const sidebar = document.createElement('aside')
-    sidebar.dataset.replayRegion = 'dim'
-    setBox(sidebar, 600, 0, 200, 600)
+    const bottomBar = document.createElement('div')
+    bottomBar.dataset.replayRegion = 'dim'
+    setBox(bottomBar, 0, 400, 800, 200)
+
+    const timeline = document.createElement('section')
+    timeline.dataset.replayRegion = 'recessed'
+    setBox(timeline, 0, 400, 800, 160)
 
     const target = document.createElement('button')
     const scrollIntoView = vi.fn()
     target.dataset.focusId = 'tx:t3:variation:v1:type'
     target.scrollIntoView = scrollIntoView
-    setBox(target, 650, 100, 80, 30)
-    sidebar.append(target)
+    setBox(target, 650, 450, 80, 30)
 
     const transport = document.createElement('div')
     transport.dataset.replayRegion = 'transport'
     setBox(transport, 20, 520, 220, 50)
-    document.body.append(canvas, sidebar, transport)
+    bottomBar.append(timeline, target, transport)
+    document.body.append(canvas, bottomBar)
 
     const action: RecordedAction = {
       t: 0,
@@ -268,7 +272,20 @@ describe('ReplaySpotlight tracking', () => {
       document.querySelectorAll('[data-replay-mask-role]'),
       (element) => element.getAttribute('data-replay-mask-role'),
     )
-    expect(roles).toEqual(['base', 'canvas', 'chrome', 'transport', 'target'])
+    expect(roles).toEqual([
+      'base',
+      'canvas',
+      'chrome',
+      'recessed',
+      'transport',
+      'target',
+    ])
+
+    const timelineCutout = document.querySelector(
+      '[data-replay-mask-role="recessed"]',
+    )
+    expect(timelineCutout?.getAttribute('y')).toBe('400')
+    expect(timelineCutout?.getAttribute('height')).toBe('160')
 
     const targetCutout = document.querySelector(
       '[data-replay-mask-role="target"]',

--- a/packages/app/src/components/SessionRecorder/ReplaySpotlight.tsx
+++ b/packages/app/src/components/SessionRecorder/ReplaySpotlight.tsx
@@ -71,6 +71,7 @@ export function ReplaySpotlight(props: {
   const [targetRect, setTargetRect] = createSignal<Rect>()
   const [canvasRect, setCanvasRect] = createSignal<Rect>()
   const [dimRects, setDimRects] = createSignal<Rect[]>([])
+  const [recessedRects, setRecessedRects] = createSignal<Rect[]>([])
   const [transportRects, setTransportRects] = createSignal<Rect[]>([])
   const [viewport, setViewport] = createSignal<Viewport>({
     width: window.innerWidth,
@@ -172,6 +173,9 @@ export function ReplaySpotlight(props: {
     const dimElements = regions.filter(
       (element) => element.getAttribute('data-replay-region') === 'dim',
     )
+    const recessedElements = regions.filter(
+      (element) => element.getAttribute('data-replay-region') === 'recessed',
+    )
     const transportElements = regions.filter(
       (element) => element.getAttribute('data-replay-region') === 'transport',
     )
@@ -189,6 +193,14 @@ export function ReplaySpotlight(props: {
     })
     setDimRects((previous) =>
       sameRects(previous, nextDimRects) ? previous : nextDimRects,
+    )
+
+    const nextRecessedRects = recessedElements.flatMap((element) => {
+      const rect = clippedRect(element)
+      return rect ? [rect] : []
+    })
+    setRecessedRects((previous) =>
+      sameRects(previous, nextRecessedRects) ? previous : nextRecessedRects,
     )
 
     const nextTransportRects = transportElements.flatMap((element) => {
@@ -209,6 +221,7 @@ export function ReplaySpotlight(props: {
     rebuildLayoutObservers([
       ...canvasElements,
       ...dimElements,
+      ...recessedElements,
       ...transportElements,
       ...(element ? [element] : []),
     ])
@@ -307,6 +320,7 @@ export function ReplaySpotlight(props: {
       setTargetRect(undefined)
       setCanvasRect(undefined)
       setDimRects([])
+      setRecessedRects([])
       setTransportRects([])
       setCaption(undefined)
       return
@@ -321,6 +335,7 @@ export function ReplaySpotlight(props: {
         setTargetRect(undefined)
         setCanvasRect(undefined)
         setDimRects([])
+        setRecessedRects([])
         setTransportRects([])
         stopTracking()
       }, TAIL_MS)
@@ -374,6 +389,18 @@ export function ReplaySpotlight(props: {
                     <rect
                       data-replay-mask-role="chrome"
                       class={styles.maskDim}
+                      x={rect.x}
+                      y={rect.y}
+                      width={rect.width}
+                      height={rect.height}
+                    />
+                  )}
+                </For>
+                <For each={recessedRects()}>
+                  {(rect) => (
+                    <rect
+                      data-replay-mask-role="recessed"
+                      class={styles.maskCutout}
                       x={rect.x}
                       y={rect.y}
                       width={rect.width}

--- a/packages/app/src/components/SessionRecorder/SessionRecorderSizing.test.ts
+++ b/packages/app/src/components/SessionRecorder/SessionRecorderSizing.test.ts
@@ -69,6 +69,28 @@ describe('recorder responsive density', () => {
     )
   })
 
+  it('keeps replay transport denser than replay forms and lists', () => {
+    expect(extractBlock(replayCss, '\n.transport {')).toContain(
+      '--replay-transport-target: 1.55rem',
+    )
+    expect(extractBlock(replayCss, '\n.button {')).toContain(
+      'min-height: var(--replay-transport-target)',
+    )
+    expect(extractBlock(replayCss, '\n.transport-icon-button {')).toContain(
+      'width: var(--replay-transport-target)',
+    )
+    expect(extractBlock(replayCss, '\n.transport-icon-button {')).toContain(
+      'min-width: var(--replay-transport-target)',
+    )
+
+    const coarse = extractBlock(replayCss, '@media (pointer: coarse)')
+    expect(extractBlock(coarse, '.transport {')).toContain(
+      '--replay-transport-target: 2rem',
+    )
+    expect(coarse).not.toMatch(/\.close,\s*\.button,/)
+    expect(coarse).toContain('var(--recorder-coarse-target, 2.25rem)')
+  })
+
   it('wraps recording actions only on narrow coarse-pointer screens', () => {
     const tabletBlock = extractBlock(libraryCss, '@media (pointer: coarse) {')
     const phoneBlock = extractBlock(

--- a/packages/app/src/components/SessionRecorder/SessionReplayPanel.module.css
+++ b/packages/app/src/components/SessionRecorder/SessionReplayPanel.module.css
@@ -75,6 +75,8 @@
 }
 
 .transport {
+  --replay-transport-target: 1.55rem;
+
   display: flex;
   align-items: center;
   gap: 0.3rem;
@@ -98,7 +100,7 @@
   align-items: center;
   justify-content: center;
   gap: 0.28rem;
-  min-height: 1.65rem;
+  min-height: var(--replay-transport-target);
   padding: 0.1rem 0.45rem;
   border-radius: 10px;
   border: 1px solid oklch(50% 0.08 240 / 0.5);
@@ -118,7 +120,8 @@
 }
 
 .transport-icon-button {
-  width: 1.65rem;
+  width: var(--replay-transport-target);
+  min-width: var(--replay-transport-target);
   padding-inline: 0;
 }
 
@@ -278,8 +281,11 @@
 }
 
 @media (pointer: coarse) {
+  .transport {
+    --replay-transport-target: 2rem;
+  }
+
   .close,
-  .button,
   .speed,
   .step,
   .step-edit,
@@ -288,7 +294,6 @@
     min-height: var(--recorder-coarse-target, 2.25rem);
   }
 
-  .transport-icon-button,
   .step-edit {
     min-width: var(--recorder-coarse-target, 2.25rem);
   }


### PR DESCRIPTION
## Summary

- expose the full dope sheet during ordinary recorder replay by cutting the recessed timeline back out of the broader bottom-bar scrim
- preserve exact timeline-control spotlighting when a replay step targets animation UI
- compact Play, Previous, and Next to recorder-parity desktop sizing and a 32px coarse-pointer middle ground

## Why

The timeline container already became translucent during replay, but the follow-cam mask painted a dark bottom-bar layer back over the full dope sheet. The prior recorder density fix also left replay transport on the larger generic touch target, so it remained visibly taller than the recorder bar.

## Verification

- 21 focused recorder tests passed
- full app Vitest suite passed serialized
- app TypeScript check passed
- full ESLint passed
- Prettier passed
- production build passed
- Impeccable UI detector reported no findings
