### PR TITLE
feat(recorder): export publishable replay videos

### DIFF
--- a/docs/plans/semantic-recorder-plan.md
+++ b/docs/plans/semantic-recorder-plan.md
@@ -16,6 +16,12 @@ call paths; a representative browser journey remains incremental work. Audited
 2026-08-16; see
 `docs/recorder-coverage.md` for the audited matrix and follow-up list.
 
+M6 turns a finished take into a publishable replay video: a deterministic,
+square MP4 rendered from the semantic session with captions, step progress and
+Lumen Apeiron identity burned into the frames. This is separate from embedding
+the session inside an ordinary animation export; the resulting video visibly
+shows the creation sequence.
+
 ## The ask
 
 Press **Record** in the app, create a flame, press **Stop** — and get, alongside
@@ -332,6 +338,44 @@ remain the honest runtime coverage signal.
 - Gallery/endpoint publishing is out of scope here — it composes on top
   (the gallery-admin plan's D1/R2 pipeline gains one more file per item).
 
+### Publishable replay video
+
+The replay panel can queue a **1080 × 1080, 24 fps MP4** from the edited take.
+It uses the same clamped timestamps, authored `holdMs` values and selected
+playback speed as interactive replay. Each step is applied in an isolated
+command world, so exporting never moves the live editor or borrows its current
+flame. Captions, step count, brand tag and progress line are composited into
+the video, and the source session remains embedded in MP4 metadata.
+
+This is intentionally a semantic render, not a screen recording. The artwork
+gets the full frame and presentation-only actions reuse the previous artwork
+while still receiving their own caption and timing. Consecutive frames with an
+unchanged semantic state reuse one accumulated GPU render, keeping export cost
+proportional to meaningful visual changes rather than video duration.
+
+The first version is silent. A `.steps.json` contains audio wiring and resource
+identity, but never copyrighted/source audio bytes; silently borrowing whatever
+track happens to be open in the exporting workspace would make the artifact
+non-deterministic.
+
+It also fails closed when any rendered state references a custom variation.
+The current session format deliberately does not carry executable WGSL, so a
+portable video cannot yet prove that the exporter has the same custom code.
+That changes only with the trust-boundary work already tracked below.
+
+Next direction, deliberately deferred from the first useful slice:
+
+1. aspect presets for 9:16 stories/reels and 16:9 video, with per-network safe
+   areas;
+2. brand templates, author/project tags and optional outro cards;
+3. an explicit soundtrack upload/mix step with trim, gain and ducking, stored
+   as export input rather than recorder session state;
+4. focus callouts and gesture-path lines derived from semantic focus metadata;
+5. publishing integrations only after the local artifact and consent flow are
+   proven;
+6. sampled gesture motion if real exported videos show that commit-level slider
+   jumps are too abrupt.
+
 ### Undo-journal interplay
 
 Recording sits _above_ the undo systems, so the usual hazards don't apply,
@@ -358,6 +402,7 @@ diagnostics.
 | M3  | Core editing-surface coverage, sonification state/commands and semantic-origin follow-cam coverage are shipped, including exact anchors for stable controls; committed custom code and a representative Playwright coverage-ratchet journey remain. | incremental    |
 | M4  | ~~Replay~~ **done**: `createSessionPlayer` transport, step-list panel, timed playback with speed control, jump-to-step, fork-from-step. A run or a seek is ONE undo step, so watching a session does not bury the viewer's own history.             | shipped        |
 | M5  | Sharing: PNG `FlameSteps` chunk, MP4 metadata and export-dialog integration.                                                                                                                                                                        | shipped        |
+| M6  | Publishable replay video: deterministic square MP4, burned captions/identity/progress, isolated command replay and background export queue.                                                                                                         | shipped        |
 | —   | Later: sandboxed replay for gallery previews, scripting/MCP surface over the registry, condensed-recipe editor, gallery publishing.                                                                                                                 | separate plans |
 
 M1 + M2 is the demoable core (record a session using existing commands +

--- a/docs/plans/semantic-recorder-plan.md
+++ b/docs/plans/semantic-recorder-plan.md
@@ -17,7 +17,7 @@ call paths; a representative browser journey remains incremental work. Audited
 `docs/recorder-coverage.md` for the audited matrix and follow-up list.
 
 M6 turns a finished take into publishable replay video. M6a is a deterministic,
-square artwork MP4 rendered from the semantic session with captions, step
+landscape artwork MP4 rendered from the semantic session with captions, step
 progress and Lumen Apeiron identity burned into the frames. M6b adds a second,
 real-time Full interface mode that records the actual app replay, including the
 flame, panels, timeline and follow-cam spotlight. These are separate from
@@ -347,7 +347,7 @@ browser-interface recording have fundamentally different guarantees.
 
 #### M6a — Artwork composition
 
-The replay panel can queue a **1080 × 1080, 24 fps MP4** from the edited take.
+The replay panel can queue a **1920 × 1080, 24 fps MP4** from the edited take.
 It uses the same clamped timestamps, authored `holdMs` values and selected
 playback speed as interactive replay. Each step is applied in an isolated
 command world, so exporting never moves the live editor or borrows its current
@@ -384,16 +384,17 @@ does not claim embedded-session portability.
 
 The two modes therefore answer different publishing needs:
 
-- **Artwork:** deterministic, square, branded, clean, background export.
+- **Artwork:** deterministic, landscape, branded, clean, background export.
 - **Full interface:** faithful app tutorial, spotlight and live workspace,
   foreground capture with explicit browser permission.
 
 #### Next phases, in order
 
-1. **M6c — Composition presets:** 9:16 stories/reels, 16:9 video and square,
-   with per-network safe areas, fit/crop controls and a preview of the chosen
-   framing. Apply these first to Artwork; Full interface can use a guided
-   viewport preset rather than distorting captured UI.
+1. **M6c — Composition presets:** keep 16:9 as the uncropped default, then add
+   9:16 stories/reels, 1:1 square and 4:5 feed plates with per-network safe
+   areas, explicit fit/crop controls and a preview of the chosen framing. Apply
+   these first to Artwork; Full interface can use a guided viewport preset
+   rather than distorting captured UI.
 2. **M6d — Identity and explanation:** reusable brand templates,
    author/project/tags, optional intro/outro cards, and semantic focus callouts
    or leader lines. Keep the default quiet so the flame remains the subject.
@@ -434,7 +435,7 @@ diagnostics.
 | M3    | Core editing-surface coverage, sonification state/commands and semantic-origin follow-cam coverage are shipped, including exact anchors for stable controls; committed custom code and a representative Playwright coverage-ratchet journey remain. | incremental    |
 | M4    | ~~Replay~~ **done**: `createSessionPlayer` transport, step-list panel, timed playback with speed control, jump-to-step, fork-from-step. A run or a seek is ONE undo step, so watching a session does not bury the viewer's own history.             | shipped        |
 | M5    | Sharing: PNG `FlameSteps` chunk, MP4 metadata and export-dialog integration.                                                                                                                                                                        | shipped        |
-| M6a   | Artwork replay video: deterministic square MP4, burned captions/identity/progress, isolated command replay and background export queue.                                                                                                             | shipped        |
+| M6a   | Artwork replay video: deterministic landscape MP4, burned captions/identity/progress, isolated command replay and background export queue.                                                                                                          | shipped        |
 | M6b   | Full-interface replay video: current-tab capture of the actual replay, panels, timeline, spotlight, captions and WebGPU flame.                                                                                                                      | in progress    |
 | M6c–g | Framing presets; identity/callouts; explicit soundtrack mixing; publishing integrations; optional sampled gesture motion.                                                                                                                           | planned        |
 | —     | Later: sandboxed replay for gallery previews, scripting/MCP surface over the registry, condensed-recipe editor, gallery publishing.                                                                                                                 | separate plans |

--- a/docs/plans/semantic-recorder-plan.md
+++ b/docs/plans/semantic-recorder-plan.md
@@ -325,8 +325,10 @@ remain the honest runtime coverage signal.
 
 ### Persistence and sharing
 
-- `.steps.json` download/upload alongside the existing export surfaces, and a
-  bundle option in `ExportPngDialog` (flame + PNG + steps).
+- `.steps.json` download/upload alongside the existing export surfaces, with
+  validated external takes imported into the capped Recordings library and
+  exact re-imports deduplicated; plus a bundle option in `ExportPngDialog`
+  (flame + PNG + steps).
 - **Embed the session in exported PNGs** as a second `zTXt` chunk
   (`FlameSteps`) next to `FlameJson` — `flameInPng.ts` already has the chunk
   machinery. A dropped PNG then offers "Load flame" _and_ "Replay creation".

--- a/docs/plans/semantic-recorder-plan.md
+++ b/docs/plans/semantic-recorder-plan.md
@@ -16,11 +16,13 @@ call paths; a representative browser journey remains incremental work. Audited
 2026-08-16; see
 `docs/recorder-coverage.md` for the audited matrix and follow-up list.
 
-M6 turns a finished take into a publishable replay video: a deterministic,
-square MP4 rendered from the semantic session with captions, step progress and
-Lumen Apeiron identity burned into the frames. This is separate from embedding
-the session inside an ordinary animation export; the resulting video visibly
-shows the creation sequence.
+M6 turns a finished take into publishable replay video. M6a is a deterministic,
+square artwork MP4 rendered from the semantic session with captions, step
+progress and Lumen Apeiron identity burned into the frames. M6b adds a second,
+real-time Full interface mode that records the actual app replay, including the
+flame, panels, timeline and follow-cam spotlight. These are separate from
+embedding the session inside an ordinary animation export; both resulting
+videos visibly show the creation sequence.
 
 ## The ask
 
@@ -340,12 +342,17 @@ remain the honest runtime coverage signal.
 
 ### Publishable replay video
 
+M6 is split into modes because an offline semantic composition and a faithful
+browser-interface recording have fundamentally different guarantees.
+
+#### M6a — Artwork composition
+
 The replay panel can queue a **1080 × 1080, 24 fps MP4** from the edited take.
 It uses the same clamped timestamps, authored `holdMs` values and selected
 playback speed as interactive replay. Each step is applied in an isolated
 command world, so exporting never moves the live editor or borrows its current
-flame. Captions, step count, brand tag and progress line are composited into
-the video, and the source session remains embedded in MP4 metadata.
+flame. Captions, step count, brand tag and progress line are composited into the
+video, and the source session remains embedded in MP4 metadata.
 
 This is intentionally a semantic render, not a screen recording. The artwork
 gets the full frame and presentation-only actions reuse the previous artwork
@@ -358,23 +365,48 @@ identity, but never copyrighted/source audio bytes; silently borrowing whatever
 track happens to be open in the exporting workspace would make the artifact
 non-deterministic.
 
-It also fails closed when any rendered state references a custom variation.
+Artwork also fails closed when any rendered state references a custom variation.
 The current session format deliberately does not carry executable WGSL, so a
 portable video cannot yet prove that the exporter has the same custom code.
 That changes only with the trust-boundary work already tracked below.
 
-Next direction, deliberately deferred from the first useful slice:
+#### M6b — Full interface capture
 
-1. aspect presets for 9:16 stories/reels and 16:9 video, with per-network safe
-   areas;
-2. brand templates, author/project tags and optional outro cards;
-3. an explicit soundtrack upload/mix step with trim, gain and ducking, stored
-   as export input rather than recorder session state;
-4. focus callouts and gesture-path lines derived from semantic focus metadata;
-5. publishing integrations only after the local artifact and consent flow are
-   proven;
-6. sampled gesture motion if real exported videos show that commit-level slider
-   jumps are too abrupt.
+Full interface is a second export mode, not an option on the artwork renderer.
+It starts the normal replay player and captures the current tab in real time,
+preserving the actual sidebar, timeline, follow-cam mask, captions, recorder
+chrome and WebGPU flame. Standard browser capture deliberately requires a new
+user-approved source picker for every recording, so the UI asks for **This
+Tab** and the tab must remain visible. The result keeps the viewport aspect,
+within a 1920-pixel long-edge / 1080p pixel budget. WebCodecs produces MP4 with
+the source session embedded; the browser-recorder fallback produces WebM and
+does not claim embedded-session portability.
+
+The two modes therefore answer different publishing needs:
+
+- **Artwork:** deterministic, square, branded, clean, background export.
+- **Full interface:** faithful app tutorial, spotlight and live workspace,
+  foreground capture with explicit browser permission.
+
+#### Next phases, in order
+
+1. **M6c — Composition presets:** 9:16 stories/reels, 16:9 video and square,
+   with per-network safe areas, fit/crop controls and a preview of the chosen
+   framing. Apply these first to Artwork; Full interface can use a guided
+   viewport preset rather than distorting captured UI.
+2. **M6d — Identity and explanation:** reusable brand templates,
+   author/project/tags, optional intro/outro cards, and semantic focus callouts
+   or leader lines. Keep the default quiet so the flame remains the subject.
+3. **M6e — Soundtrack:** an explicit upload/mix step with trim, gain, fades and
+   caption ducking. Treat audio as export input rather than recorder-session
+   state so local files and rights remain deliberate.
+4. **M6f — Publishing:** platform-specific filenames/metadata and opt-in
+   publishing integrations only after the local artifact, preview and consent
+   flow are proven.
+5. **M6g — Motion fidelity:** optional sampled gesture paths for sliders,
+   affine handles and colour controls if real exports show that commit-level
+   jumps feel too abrupt. Do not inflate the portable action log until that
+   visual need is demonstrated.
 
 ### Undo-journal interplay
 
@@ -395,15 +427,17 @@ Each ships independently; nothing blocks the app in a half-migrated state
 because unrecorded mutations still work — they're just visible as `unnamed`
 diagnostics.
 
-| #   | Deliverable                                                                                                                                                                                                                                         | Effort         |
-| --- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- |
-| M1  | `src/recorder/` module: session schema, recorder hooked into command/history seams, fidelity diagnostics, production UI and `.steps.json` persistence.                                                                                              | shipped        |
-| M2  | Determinism: id-based addressing, pre-minted ids, seeded generate/mutate and round-trip tests.                                                                                                                                                      | shipped        |
-| M3  | Core editing-surface coverage, sonification state/commands and semantic-origin follow-cam coverage are shipped, including exact anchors for stable controls; committed custom code and a representative Playwright coverage-ratchet journey remain. | incremental    |
-| M4  | ~~Replay~~ **done**: `createSessionPlayer` transport, step-list panel, timed playback with speed control, jump-to-step, fork-from-step. A run or a seek is ONE undo step, so watching a session does not bury the viewer's own history.             | shipped        |
-| M5  | Sharing: PNG `FlameSteps` chunk, MP4 metadata and export-dialog integration.                                                                                                                                                                        | shipped        |
-| M6  | Publishable replay video: deterministic square MP4, burned captions/identity/progress, isolated command replay and background export queue.                                                                                                         | shipped        |
-| —   | Later: sandboxed replay for gallery previews, scripting/MCP surface over the registry, condensed-recipe editor, gallery publishing.                                                                                                                 | separate plans |
+| #     | Deliverable                                                                                                                                                                                                                                         | Effort         |
+| ----- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- |
+| M1    | `src/recorder/` module: session schema, recorder hooked into command/history seams, fidelity diagnostics, production UI and `.steps.json` persistence.                                                                                              | shipped        |
+| M2    | Determinism: id-based addressing, pre-minted ids, seeded generate/mutate and round-trip tests.                                                                                                                                                      | shipped        |
+| M3    | Core editing-surface coverage, sonification state/commands and semantic-origin follow-cam coverage are shipped, including exact anchors for stable controls; committed custom code and a representative Playwright coverage-ratchet journey remain. | incremental    |
+| M4    | ~~Replay~~ **done**: `createSessionPlayer` transport, step-list panel, timed playback with speed control, jump-to-step, fork-from-step. A run or a seek is ONE undo step, so watching a session does not bury the viewer's own history.             | shipped        |
+| M5    | Sharing: PNG `FlameSteps` chunk, MP4 metadata and export-dialog integration.                                                                                                                                                                        | shipped        |
+| M6a   | Artwork replay video: deterministic square MP4, burned captions/identity/progress, isolated command replay and background export queue.                                                                                                             | shipped        |
+| M6b   | Full-interface replay video: current-tab capture of the actual replay, panels, timeline, spotlight, captions and WebGPU flame.                                                                                                                      | in progress    |
+| M6c–g | Framing presets; identity/callouts; explicit soundtrack mixing; publishing integrations; optional sampled gesture motion.                                                                                                                           | planned        |
+| —     | Later: sandboxed replay for gallery previews, scripting/MCP surface over the registry, condensed-recipe editor, gallery publishing.                                                                                                                 | separate plans |
 
 M1 + M2 is the demoable core (record a session using existing commands +
 randomize, replay it deterministically). M3 is the long tail and can proceed

--- a/docs/recorder-coverage.md
+++ b/docs/recorder-coverage.md
@@ -292,7 +292,10 @@ the panel's current caption and hold edits at the selected replay speed without
 requiring a separate save, and both refuse takes whose `unnamedWriteCount` says
 the authored result is incomplete.
 
-**Artwork** queues a square MP4 in the normal Exports tracker. The exporter
+**Artwork** queues a 1920 × 1080 landscape MP4 in the normal Exports tracker.
+That frame matches the editor camera's landscape composition: the 2D camera
+holds its vertical extent and reveals more of the flame horizontally, whereas
+a square render would crop the authored view. The exporter
 reconstructs the take in a private command context, so it never drives the open
 workspace or borrows its current flame. Non-visual steps reuse the last artwork
 frame instead of waiting for a renderer change that cannot occur. The MP4 burns

--- a/docs/recorder-coverage.md
+++ b/docs/recorder-coverage.md
@@ -285,6 +285,38 @@ All three are in:
 Edit them with the pencil button on any step in the replay list; **Save captions**
 writes the result to the library as a new entry, leaving the raw take alone.
 
+## Publishable replay video
+
+**Export video** in the replay panel queues a square MP4 in the normal Exports
+tracker. It exports the panel's current caption and hold edits at the selected
+replay speed without requiring a separate save, and it refuses takes whose
+`unnamedWriteCount` says the authored result is incomplete.
+
+The exporter reconstructs the take in a private command context. It never
+drives the open workspace, and non-visual steps reuse the last artwork frame
+instead of waiting for a renderer change that cannot occur. The MP4 burns in
+the Lumen Apeiron replay tag, current caption, step count and progress line;
+the complete `.steps` session is also embedded as metadata for round-trip
+loading.
+
+Replay video is silent in this first version. Sessions intentionally contain
+no audio bytes, and the exporter will not substitute an unrelated file or live
+microphone from the current workspace. Aspect presets, explicit soundtrack
+mixing, richer brand templates and semantic focus/gesture callout lines are
+tracked in the plan's M6 follow-ups.
+
+The exporter also refuses a take that renders a custom variation. Recorder v1
+does not package executable WGSL definitions, so accepting that take would make
+the pixels depend on the exporting browser's local variation library rather
+than the saved session.
+
+Replay video also requires the browser's offline video encoder. The ordinary
+animation exporter can fall back to real-time capture, but that fallback cannot
+preserve semantic step timing or embedded session metadata, so replay export
+fails clearly instead of producing a misleading file. Empty takes and videos
+longer than the current two-minute safety limit are likewise rejected before a
+render job is queued.
+
 ## The dock (recorder UI)
 
 Everything lives in one dock in the bottom-left: the record pill, and above it
@@ -309,8 +341,9 @@ the replay and library panels it opens.
 
 - Start the recording **before** the work you want captured; the log embeds
   the document as it was at that moment.
-- To embed steps in an export, stop the recording first — the export picks up
-  the **last finished** session.
+- To embed steps in an ordinary export, stop the recording first — the export
+  picks up the **last finished** session. To publish the steps themselves as a
+  video, open that take in Replay and choose **Export video**.
 - `unnamedWriteCount` in the saved file is the honest measure of untracked
   flame/timeline writes. Zero means every watched document edit was
   represented; state explicitly listed under “Authored state not represented

--- a/docs/recorder-coverage.md
+++ b/docs/recorder-coverage.md
@@ -287,35 +287,53 @@ writes the result to the library as a new entry, leaving the raw take alone.
 
 ## Publishable replay video
 
-**Export video** in the replay panel queues a square MP4 in the normal Exports
-tracker. It exports the panel's current caption and hold edits at the selected
-replay speed without requiring a separate save, and it refuses takes whose
-`unnamedWriteCount` says the authored result is incomplete.
+The replay panel offers two deliberately different publication modes. Both use
+the panel's current caption and hold edits at the selected replay speed without
+requiring a separate save, and both refuse takes whose `unnamedWriteCount` says
+the authored result is incomplete.
 
-The exporter reconstructs the take in a private command context. It never
-drives the open workspace, and non-visual steps reuse the last artwork frame
-instead of waiting for a renderer change that cannot occur. The MP4 burns in
-the Lumen Apeiron replay tag, current caption, step count and progress line;
+**Artwork** queues a square MP4 in the normal Exports tracker. The exporter
+reconstructs the take in a private command context, so it never drives the open
+workspace or borrows its current flame. Non-visual steps reuse the last artwork
+frame instead of waiting for a renderer change that cannot occur. The MP4 burns
+in the Lumen Apeiron replay tag, current caption, step count and progress line;
 the complete `.steps` session is also embedded as metadata for round-trip
 loading.
 
-Replay video is silent in this first version. Sessions intentionally contain
+**Full interface** records the ordinary in-app replay in real time: the actual
+flame, panels, timeline, follow-cam spotlight and captions visible in the
+current viewport. The browser must ask which surface to share on every export;
+choose **This Tab** and keep it visible until the replay finishes. The recorder
+cannot select a tab or retain capture permission on the user's behalf. This
+mode preserves the viewport aspect ratio and caps capture at a 1920-pixel long
+edge and a 1080p pixel budget. It downloads an MP4 with embedded session data
+when the browser's offline encoder is available, or a WebM without embedded
+session metadata through the browser recorder fallback.
+
+These are complementary outputs, not quality levels. Artwork is deterministic,
+backgroundable and purpose-composed for a social post. Full interface is a
+faithful recording of the app and therefore runs in the foreground at real
+replay speed under the browser's screen-capture permission.
+
+Replay video is silent in these first modes. Sessions intentionally contain
 no audio bytes, and the exporter will not substitute an unrelated file or live
 microphone from the current workspace. Aspect presets, explicit soundtrack
 mixing, richer brand templates and semantic focus/gesture callout lines are
 tracked in the plan's M6 follow-ups.
 
-The exporter also refuses a take that renders a custom variation. Recorder v1
-does not package executable WGSL definitions, so accepting that take would make
-the pixels depend on the exporting browser's local variation library rather
-than the saved session.
+Artwork also refuses a take that renders a custom variation. Recorder v1 does
+not package executable WGSL definitions, so accepting that take would make the
+pixels depend on the exporting browser's local variation library rather than
+the saved session. Full-interface capture can record what a locally configured
+editor visibly renders, but it does not make the embedded session portable to a
+browser that lacks those custom definitions.
 
-Replay video also requires the browser's offline video encoder. The ordinary
-animation exporter can fall back to real-time capture, but that fallback cannot
-preserve semantic step timing or embedded session metadata, so replay export
-fails clearly instead of producing a misleading file. Empty takes and videos
-longer than the current two-minute safety limit are likewise rejected before a
-render job is queued.
+Artwork requires the browser's offline video encoder and fails clearly instead
+of substituting a non-deterministic real-time render. Full interface can fall
+back to the browser recorder because real-time capture is its explicit
+contract. Empty takes and videos longer than the current two-minute safety
+limit are rejected before either expensive render or privacy-sensitive share
+prompt begins.
 
 ## The dock (recorder UI)
 
@@ -343,7 +361,7 @@ the replay and library panels it opens.
   the document as it was at that moment.
 - To embed steps in an ordinary export, stop the recording first — the export
   picks up the **last finished** session. To publish the steps themselves as a
-  video, open that take in Replay and choose **Export video**.
+  video, open that take in Replay and choose **Artwork** or **Full interface**.
 - `unnamedWriteCount` in the saved file is the honest measure of untracked
   flame/timeline writes. Zero means every watched document edit was
   represented; state explicitly listed under “Authored state not represented

--- a/docs/recorder-coverage.md
+++ b/docs/recorder-coverage.md
@@ -230,6 +230,11 @@ Three ways to bring a session back:
   offers the session against whatever is open. Dropping one of our PNGs or
   MP4s loads the flame _and_ offers its session.
 
+Opening or dropping an external take imports it into **Recordings** before
+replay, so closing the replay never loses the file from the browser library.
+Opening the exact same session again reuses its existing entry; edited caption
+or hold variants remain separate recordings.
+
 Everything that arrives from outside is data, never code. The loader caps raw
 and decompressed session sizes, action/argument counts, nesting and string
 budgets, validates the initial flame/timeline/audio schemas, and preflights all

--- a/packages/app/src/MainWorkspace.tsx
+++ b/packages/app/src/MainWorkspace.tsx
@@ -57,7 +57,7 @@ import { PopulationSimulator } from './components/PopulationSimulator/Population
 import { ProgressBar } from './components/ProgressBar/ProgressBar'
 import { getPresetFromQuality, qualityPresets, } from './components/Quality/QualityPresets'
 import { QuickVariationPicker } from './components/QuickVariationPicker/QuickVariationPicker'
-import { recorderSavePending, recorderVisible, } from './components/SessionRecorder/recorderUi'
+import { recorderExportPending, recorderTaskPending, recorderVisible, } from './components/SessionRecorder/recorderUi'
 import { SessionRecorderDock } from './components/SessionRecorder/SessionRecorderDock'
 import { createShareLinkModal } from './components/ShareLinkModal/ShareLinkModal'
 import { createShareVariationLinkModal, createShareVariationLoadModal, } from './components/ShareVariationModal/ShareVariationModal'
@@ -102,9 +102,10 @@ import { AutoCanvas } from './lib/AutoCanvas'
 import { affineFocusId, transformColorRandomizeFocusId, transformFocusId, transformVisibilityFocusId, variationParamsFocusId, variationRandomizeFocusId, variationTypeFocusId, variationVisibilityFocusId, } from './recorder/focusIds'
 import { breakRecordingCoalescing, invalidateLastFinishedSession, isSessionRecording, notePreviewStarted, recordSyntheticAction, reportDerivedWorkspaceWrite, reportDocumentWrite, reportTimelineTransport, reportUnreplayable, reportUnreplayableOnce, withRecordingSuppressed, } from './recorder/recorder'
 import { applyReplayAudioWiring, canEnableReplayAudio, sessionMayEnableSonification, } from './recorder/replay'
+import { captureReplayInterfaceVideo } from './recorder/replayInterfaceVideo'
 import { captureTransformColors, paletteRestoreColorsAfterReplayCommand, runPaletteRestoreTransition, } from './recorder/replayPaletteState'
 import { normalizeReplayPresentation, replaySideStateChanged, } from './recorder/replaySideState'
-import { createReplayVideoJobSpec } from './recorder/replayVideo'
+import { createReplayVideoJobSpec, replayVideoFileName, } from './recorder/replayVideo'
 import { snapshotOrigin, snapshotOriginLabel } from './recorder/snapshotOrigin'
 import { applySonificationSnapshot, closeAuthoredSonificationPanel, shouldRevealSonificationAfterReplay, shouldStopHiddenSonification, SONIFICATION_SNAPSHOT_VERSION, } from './recorder/sonificationState'
 import { createRecorderAwareTimeline, runTimelineSnapshotMutation, } from './recorder/timelineActions'
@@ -151,6 +152,7 @@ import type { CustomVariationDef } from './flame/variations/custom/types'
 import type { TransformVariationType3D } from './flame/variations3D'
 import type { ReplayAffineMode, ReplayAffineTab, ReplayColorView, ReplayFocusPreparationHandler, } from './recorder/focusPreparation'
 import type { ReplayTarget } from './recorder/replay'
+import type { ReplayVideoExportRequest } from './recorder/replayInterfaceVideo'
 import type { ReplayNonFlameSideState, ReplayPresentationSnapshot, } from './recorder/replaySideState'
 import type { RecordedSession } from './recorder/schema'
 import type { SnapshotOrigin } from './recorder/snapshotOrigin'
@@ -446,8 +448,12 @@ export function MainWorkspace(props: AppProps) {
   const [recorderReplayPresentation, setRecorderReplayPresentation] =
     createSignal({ playing: false, timelineTargeted: false })
   const openReplaySession = (session: RecordedSession | undefined) => {
-    if (recorderSavePending()) {
-      showToast('Wait for the caption save to finish before changing replays')
+    if (recorderTaskPending()) {
+      showToast(
+        recorderExportPending()
+          ? 'Wait for the replay video recording to finish before changing replays'
+          : 'Wait for the caption save to finish before changing replays',
+      )
       return
     }
     if (session !== undefined && isSessionRecording()) {
@@ -4218,13 +4224,27 @@ export function MainWorkspace(props: AppProps) {
     },
   }
 
-  const exportReplayVideo = (
-    session: RecordedSession,
-    playbackSpeed: number,
-  ) => {
+  const exportReplayVideo = async (request: ReplayVideoExportRequest) => {
     try {
-      enqueueAnimationJob(createReplayVideoJobSpec(session, playbackSpeed))
-      showToast('Replay video added to Exports', 3500)
+      if (request.mode === 'artwork') {
+        enqueueAnimationJob(
+          createReplayVideoJobSpec(request.session, request.playbackSpeed),
+        )
+        showToast('Artwork replay added to Exports', 3500)
+        return
+      }
+
+      const result = await captureReplayInterfaceVideo(request)
+      downloadBlob(
+        result.blob,
+        `${replayVideoFileName(request.session, 'interface')}.${result.extension}`,
+      )
+      showToast(
+        result.extension === 'mp4'
+          ? 'Full-interface replay downloaded'
+          : 'Full-interface replay downloaded as WebM (MP4 encoding is unavailable in this browser)',
+        5000,
+      )
     } catch (error: unknown) {
       const message =
         error instanceof Error ? error.message : 'Could not export replay video'

--- a/packages/app/src/MainWorkspace.tsx
+++ b/packages/app/src/MainWorkspace.tsx
@@ -104,6 +104,7 @@ import { breakRecordingCoalescing, invalidateLastFinishedSession, isSessionRecor
 import { applyReplayAudioWiring, canEnableReplayAudio, sessionMayEnableSonification, } from './recorder/replay'
 import { captureTransformColors, paletteRestoreColorsAfterReplayCommand, runPaletteRestoreTransition, } from './recorder/replayPaletteState'
 import { normalizeReplayPresentation, replaySideStateChanged, } from './recorder/replaySideState'
+import { createReplayVideoJobSpec } from './recorder/replayVideo'
 import { snapshotOrigin, snapshotOriginLabel } from './recorder/snapshotOrigin'
 import { applySonificationSnapshot, closeAuthoredSonificationPanel, shouldRevealSonificationAfterReplay, shouldStopHiddenSonification, SONIFICATION_SNAPSHOT_VERSION, } from './recorder/sonificationState'
 import { createRecorderAwareTimeline, runTimelineSnapshotMutation, } from './recorder/timelineActions'
@@ -4217,6 +4218,21 @@ export function MainWorkspace(props: AppProps) {
     },
   }
 
+  const exportReplayVideo = (
+    session: RecordedSession,
+    playbackSpeed: number,
+  ) => {
+    try {
+      enqueueAnimationJob(createReplayVideoJobSpec(session, playbackSpeed))
+      showToast('Replay video added to Exports', 3500)
+    } catch (error: unknown) {
+      const message =
+        error instanceof Error ? error.message : 'Could not export replay video'
+      showToast(message, 5000)
+      throw error
+    }
+  }
+
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   runTourCommand.fn = (id, ...args: any[]) => {
     executeCommand(id, cmdContext, ...args)
@@ -4497,6 +4513,7 @@ export function MainWorkspace(props: AppProps) {
                     onPrepareAction={prepareReplayFocus}
                     session={replaySession()}
                     onSessionChange={openReplaySession}
+                    onExportVideo={exportReplayVideo}
                     onReplayPresentationChange={setRecorderReplayPresentation}
                     busy={animationExportRunning() || timeline.isPlaying()}
                     replayBlocked={animationExportRunning()}

--- a/packages/app/src/MainWorkspace.tsx
+++ b/packages/app/src/MainWorkspace.tsx
@@ -124,6 +124,7 @@ import { persistentSignal } from './utils/persistentSignal'
 import { addRandomizerHistoryEntry, clearRandomizerHistory, loadRandomizerHistoryEntries, MAX_RANDOMIZER_HISTORY_LIMIT, } from './utils/randomizerHistoryDB'
 import { buildReadableIds } from './utils/readableIds'
 import { getOldestRecentFlame, saveRecentFlame, upsertRecentFlame, } from './utils/recentFlames'
+import { storeImportedSession } from './utils/sessionsDB'
 import { createShareLink, deriveOgMeta, uploadOgPreview, } from './utils/shareLink'
 import { sum } from './utils/sum'
 import { createTimelineState, defaultConfig as defaultTimelineConfig, resolveKeyframeValue, } from './utils/timeline'
@@ -445,6 +446,8 @@ export function MainWorkspace(props: AppProps) {
   // The session currently open for replay (M4), if any. Lives here rather than
   // in the dock because dropping a .steps.json opens one too.
   const [replaySession, setReplaySession] = createSignal<RecordedSession>()
+  const [externalSessionLibraryRevision, setExternalSessionLibraryRevision] =
+    createSignal(0)
   const [recorderReplayPresentation, setRecorderReplayPresentation] =
     createSignal({ playing: false, timelineTargeted: false })
   const openReplaySession = (session: RecordedSession | undefined) => {
@@ -461,6 +464,24 @@ export function MainWorkspace(props: AppProps) {
       return
     }
     setReplaySession(session)
+  }
+  const importReplaySession = async (
+    session: RecordedSession,
+    sourceFile: File,
+  ) => {
+    try {
+      const result = await storeImportedSession(session, sourceFile.name)
+      if (result.added) {
+        setExternalSessionLibraryRevision((revision) => revision + 1)
+        showToast(`Imported "${result.name}" to Recordings`, 3500)
+      } else {
+        showToast(`"${result.name}" is already in Recordings`, 3500)
+      }
+    } catch (error: unknown) {
+      console.warn('[recorder] could not store dropped session', error)
+      showToast('Could not save the imported replay to Recordings', 5000)
+    }
+    openReplaySession(session)
   }
   // Colors as they were before the first palette apply — lets Unselect
   // restore the "natural" colors. UI stash only; undo handles the rest.
@@ -1661,7 +1682,7 @@ export function MainWorkspace(props: AppProps) {
       },
     },
     setLoadedAnimation,
-    openReplaySession,
+    importReplaySession,
   )
 
   const timeline = createTimelineState()
@@ -4533,6 +4554,7 @@ export function MainWorkspace(props: AppProps) {
                     onPrepareAction={prepareReplayFocus}
                     session={replaySession()}
                     onSessionChange={openReplaySession}
+                    libraryRevision={externalSessionLibraryRevision()}
                     onExportVideo={exportReplayVideo}
                     onReplayPresentationChange={setRecorderReplayPresentation}
                     busy={animationExportRunning() || timeline.isPlaying()}

--- a/packages/app/src/components/ExportJobs/OffscreenAnimationRender.tsx
+++ b/packages/app/src/components/ExportJobs/OffscreenAnimationRender.tsx
@@ -6,6 +6,7 @@ import { AutoCanvas } from '@/lib/AutoCanvas'
 import { Root } from '@/lib/Root'
 import { WheelZoomCamera2D } from '@/lib/WheelZoomCamera2D'
 import { WheelZoomCamera3D } from '@/lib/WheelZoomCamera3D'
+import { assertReplayVideoStatePortable, createReplayVideoDriver, createReplayVideoSchedule, drawReplayVideoOverlay, replayActionIndexAtFrame, replayFramesInStateRun, replayVideoVisualFingerprint, } from '@/recorder/replayVideo'
 import { applyAudioMappingsToFlame, createAudioAnalyzer, } from '@/utils/audioAnalysis'
 import { createAudioVideoEncoder } from '@/utils/audioExport'
 import { deepClone } from '@/utils/clone'
@@ -37,7 +38,27 @@ function readonlySignal<T>(get: () => T): Signal<T> {
  */
 export function OffscreenAnimationRender(props: { job: AnimationJob }) {
   const { job } = props
-  const is3D = (job.flame.renderSettings.dimensions ?? 2) === 3
+  const replaySchedule =
+    job.replayVideo && job.session
+      ? createReplayVideoSchedule(
+          job.session,
+          job.replayVideo.playbackSpeed,
+          job.fps,
+          job.replayVideo.leadInMs,
+          job.replayVideo.tailMs,
+        )
+      : undefined
+  const replayDriver =
+    replaySchedule && job.session
+      ? createReplayVideoDriver(job.session)
+      : undefined
+  const initialReplayActionIndex = replaySchedule
+    ? replayActionIndexAtFrame(replaySchedule, 0)
+    : -1
+  let replayState = replayDriver?.advanceTo(initialReplayActionIndex)
+  let replayVisualKey = replayState
+    ? replayVideoVisualFingerprint(replayState)
+    : undefined
 
   const totalFrames = job.frameEnd - job.frameStart + 1
   const totalRenders = totalFrames * Math.max(1, job.playCount)
@@ -48,7 +69,7 @@ export function OffscreenAnimationRender(props: { job: AnimationJob }) {
 
   const [audioAnalyzer] = createResource(
     () =>
-      job.audioBuffer && job.audioMapping?.length
+      !replaySchedule && job.audioBuffer && job.audioMapping?.length
         ? ({ buf: job.audioBuffer, fps: job.fps } as const)
         : null,
     async (src) => {
@@ -83,11 +104,24 @@ export function OffscreenAnimationRender(props: { job: AnimationJob }) {
   }
 
   const [perFrameFlame, setPerFrameFlame] = createSignal<FlameDescriptor>(
-    frameFlame(job.frameStart),
+    replayState?.flame ?? frameFlame(job.frameStart),
   )
   const [perFrameBlendWeight, setPerFrameBlendWeight] = createSignal(
-    blendWeightAtFrame(job.frameStart),
+    replayState?.blendWeight ?? blendWeightAtFrame(job.frameStart),
   )
+  const [perFrameBlendFlame, setPerFrameBlendFlame] = createSignal(
+    replayState?.blendFlame ?? job.blendFlame,
+  )
+  const [perFramePalette, setPerFramePalette] = createSignal(
+    replayState?.palette ?? job.palette,
+  )
+  const [perFrameAdaptiveFilter, setPerFrameAdaptiveFilter] = createSignal(
+    replayState?.adaptiveFilter ?? true,
+  )
+  const [perFrameStochasticFilter, setPerFrameStochasticFilter] = createSignal(
+    replayState?.stochasticFilter ?? false,
+  )
+  const is3D = () => (perFrameFlame().renderSettings.dimensions ?? 2) === 3
 
   // Camera accessors follow the per-frame flame so animated camera moves bake in.
   const cam = () => perFrameFlame().renderSettings.camera
@@ -120,6 +154,8 @@ export function OffscreenAnimationRender(props: { job: AnimationJob }) {
   let limitAccessor: () => number = () => 0
   let posterUrl: string | undefined
   let encoder: Awaited<ReturnType<typeof createVideoEncoder>> | undefined
+  let compositeCanvas: HTMLCanvasElement | undefined
+  let compositeContext: CanvasRenderingContext2D | undefined
 
   onCleanup(() => {
     disposed = true
@@ -128,23 +164,35 @@ export function OffscreenAnimationRender(props: { job: AnimationJob }) {
 
   void (async () => {
     try {
-      encoder = job.audioBuffer
-        ? await createAudioVideoEncoder(
-            {
+      const nextEncoder =
+        job.audioBuffer && !replaySchedule
+          ? await createAudioVideoEncoder(
+              {
+                codec: job.codec,
+                width: resizeWidth,
+                height: resizeHeight,
+                fps: job.fps,
+              },
+              job.audioBuffer,
+              job.fps,
+            )
+          : await createVideoEncoder({
               codec: job.codec,
               width: resizeWidth,
               height: resizeHeight,
               fps: job.fps,
-            },
-            job.audioBuffer,
-            job.fps,
-          )
-        : await createVideoEncoder({
-            codec: job.codec,
-            width: resizeWidth,
-            height: resizeHeight,
-            fps: job.fps,
-          })
+            })
+      // MediaRecorder's captureStream fallback advances in wall-clock time,
+      // while a semantic replay deliberately renders frames off-line and may
+      // reuse one accumulated artwork frame many times. Accepting that fallback
+      // would produce the wrong pacing and no embedded session metadata.
+      if (replaySchedule && nextEncoder.usedFallback) {
+        nextEncoder.cancel()
+        throw new Error(
+          'Replay video export needs browser support for offline video encoding',
+        )
+      }
+      encoder = nextEncoder
       if (disposed) encoder.cancel()
     } catch (err) {
       setJobError(job.id, err instanceof Error ? err.message : String(err))
@@ -184,31 +232,130 @@ export function OffscreenAnimationRender(props: { job: AnimationJob }) {
     }
   }
 
-  async function captureAndAdvance(canvas: HTMLCanvasElement) {
-    if (!encoder) {
-      capturing = false
-      return
+  function queuePoster(canvas: HTMLCanvasElement) {
+    if (frameIndex !== 0) return
+    // A poster-less <video> often shows a blank/green undecoded frame.
+    canvas.toBlob((blob) => {
+      if (blob && !disposed) posterUrl = URL.createObjectURL(blob)
+    }, 'image/png')
+  }
+
+  function updateReplayState(actionIndex: number): boolean {
+    if (!replayDriver) return false
+    const next = replayDriver.advanceTo(actionIndex)
+    assertReplayVideoStatePortable(next, actionIndex)
+    const nextVisualKey = replayVideoVisualFingerprint(next)
+    const visualChanged = nextVisualKey !== replayVisualKey
+    replayState = next
+    replayVisualKey = nextVisualKey
+    if (!visualChanged) return false
+
+    setPerFrameFlame(next.flame)
+    setPerFrameBlendFlame(() => next.blendFlame)
+    setPerFrameBlendWeight(next.blendWeight)
+    setPerFramePalette(() => next.palette)
+    setPerFrameAdaptiveFilter(next.adaptiveFilter)
+    setPerFrameStochasticFilter(next.stochasticFilter)
+    return true
+  }
+
+  function getCompositeSurface(): {
+    canvas: HTMLCanvasElement
+    context: CanvasRenderingContext2D
+  } {
+    compositeCanvas ??= document.createElement('canvas')
+    compositeCanvas.width = resizeWidth
+    compositeCanvas.height = resizeHeight
+    compositeContext ??=
+      compositeCanvas.getContext('2d', { alpha: false }) ?? undefined
+    if (!compositeContext) {
+      throw new Error('Could not create the replay-video composition canvas')
     }
-    if (frameIndex === 0) {
-      // Poster of the first rendered frame for the tracker thumbnail — a
-      // poster-less <video> shows a blank/green undecoded frame. Best-effort
-      // and async; if it isn't ready by finish() the video just has no poster.
-      canvas.toBlob((blob) => {
-        if (blob && !disposed) posterUrl = URL.createObjectURL(blob)
-      }, 'image/png')
-    }
-    const bitmap = await globalThis.createImageBitmap(canvas, {
+    return { canvas: compositeCanvas, context: compositeContext }
+  }
+
+  async function captureReplayStateRuns(canvas: HTMLCanvasElement) {
+    if (!encoder || !replaySchedule || !job.session) return
+    const rendered = await globalThis.createImageBitmap(canvas, {
       resizeWidth,
       resizeHeight,
       resizeQuality: 'high',
     })
     if (disposed) {
-      bitmap.close()
+      rendered.close()
       return
     }
-    // encodeFrame applies backpressure and closes the bitmap.
-    await encoder.encodeFrame(bitmap, frameIndex)
-    frameIndex++
+    const composite = getCompositeSurface()
+    try {
+      while (frameIndex < totalRenders) {
+        const runFrames = replayFramesInStateRun(replaySchedule, frameIndex)
+        for (let offset = 0; offset < runFrames; offset++) {
+          if (disposed || (props.job.forceExport && frameIndex > 0)) return
+          const actionIndex = replayActionIndexAtFrame(
+            replaySchedule,
+            frameIndex,
+          )
+          composite.context.clearRect(0, 0, resizeWidth, resizeHeight)
+          composite.context.drawImage(rendered, 0, 0, resizeWidth, resizeHeight)
+          drawReplayVideoOverlay(composite.context, resizeWidth, resizeHeight, {
+            action:
+              actionIndex < 0 ? undefined : job.session.actions[actionIndex],
+            actionIndex,
+            totalActions: job.session.actions.length,
+            progress: totalRenders <= 1 ? 1 : frameIndex / (totalRenders - 1),
+            flameName: job.session.initial.metadata?.name,
+          })
+          queuePoster(composite.canvas)
+          const bitmap = await globalThis.createImageBitmap(composite.canvas)
+          if (disposed) {
+            bitmap.close()
+            return
+          }
+          await encoder.encodeFrame(bitmap, frameIndex)
+          frameIndex++
+          setAnimationJobProgress(job.id, frameIndex, totalRenders, 'rendering')
+        }
+
+        if (
+          frameIndex >= totalRenders ||
+          props.job.forceExport ||
+          updateReplayState(
+            replayActionIndexAtFrame(replaySchedule, frameIndex),
+          )
+        ) {
+          return
+        }
+        // The next step changed only non-rendered state. Keep using this exact
+        // artwork frame while advancing its caption/progress run rather than
+        // waiting for a GPU reset that will (correctly) never happen.
+      }
+    } finally {
+      rendered.close()
+    }
+  }
+
+  async function captureAndAdvance(canvas: HTMLCanvasElement) {
+    if (!encoder) {
+      capturing = false
+      return
+    }
+    if (replaySchedule) {
+      await captureReplayStateRuns(canvas)
+    } else {
+      queuePoster(canvas)
+      const bitmap = await globalThis.createImageBitmap(canvas, {
+        resizeWidth,
+        resizeHeight,
+        resizeQuality: 'high',
+      })
+      if (disposed) {
+        bitmap.close()
+        return
+      }
+      // encodeFrame applies backpressure and closes the bitmap.
+      await encoder.encodeFrame(bitmap, frameIndex)
+      frameIndex++
+    }
     capturing = false
     if (disposed) return
     setAnimationJobProgress(job.id, frameIndex, totalRenders, 'rendering')
@@ -218,9 +365,11 @@ export function OffscreenAnimationRender(props: { job: AnimationJob }) {
     }
     // Advancing the flame changes Flam3's accumulationFingerprint, which resets
     // accumulation so the next frame renders fresh.
-    const frame = job.frameStart + (frameIndex % totalFrames)
-    setPerFrameFlame(frameFlame(frame))
-    setPerFrameBlendWeight(blendWeightAtFrame(frame))
+    if (!replaySchedule) {
+      const frame = job.frameStart + (frameIndex % totalFrames)
+      setPerFrameFlame(frameFlame(frame))
+      setPerFrameBlendWeight(blendWeightAtFrame(frame))
+    }
   }
 
   const handleExport: ExportImageType = (canvas, info) => {
@@ -255,7 +404,7 @@ export function OffscreenAnimationRender(props: { job: AnimationJob }) {
     <Root adapterOptions={{ powerPreference: 'high-performance' }}>
       <AutoCanvas fixedResolution={job.dimensions} alphaMode="opaque">
         <Show
-          when={is3D}
+          when={is3D()}
           fallback={
             <WheelZoomCamera2D
               zoom={zoom}
@@ -265,15 +414,16 @@ export function OffscreenAnimationRender(props: { job: AnimationJob }) {
               <Flam3
                 quality={job.quality}
                 pointCountPerBatch={DEFAULT_POINT_COUNT}
-                adaptiveFilterEnabled={true}
+                adaptiveFilterEnabled={perFrameAdaptiveFilter()}
+                stochasticFilterEnabled={perFrameStochasticFilter()}
                 animationEnabled={false}
                 exportDriver
                 flameDescriptor={perFrameFlame()}
-                blendFlame={job.blendFlame}
+                blendFlame={perFrameBlendFlame()}
                 blendWeight={perFrameBlendWeight()}
                 renderInterval={0}
                 edgeFadeColor={vec4f(0)}
-                palette={() => job.palette}
+                palette={perFramePalette}
                 onExportImage={handleExport}
                 onAccumulatedPointCount={(c) => {
                   accumulated = c
@@ -297,15 +447,16 @@ export function OffscreenAnimationRender(props: { job: AnimationJob }) {
             <Flam3
               quality={job.quality}
               pointCountPerBatch={DEFAULT_POINT_COUNT}
-              adaptiveFilterEnabled={true}
+              adaptiveFilterEnabled={perFrameAdaptiveFilter()}
+              stochasticFilterEnabled={perFrameStochasticFilter()}
               animationEnabled={false}
               exportDriver
               flameDescriptor={perFrameFlame()}
-              blendFlame={job.blendFlame}
+              blendFlame={perFrameBlendFlame()}
               blendWeight={perFrameBlendWeight()}
               renderInterval={0}
               edgeFadeColor={vec4f(0)}
-              palette={() => job.palette}
+              palette={perFramePalette}
               onExportImage={handleExport}
               onAccumulatedPointCount={(c) => {
                 accumulated = c

--- a/packages/app/src/components/FloatingActions/FloatingActions.test.tsx
+++ b/packages/app/src/components/FloatingActions/FloatingActions.test.tsx
@@ -3,7 +3,7 @@ import { createSignal } from 'solid-js'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { examples } from '@/flame/examples'
 import { cancelSessionRecording, startSessionRecording, } from '@/recorder/recorder'
-import { recorderVisible, setRecorderSavePending, setRecorderVisible, } from '../SessionRecorder/recorderUi'
+import { recorderVisible, setRecorderExportPending, setRecorderSavePending, setRecorderVisible, } from '../SessionRecorder/recorderUi'
 import { FloatingActions } from './FloatingActions'
 
 function renderFloatingActions(initiallyCollapsed = false) {
@@ -83,12 +83,14 @@ describe('FloatingActions controlled collapse', () => {
 describe('FloatingActions recorder toggle', () => {
   beforeEach(() => {
     cancelSessionRecording()
+    setRecorderExportPending(false)
     setRecorderSavePending(false)
     setRecorderVisible(true)
   })
 
   afterEach(() => {
     cancelSessionRecording()
+    setRecorderExportPending(false)
     setRecorderSavePending(false)
     setRecorderVisible(true)
   })
@@ -117,6 +119,24 @@ describe('FloatingActions recorder toggle', () => {
 
     fireEvent.click(toggle)
     expect(recorderVisible()).toBe(false)
+    unmount()
+  })
+
+  it('cannot hide the recorder while a full-interface export is active', () => {
+    const { unmount } = renderFloatingActions()
+    const toggle = screen.getByRole<HTMLButtonElement>('button', {
+      name: 'Hide the step recorder',
+    })
+
+    setRecorderExportPending(true)
+
+    expect(toggle.disabled).toBe(true)
+    expect(toggle.title).toBe('Wait for the replay video recording to finish')
+    fireEvent.click(toggle)
+    expect(recorderVisible()).toBe(true)
+
+    setRecorderExportPending(false)
+    expect(toggle.disabled).toBe(false)
     unmount()
   })
 })

--- a/packages/app/src/components/FloatingActions/FloatingActions.tsx
+++ b/packages/app/src/components/FloatingActions/FloatingActions.tsx
@@ -3,7 +3,7 @@ import { Bookmark, CameraIcon, Discord, Eye, FolderOpen, Home, Pause, Plus, Shar
 import { setActiveTab } from '@/lib/activeTab'
 import { isSessionRecording } from '@/recorder/recorder'
 import { defaultPills, QualityPresets } from '../Quality/QualityPresets'
-import { recorderSavePending, recorderVisible, setRecorderVisible, } from '../SessionRecorder/recorderUi'
+import { recorderExportPending, recorderSavePending, recorderTaskPending, recorderVisible, setRecorderVisible, } from '../SessionRecorder/recorderUi'
 import ui from './FloatingActions.module.css'
 
 type Props = {
@@ -62,15 +62,17 @@ export function FloatingActions(props: Props) {
   const collapsed = props.collapsed
 
   const recorderToggleDisabled = () =>
-    isSessionRecording() || recorderSavePending()
+    isSessionRecording() || recorderTaskPending()
   const recorderToggleLabel = () =>
     isSessionRecording()
       ? 'Stop or discard the recording first'
-      : recorderSavePending()
-        ? 'Wait for the caption save to finish'
-        : recorderVisible()
-          ? 'Hide the step recorder'
-          : 'Show the step recorder'
+      : recorderExportPending()
+        ? 'Wait for the replay video recording to finish'
+        : recorderSavePending()
+          ? 'Wait for the caption save to finish'
+          : recorderVisible()
+            ? 'Hide the step recorder'
+            : 'Show the step recorder'
 
   // Position saved before collapsing so both user and replay-driven expansion
   // return the widget to the same place.

--- a/packages/app/src/components/SessionRecorder/SessionRecorderControls.test.tsx
+++ b/packages/app/src/components/SessionRecorder/SessionRecorderControls.test.tsx
@@ -1,13 +1,41 @@
-import { fireEvent, render, screen } from '@solidjs/testing-library'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@solidjs/testing-library'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ToastHost } from '@/components/Toast/Toast'
 import { ToastProvider } from '@/contexts/ToastContext'
 import { examples } from '@/flame/examples'
 import { cancelSessionRecording, isSessionRecording } from '@/recorder/recorder'
+import { serializeSession, SESSION_FORMAT_VERSION } from '@/recorder/schema'
 import { deepClone } from '@/utils/clone'
 import { SessionRecorderControls } from './SessionRecorderControls'
+import type { RecordedSession } from '@/recorder/schema'
+
+const { storeImportedSessionMock, storeSessionMock } = vi.hoisted(() => ({
+  storeImportedSessionMock: vi.fn(),
+  storeSessionMock: vi.fn(),
+}))
+
+vi.mock('@/utils/sessionsDB', () => ({
+  storeImportedSession: storeImportedSessionMock,
+  storeSession: storeSessionMock,
+}))
+
+function validSession(): RecordedSession {
+  return {
+    version: SESSION_FORMAT_VERSION,
+    app: { version: 'test', flameSchemaVersion: 'test' },
+    createdAt: '2026-08-21T12:00:00.000Z',
+    initial: deepClone(examples.example1),
+    actions: [{ t: 0, id: 'flame.setGamma', args: [2] }],
+    unnamedWriteCount: 0,
+  }
+}
 
 describe('SessionRecorderControls start feedback', () => {
+  beforeEach(() => {
+    storeImportedSessionMock.mockReset()
+    storeSessionMock.mockReset()
+  })
+
   afterEach(() => {
     cancelSessionRecording()
     vi.restoreAllMocks()
@@ -65,6 +93,92 @@ describe('SessionRecorderControls start feedback', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Open steps' }))
 
     expect(click).toHaveBeenCalledTimes(1)
+    unmount()
+  })
+
+  it('imports a selected steps file before opening its replay', async () => {
+    const session = validSession()
+    const file = new File(['session'], 'Imported take.steps.json', {
+      type: 'application/json',
+    })
+    Object.defineProperty(file, 'text', {
+      value: () => Promise.resolve(serializeSession(session)),
+    })
+    storeImportedSessionMock.mockResolvedValue({
+      added: true,
+      name: 'Imported take',
+    })
+    const onOpenSession = vi.fn()
+    const onSessionStored = vi.fn()
+    const { container, unmount } = render(() => (
+      <ToastProvider>
+        <SessionRecorderControls
+          flameDescriptor={examples.example1}
+          onOpenSession={onOpenSession}
+          onSessionStored={onSessionStored}
+          onToggleLibrary={() => {}}
+        />
+        <ToastHost />
+      </ToastProvider>
+    ))
+    const input =
+      container.querySelector<HTMLInputElement>('input[type="file"]')
+
+    fireEvent.change(input!, { target: { files: [file] } })
+
+    await waitFor(() => {
+      expect(storeImportedSessionMock).toHaveBeenCalledWith(session, file.name)
+    })
+    expect(onSessionStored).toHaveBeenCalledWith({ openLibrary: false })
+    expect(onOpenSession).toHaveBeenCalledWith(session)
+    expect(
+      screen.getByText('Imported "Imported take" to Recordings'),
+    ).toBeTruthy()
+    unmount()
+  })
+
+  it('still opens a validated replay when local import storage fails', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const storageError = new Error('quota exceeded')
+    const session = validSession()
+    const file = new File(['session'], 'Portable take.steps.json', {
+      type: 'application/json',
+    })
+    Object.defineProperty(file, 'text', {
+      value: () => Promise.resolve(serializeSession(session)),
+    })
+    storeImportedSessionMock.mockRejectedValue(storageError)
+    const onOpenSession = vi.fn()
+    const onSessionStored = vi.fn()
+    const { container, unmount } = render(() => (
+      <ToastProvider>
+        <SessionRecorderControls
+          flameDescriptor={examples.example1}
+          onOpenSession={onOpenSession}
+          onSessionStored={onSessionStored}
+          onToggleLibrary={() => {}}
+        />
+        <ToastHost />
+      </ToastProvider>
+    ))
+    const input =
+      container.querySelector<HTMLInputElement>('input[type="file"]')
+
+    fireEvent.change(input!, { target: { files: [file] } })
+
+    await waitFor(() => {
+      expect(onOpenSession).toHaveBeenCalledWith(session)
+    })
+    expect(onSessionStored).not.toHaveBeenCalled()
+    expect(
+      screen.getByText(
+        'Replay opened, but it could not be saved to Recordings',
+      ),
+    ).toBeTruthy()
+    expect(warn).toHaveBeenCalledWith(
+      '[recorder] could not store imported session',
+      storageError,
+    )
     unmount()
   })
 

--- a/packages/app/src/components/SessionRecorder/SessionRecorderControls.tsx
+++ b/packages/app/src/components/SessionRecorder/SessionRecorderControls.tsx
@@ -1,10 +1,10 @@
-import { Show } from 'solid-js'
+import { createSignal, Show } from 'solid-js'
 import { useToast } from '@/contexts/ToastContext'
 import { Book, FolderOpen, Record } from '@/icons'
 import { cancelSessionRecording, isSessionRecording, recordedActionCount, startSessionRecording, stopSessionRecording, unnamedWriteCount, } from '@/recorder/recorder'
 import { MAX_SESSION_FILE_BYTES, parseSession, serializeSession, sessionFilename, } from '@/recorder/schema'
 import { downloadBlob } from '@/utils/blob'
-import { storeSession } from '@/utils/sessionsDB'
+import { storeImportedSession, storeSession } from '@/utils/sessionsDB'
 import styles from './SessionRecorderControls.module.css'
 import type { FlameDescriptor } from '@/flame/schema/flameSchema'
 import type { SessionRecordingStartFailureReason, SessionStartExtras, } from '@/recorder/recorder'
@@ -40,7 +40,7 @@ export function SessionRecorderControls(props: {
   onRecordingStarted?: () => void
   onOpenSession: (session: RecordedSession) => void
   /** Called after a recording is stored, so the library list refetches. */
-  onSessionStored: () => void
+  onSessionStored: (options?: { openLibrary?: boolean }) => void
   onToggleLibrary: () => void
   libraryOpen?: boolean
   recordingsButtonRef?: (element: HTMLButtonElement) => void
@@ -48,6 +48,7 @@ export function SessionRecorderControls(props: {
   blocked?: boolean
 }) {
   const { showToast } = useToast()
+  const [importingSession, setImportingSession] = createSignal(false)
   let fileInputRef: HTMLInputElement | undefined
 
   const startRecording = () => {
@@ -111,7 +112,7 @@ export function SessionRecorderControls(props: {
   }
 
   const openSessionFile = async (file: File | undefined) => {
-    if (!file) return
+    if (!file || importingSession()) return
     // Check the browser-provided byte count before allocating and decoding an
     // attacker-controlled file. parseSession applies the decoded-char and
     // schema limits after this cheap boundary check.
@@ -119,12 +120,38 @@ export function SessionRecorderControls(props: {
       showToast('That .steps.json file is too large to open safely', 4000)
       return
     }
-    const session = parseSession(await file.text())
-    if (!session) {
-      showToast('That file is not a readable .steps.json session', 4000)
-      return
+    setImportingSession(true)
+    try {
+      const session = parseSession(await file.text())
+      if (!session) {
+        showToast('That file is not a readable .steps.json session', 4000)
+        return
+      }
+
+      try {
+        const result = await storeImportedSession(session, file.name)
+        if (result.added) {
+          props.onSessionStored({ openLibrary: false })
+          showToast(`Imported "${result.name}" to Recordings`, 3500)
+        } else {
+          showToast(`"${result.name}" is already in Recordings`, 3500)
+        }
+      } catch (error: unknown) {
+        // Opening the validated take is still useful when IndexedDB is
+        // unavailable (private browsing, quota, or transient browser error).
+        console.warn('[recorder] could not store imported session', error)
+        showToast(
+          'Replay opened, but it could not be saved to Recordings',
+          5000,
+        )
+      }
+      props.onOpenSession(session)
+    } catch (error: unknown) {
+      console.warn('[recorder] could not read imported session', error)
+      showToast('That .steps.json file could not be read', 4000)
+    } finally {
+      setImportingSession(false)
     }
-    props.onOpenSession(session)
   }
 
   return (
@@ -163,8 +190,14 @@ export function SessionRecorderControls(props: {
               type="button"
               class={styles.iconButton}
               onClick={() => fileInputRef?.click()}
+              disabled={importingSession()}
+              aria-busy={importingSession()}
               aria-label="Open steps"
-              title="Replay a saved .steps.json"
+              title={
+                importingSession()
+                  ? 'Importing steps…'
+                  : 'Import a .steps.json into Recordings and replay it'
+              }
             >
               <FolderOpen class={styles.icon} aria-hidden="true" />
             </button>
@@ -173,6 +206,7 @@ export function SessionRecorderControls(props: {
               type="file"
               accept=".json,application/json"
               class={styles.fileInput}
+              disabled={importingSession()}
               onChange={(ev) => {
                 const input = ev.currentTarget
                 void openSessionFile(input.files?.[0]).finally(() => {

--- a/packages/app/src/components/SessionRecorder/SessionRecorderDock.test.tsx
+++ b/packages/app/src/components/SessionRecorder/SessionRecorderDock.test.tsx
@@ -261,6 +261,36 @@ describe('SessionRecorderDock caption persistence', () => {
     unmount()
   })
 
+  it('refreshes a retained library after an external recording import', async () => {
+    const [libraryRevision, setLibraryRevision] = createSignal(0)
+    const { unmount } = render(() => (
+      <ToastProvider>
+        <SessionRecorderDock
+          flameDescriptor={examples.example1}
+          target={target}
+          session={undefined}
+          onSessionChange={() => {}}
+          libraryRevision={libraryRevision()}
+          busy={false}
+        />
+      </ToastProvider>
+    ))
+
+    fireEvent.click(
+      screen.getByRole<HTMLButtonElement>('button', { name: 'Recordings' }),
+    )
+    await waitFor(() => {
+      expect(loadStoredSessionsMock).toHaveBeenCalledTimes(1)
+    })
+
+    setLibraryRevision(1)
+
+    await waitFor(() => {
+      expect(loadStoredSessionsMock).toHaveBeenCalledTimes(2)
+    })
+    unmount()
+  })
+
   it('exposes transparency as a disclosure and preserves keyboard focus flow', async () => {
     const { unmount } = render(() => (
       <ToastProvider>

--- a/packages/app/src/components/SessionRecorder/SessionRecorderDock.test.tsx
+++ b/packages/app/src/components/SessionRecorder/SessionRecorderDock.test.tsx
@@ -5,7 +5,7 @@ import { ToastHost } from '@/components/Toast/Toast'
 import { ToastProvider } from '@/contexts/ToastContext'
 import { examples } from '@/flame/examples'
 import { cancelSessionRecording, startSessionRecording, stopSessionRecording, } from '@/recorder/recorder'
-import { recorderOffset, recorderSavePending, recorderVisible, setFollowCamEnabled, setRecorderCollapsed, setRecorderFadeOnPlayback, setRecorderOffset, setRecorderOpacity, setRecorderSavePending, setRecorderVisible, } from './recorderUi'
+import { recorderOffset, recorderSavePending, recorderVisible, setFollowCamEnabled, setRecorderCollapsed, setRecorderExportPending, setRecorderFadeOnPlayback, setRecorderOffset, setRecorderOpacity, setRecorderSavePending, setRecorderVisible, } from './recorderUi'
 import { calculateFloatingPanelPlacement, SessionRecorderDock, } from './SessionRecorderDock'
 import type { ReplayTarget } from '@/recorder/replay'
 import type { RecordedSession } from '@/recorder/schema'
@@ -40,6 +40,7 @@ describe('SessionRecorderDock caption persistence', () => {
     deleteStoredSessionMock.mockReset().mockResolvedValue([])
     loadStoredSessionsMock.mockReset().mockResolvedValue([])
     renameStoredSessionMock.mockReset().mockResolvedValue([])
+    setRecorderExportPending(false)
     setRecorderSavePending(false)
     setRecorderVisible(true)
     setRecorderCollapsed(false)
@@ -55,6 +56,7 @@ describe('SessionRecorderDock caption persistence', () => {
     storeSessionMock.mockReset()
     loadStoredSessionsMock.mockReset()
     renameStoredSessionMock.mockReset()
+    setRecorderExportPending(false)
     setRecorderSavePending(false)
     setRecorderVisible(true)
     setRecorderCollapsed(false)

--- a/packages/app/src/components/SessionRecorder/SessionRecorderDock.tsx
+++ b/packages/app/src/components/SessionRecorder/SessionRecorderDock.tsx
@@ -3,7 +3,7 @@ import { useToast } from '@/contexts/ToastContext'
 import { ChevronDown, CircleHalf, Cross } from '@/icons'
 import { isSessionRecording } from '@/recorder/recorder'
 import { storeSession } from '@/utils/sessionsDB'
-import { clampRecorderOpacity, FADED_RECORDER_OPACITY, followCamEnabled, MIN_RECORDER_OPACITY, recorderCollapsed, recorderFadeOnPlayback, recorderOffset, recorderOpacity, recorderSavePending, setRecorderCollapsed, setRecorderFadeOnPlayback, setRecorderOffset, setRecorderOpacity, setRecorderSavePending, setRecorderVisible, } from './recorderUi'
+import { clampRecorderOpacity, FADED_RECORDER_OPACITY, followCamEnabled, MIN_RECORDER_OPACITY, recorderCollapsed, recorderExportPending, recorderFadeOnPlayback, recorderOffset, recorderOpacity, recorderSavePending, recorderTaskPending, setRecorderCollapsed, setRecorderFadeOnPlayback, setRecorderOffset, setRecorderOpacity, setRecorderSavePending, setRecorderVisible, } from './recorderUi'
 import { SessionLibraryPanel } from './SessionLibraryPanel'
 import { SessionRecorderControls } from './SessionRecorderControls'
 import styles from './SessionRecorderDock.module.css'
@@ -12,6 +12,7 @@ import type { FlameDescriptor } from '@/flame/schema/flameSchema'
 import type { ReplayFocusPreparation, ReplayFocusPreparationHandler, } from '@/recorder/focusPreparation'
 import type { SessionStartExtras } from '@/recorder/recorder'
 import type { ReplayTarget } from '@/recorder/replay'
+import type { ReplayVideoExportRequest } from '@/recorder/replayInterfaceVideo'
 import type { RecordedSession } from '@/recorder/schema'
 
 /**
@@ -81,11 +82,8 @@ export function SessionRecorderDock(props: {
    *  file opens one too. */
   session: RecordedSession | undefined
   onSessionChange: (session: RecordedSession | undefined) => void
-  /** Queue a detached, publishable replay video from the edited take. */
-  onExportVideo?: (
-    session: RecordedSession,
-    playbackSpeed: number,
-  ) => Promise<void> | void
+  /** Export a publishable artwork or full-interface video from the edited take. */
+  onExportVideo?: (request: ReplayVideoExportRequest) => Promise<void> | void
   /** True while the canvas is animating or exporting — the cue to fade. */
   busy: boolean
   /** True while an export temporarily owns and restores the main document. */
@@ -568,10 +566,13 @@ export function SessionRecorderDock(props: {
           onClick={() => {
             setRecorderCollapsed((collapsed) => !collapsed)
           }}
+          disabled={recorderExportPending()}
           title={
-            recorderCollapsed()
-              ? 'Show the replay steps and the recordings list'
-              : 'Collapse to the pill (keeps the transport)'
+            recorderExportPending()
+              ? 'Keep the replay panel visible while recording the interface'
+              : recorderCollapsed()
+                ? 'Show the replay steps and the recordings list'
+                : 'Collapse to the pill (keeps the transport)'
           }
           aria-label={
             recorderCollapsed() ? 'Expand recorder' : 'Collapse recorder'
@@ -590,13 +591,15 @@ export function SessionRecorderDock(props: {
           onClick={() => {
             setRecorderVisible(false)
           }}
-          disabled={isSessionRecording() || recorderSavePending()}
+          disabled={isSessionRecording() || recorderTaskPending()}
           title={
             isSessionRecording()
               ? 'Stop or discard the recording first'
-              : recorderSavePending()
-                ? 'Wait for the caption save to finish'
-                : 'Hide the recorder (bring it back from the toolbar)'
+              : recorderExportPending()
+                ? 'Wait for the replay video recording to finish'
+                : recorderSavePending()
+                  ? 'Wait for the caption save to finish'
+                  : 'Hide the recorder (bring it back from the toolbar)'
           }
           aria-label="Hide recorder"
         >

--- a/packages/app/src/components/SessionRecorder/SessionRecorderDock.tsx
+++ b/packages/app/src/components/SessionRecorder/SessionRecorderDock.tsx
@@ -81,6 +81,11 @@ export function SessionRecorderDock(props: {
    *  file opens one too. */
   session: RecordedSession | undefined
   onSessionChange: (session: RecordedSession | undefined) => void
+  /** Queue a detached, publishable replay video from the edited take. */
+  onExportVideo?: (
+    session: RecordedSession,
+    playbackSpeed: number,
+  ) => Promise<void> | void
   /** True while the canvas is animating or exporting — the cue to fade. */
   busy: boolean
   /** True while an export temporarily owns and restores the main document. */
@@ -398,6 +403,7 @@ export function SessionRecorderDock(props: {
               session={session}
               target={props.target}
               compact={recorderCollapsed()}
+              onExportVideo={props.onExportVideo}
               onSave={async (edited) => {
                 // Saved as a NEW entry rather than overwriting: captions are an
                 // authoring pass over a take, and the raw take is what you go

--- a/packages/app/src/components/SessionRecorder/SessionRecorderDock.tsx
+++ b/packages/app/src/components/SessionRecorder/SessionRecorderDock.tsx
@@ -82,6 +82,8 @@ export function SessionRecorderDock(props: {
    *  file opens one too. */
   session: RecordedSession | undefined
   onSessionChange: (session: RecordedSession | undefined) => void
+  /** Bumped when an external drop imports a take into Recordings. */
+  libraryRevision?: number
   /** Export a publishable artwork or full-interface video from the edited take. */
   onExportVideo?: (request: ReplayVideoExportRequest) => Promise<void> | void
   /** True while the canvas is animating or exporting — the cue to fade. */
@@ -443,7 +445,7 @@ export function SessionRecorderDock(props: {
 
         <Show when={libraryMounted()}>
           <SessionLibraryPanel
-            revision={libraryRevision()}
+            revision={libraryRevision() + (props.libraryRevision ?? 0)}
             hidden={!showLibrary()}
             panelRef={(element) => {
               libraryPanelRef = element
@@ -482,9 +484,9 @@ export function SessionRecorderDock(props: {
             startExtras={props.startExtras}
             onRecordingStarted={props.onRecordingStarted}
             onOpenSession={openReplay}
-            onSessionStored={() => {
+            onSessionStored={(options) => {
               setLibraryRevision((n) => n + 1)
-              openLibrary()
+              if (options?.openLibrary !== false) openLibrary()
             }}
             libraryOpen={showLibrary()}
             recordingsButtonRef={(element) => {

--- a/packages/app/src/components/SessionRecorder/SessionReplayPanel.module.css
+++ b/packages/app/src/components/SessionRecorder/SessionReplayPanel.module.css
@@ -284,8 +284,79 @@
 
 .footer-actions {
   display: flex;
+  align-items: flex-end;
   justify-content: flex-end;
   gap: 0.3rem;
+}
+
+.video-export {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.25rem 0.35rem;
+}
+
+.video-modes {
+  display: inline-flex;
+  padding: 2px;
+  border-radius: 8px;
+  background: oklch(12% 0.02 240 / 0.45);
+
+  [data-theme='light'] & {
+    background: oklch(88% 0.02 240 / 0.75);
+  }
+}
+
+.video-mode {
+  padding: 0.12rem 0.4rem;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  opacity: 0.62;
+
+  &:hover:not(:disabled) {
+    opacity: 1;
+  }
+
+  &:disabled {
+    cursor: default;
+    opacity: 0.32;
+  }
+}
+
+.video-mode-active {
+  background: oklch(54% 0.12 240 / 0.48);
+  box-shadow: 0 1px 3px oklch(0% 0 0 / 0.22);
+  opacity: 1;
+}
+
+.video-help {
+  flex-basis: 100%;
+  order: 3;
+  margin: 0;
+  color: oklch(79% 0.035 240);
+  font-size: 0.65rem;
+  line-height: 1.3;
+
+  [data-theme='light'] & {
+    color: oklch(43% 0.035 240);
+  }
+}
+
+.export-error {
+  flex-basis: 100%;
+  order: 4;
+  color: oklch(84% 0.12 30);
+  line-height: 1.3;
+
+  [data-theme='light'] & {
+    color: oklch(40% 0.12 30);
+  }
 }
 
 @media (pointer: coarse) {
@@ -303,6 +374,10 @@
   .step-edit,
   .note-input,
   .hold-input {
+    min-height: var(--recorder-coarse-target, 2.25rem);
+  }
+
+  .video-mode {
     min-height: var(--recorder-coarse-target, 2.25rem);
   }
 

--- a/packages/app/src/components/SessionRecorder/SessionReplayPanel.module.css
+++ b/packages/app/src/components/SessionRecorder/SessionReplayPanel.module.css
@@ -282,6 +282,12 @@
   white-space: nowrap;
 }
 
+.footer-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.3rem;
+}
+
 @media (pointer: coarse) {
   .panel {
     --replay-control-target: var(--recorder-coarse-target, 2.25rem);

--- a/packages/app/src/components/SessionRecorder/SessionReplayPanel.test.tsx
+++ b/packages/app/src/components/SessionRecorder/SessionReplayPanel.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor } from '@solidjs/testing-library'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { examples } from '@/flame/examples'
 import { cancelSessionRecording } from '@/recorder/recorder'
 import { SESSION_FORMAT_VERSION } from '@/recorder/schema'
@@ -120,5 +120,83 @@ describe('SessionReplayPanel accessibility', () => {
       screen.getByRole('button', { name: 'Close editor for step 1' }),
     ).toBe(edit)
     unmount()
+  })
+
+  it('exports the edited take at the selected replay speed without mutating the source', async () => {
+    const source = makeSession()
+    const exportVideo = vi.fn().mockResolvedValue(undefined)
+    const { unmount } = render(() => (
+      <SessionReplayPanel
+        session={source}
+        target={makeTarget()}
+        onExportVideo={exportVideo}
+        onClose={() => {}}
+      />
+    ))
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Edit caption for step 1' }),
+    )
+    fireEvent.input(
+      screen.getByRole('textbox', { name: 'Caption for step 1' }),
+      { target: { value: 'Reveal the first transform' } },
+    )
+    fireEvent.input(screen.getByRole('spinbutton', { name: /hold/i }), {
+      target: { value: '900' },
+    })
+    fireEvent.change(screen.getByRole('combobox', { name: 'Playback speed' }), {
+      target: { value: '2' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Export video' }))
+
+    await waitFor(() => {
+      expect(exportVideo).toHaveBeenCalledTimes(1)
+    })
+    const [exported, playbackSpeed] = exportVideo.mock.calls[0] as [
+      RecordedSession,
+      number,
+    ]
+    expect(exported.actions[0]?.note).toBe('Reveal the first transform')
+    expect(exported.actions[0]?.holdMs).toBe(900)
+    expect(playbackSpeed).toBe(2)
+    expect(source.actions[0]?.note).toBe('Shape the first transform')
+    expect(source.actions[0]?.holdMs).toBeUndefined()
+    unmount()
+  })
+
+  it('disables publishing when the take has no trustworthy creation sequence', () => {
+    const empty = makeSession()
+    empty.actions = []
+    const first = render(() => (
+      <SessionReplayPanel
+        session={empty}
+        target={makeTarget()}
+        onExportVideo={() => {}}
+        onClose={() => {}}
+      />
+    ))
+
+    const emptyExport = screen.getByRole('button', { name: 'Export video' })
+    expect((emptyExport as HTMLButtonElement).disabled).toBe(true)
+    expect(emptyExport.title).toMatch(/at least one authored step/)
+    first.unmount()
+
+    const incomplete = makeSession()
+    incomplete.unnamedWriteCount = 1
+    const second = render(() => (
+      <SessionReplayPanel
+        session={incomplete}
+        target={makeTarget()}
+        onExportVideo={() => {}}
+        onClose={() => {}}
+      />
+    ))
+
+    const incompleteExport = screen.getByRole('button', {
+      name: 'Export video',
+    })
+    expect((incompleteExport as HTMLButtonElement).disabled).toBe(true)
+    expect(incompleteExport.title).toMatch(/clean take/)
+    second.unmount()
   })
 })

--- a/packages/app/src/components/SessionRecorder/SessionReplayPanel.test.tsx
+++ b/packages/app/src/components/SessionRecorder/SessionReplayPanel.test.tsx
@@ -7,7 +7,12 @@ import { deepClone } from '@/utils/clone'
 import { setFollowCamEnabled } from './recorderUi'
 import { SessionReplayPanel } from './SessionReplayPanel'
 import type { ReplayTarget } from '@/recorder/replay'
+import type { ReplayVideoExportRequest } from '@/recorder/replayInterfaceVideo'
 import type { RecordedSession } from '@/recorder/schema'
+
+vi.mock('@/recorder/replayInterfaceVideo', () => ({
+  replayInterfaceCaptureSupported: () => true,
+}))
 
 function makeSession(): RecordedSession {
   return {
@@ -147,20 +152,51 @@ describe('SessionReplayPanel accessibility', () => {
     fireEvent.change(screen.getByRole('combobox', { name: 'Playback speed' }), {
       target: { value: '2' },
     })
-    fireEvent.click(screen.getByRole('button', { name: 'Export video' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Export artwork' }))
 
     await waitFor(() => {
       expect(exportVideo).toHaveBeenCalledTimes(1)
     })
-    const [exported, playbackSpeed] = exportVideo.mock.calls[0] as [
-      RecordedSession,
-      number,
-    ]
-    expect(exported.actions[0]?.note).toBe('Reveal the first transform')
-    expect(exported.actions[0]?.holdMs).toBe(900)
-    expect(playbackSpeed).toBe(2)
+    const [request] = exportVideo.mock.calls[0] as [ReplayVideoExportRequest]
+    expect(request.mode).toBe('artwork')
+    expect(request.session.actions[0]?.note).toBe('Reveal the first transform')
+    expect(request.session.actions[0]?.holdMs).toBe(900)
+    expect(request.playbackSpeed).toBe(2)
     expect(source.actions[0]?.note).toBe('Shape the first transform')
     expect(source.actions[0]?.holdMs).toBeUndefined()
+    unmount()
+  })
+
+  it('starts full-interface capture directly from the export click', () => {
+    const exportVideo = vi.fn().mockResolvedValue(undefined)
+    const { unmount } = render(() => (
+      <SessionReplayPanel
+        session={makeSession()}
+        target={makeTarget()}
+        onExportVideo={exportVideo}
+        onClose={() => {}}
+      />
+    ))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Full interface' }))
+    expect(screen.getByText(/Choose This Tab/)).toBeTruthy()
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Record full interface' }),
+    )
+
+    // getDisplayMedia requires transient activation. The owner callback must
+    // therefore run synchronously on this same trusted click, not after an
+    // awaited validation or queued microtask.
+    expect(exportVideo).toHaveBeenCalledTimes(1)
+    const [request] = exportVideo.mock.calls[0] as [ReplayVideoExportRequest]
+    expect(request.mode).toBe('interface')
+    if (request.mode !== 'interface') {
+      throw new Error('expected a full-interface export request')
+    }
+    expect(request.playbackSpeed).toBe(1)
+    expect(request.prepareReplay).toEqual(expect.any(Function))
+    expect(request.playReplay).toEqual(expect.any(Function))
     unmount()
   })
 
@@ -176,7 +212,7 @@ describe('SessionReplayPanel accessibility', () => {
       />
     ))
 
-    const emptyExport = screen.getByRole('button', { name: 'Export video' })
+    const emptyExport = screen.getByRole('button', { name: 'Export artwork' })
     expect((emptyExport as HTMLButtonElement).disabled).toBe(true)
     expect(emptyExport.title).toMatch(/at least one authored step/)
     first.unmount()
@@ -193,7 +229,7 @@ describe('SessionReplayPanel accessibility', () => {
     ))
 
     const incompleteExport = screen.getByRole('button', {
-      name: 'Export video',
+      name: 'Export artwork',
     })
     expect((incompleteExport as HTMLButtonElement).disabled).toBe(true)
     expect(incompleteExport.title).toMatch(/clean take/)

--- a/packages/app/src/components/SessionRecorder/SessionReplayPanel.tsx
+++ b/packages/app/src/components/SessionRecorder/SessionReplayPanel.tsx
@@ -3,13 +3,15 @@ import { createStore, unwrap } from 'solid-js/store'
 import { ChevronLeft, ChevronRight, Download, Focus, Pause, Pencil, PlayPause, SkipBack, } from '@/icons'
 import { deriveReplayFocusPreparation } from '@/recorder/focusPreparation'
 import { createSessionPlayer, PLAYBACK_SPEEDS } from '@/recorder/player'
+import { replayInterfaceCaptureSupported } from '@/recorder/replayInterfaceVideo'
 import { MAX_ACTION_HOLD_MS, MAX_ACTION_NOTE_CHARS, validateSession, } from '@/recorder/schema'
 import { deepClone } from '@/utils/clone'
-import { followCamEnabled, setFollowCamEnabled } from './recorderUi'
+import { followCamEnabled, setFollowCamEnabled, setRecorderExportPending, } from './recorderUi'
 import { ReplaySpotlight } from './ReplaySpotlight'
 import styles from './SessionReplayPanel.module.css'
 import type { ReplayFocusPreparation, ReplayFocusPreparationHandler, } from '@/recorder/focusPreparation'
 import type { ReplayTarget } from '@/recorder/replay'
+import type { ReplayVideoExportMode, ReplayVideoExportRequest, } from '@/recorder/replayInterfaceVideo'
 import type { RecordedSession } from '@/recorder/schema'
 
 /**
@@ -30,12 +32,9 @@ export function SessionReplayPanel(props: {
   /** Persist the edited session (captions and holds). Absent = no editing
    *  affordance, which is what a read-only replay surface wants. */
   onSave?: (session: RecordedSession) => Promise<void>
-  /** Queue a publishable video using the currently edited captions, holds and
-   *  selected replay speed. */
-  onExportVideo?: (
-    session: RecordedSession,
-    playbackSpeed: number,
-  ) => Promise<void> | void
+  /** Export either a detached artwork composition or the live interface using
+   *  the currently edited captions, holds and selected replay speed. */
+  onExportVideo?: (request: ReplayVideoExportRequest) => Promise<void> | void
   onClose: () => void
   /** Lets the owning dock recede while timed replay is advancing. */
   onPlaybackChange?: (playing: boolean) => void
@@ -52,7 +51,26 @@ export function SessionReplayPanel(props: {
   const [editing, setEditing] = createSignal<number>()
   const [saving, setSaving] = createSignal(false)
   const [exporting, setExporting] = createSignal(false)
+  const [exportMode, setExportMode] =
+    createSignal<ReplayVideoExportMode>('artwork')
+  const [exportError, setExportError] = createSignal<string>()
   const panelId = createUniqueId()
+
+  type LiveReplayWaiter = {
+    resolve: () => void
+    reject: (error: Error) => void
+    cleanup: () => void
+  }
+  let liveReplayWaiter: LiveReplayWaiter | undefined
+
+  const settleLiveReplay = (error?: Error) => {
+    const waiter = liveReplayWaiter
+    if (!waiter) return
+    liveReplayWaiter = undefined
+    waiter.cleanup()
+    if (error) waiter.reject(error)
+    else waiter.resolve()
+  }
 
   /**
    * The session is cloned into a store so captions and holds are editable
@@ -68,6 +86,12 @@ export function SessionReplayPanel(props: {
       if (followCamEnabled()) {
         props.onPrepareAction?.(deriveReplayFocusPreparation(action))
       }
+    },
+    onFinished: () => {
+      settleLiveReplay()
+    },
+    onError: (message) => {
+      settleLiveReplay(new Error(message))
     },
   })
   const currentPreparation = createMemo(() => {
@@ -92,7 +116,9 @@ export function SessionReplayPanel(props: {
   })
   // A player left running past unmount would keep writing into the document.
   onCleanup(() => {
+    settleLiveReplay(new Error('Full-interface recording was interrupted'))
     player.stop()
+    setRecorderExportPending(false)
     props.onPlaybackChange?.(false)
     props.onCurrentPreparationChange?.(undefined)
   })
@@ -101,6 +127,57 @@ export function SessionReplayPanel(props: {
     const action = session.actions[index]
     if (!action) return ''
     return action.note ?? action.label ?? action.id
+  }
+  const interactionBlocked = () => props.blocked || exporting()
+  const interfaceCaptureAvailable = () =>
+    props.onExportVideo !== undefined && replayInterfaceCaptureSupported()
+
+  const prepareLiveReplay = () => {
+    setFollowCamEnabled(true)
+    player.stop()
+    player.seek(-1)
+    const error = player.lastError()
+    if (error) throw new Error(error)
+  }
+
+  const playLiveReplay = (signal: AbortSignal): Promise<void> => {
+    if (signal.aborted) {
+      return Promise.reject(
+        signal.reason instanceof Error
+          ? signal.reason
+          : new Error('Full-interface recording was cancelled'),
+      )
+    }
+    if (liveReplayWaiter) {
+      return Promise.reject(
+        new Error('A full-interface replay is already running'),
+      )
+    }
+
+    return new Promise<void>((resolve, reject) => {
+      const onAbort = () => {
+        player.stop()
+        settleLiveReplay(
+          signal.reason instanceof Error
+            ? signal.reason
+            : new Error('Full-interface recording was cancelled'),
+        )
+      }
+      signal.addEventListener('abort', onAbort, { once: true })
+      liveReplayWaiter = {
+        resolve,
+        reject,
+        cleanup: () => {
+          signal.removeEventListener('abort', onAbort)
+        },
+      }
+      player.play()
+      if (!player.isPlaying()) {
+        settleLiveReplay(
+          new Error(player.lastError() ?? 'The replay could not start'),
+        )
+      }
+    })
   }
   const replayStatus = createMemo(() => {
     const index = player.stepIndex()
@@ -170,7 +247,7 @@ export function SessionReplayPanel(props: {
           onClick={() => {
             player.seek(-1)
           }}
-          disabled={props.blocked}
+          disabled={interactionBlocked()}
           title="Back to the starting flame"
           aria-label="Back to the starting flame"
         >
@@ -183,7 +260,7 @@ export function SessionReplayPanel(props: {
           onClick={() => {
             player.seek(player.stepIndex() - 1)
           }}
-          disabled={props.blocked || player.stepIndex() < 0}
+          disabled={interactionBlocked() || player.stepIndex() < 0}
           title="Previous step"
           aria-label="Previous step"
         >
@@ -199,7 +276,7 @@ export function SessionReplayPanel(props: {
               onClick={() => {
                 player.play()
               }}
-              disabled={props.blocked || player.total === 0}
+              disabled={interactionBlocked() || player.total === 0}
               title="Play replay"
             >
               <PlayPause class={styles.buttonIcon} aria-hidden="true" />
@@ -214,6 +291,7 @@ export function SessionReplayPanel(props: {
             onClick={() => {
               player.pause()
             }}
+            disabled={exporting()}
             title="Pause replay"
           >
             <Pause class={styles.buttonIcon} aria-hidden="true" />
@@ -227,7 +305,9 @@ export function SessionReplayPanel(props: {
           onClick={() => {
             player.seek(player.stepIndex() + 1)
           }}
-          disabled={props.blocked || player.stepIndex() >= player.total - 1}
+          disabled={
+            interactionBlocked() || player.stepIndex() >= player.total - 1
+          }
           title="Next step"
           aria-label="Next step"
         >
@@ -261,6 +341,7 @@ export function SessionReplayPanel(props: {
               ? 'Disable replay follow-cam'
               : 'Enable replay follow-cam'
           }
+          disabled={exporting()}
         >
           <Focus class={styles.buttonIcon} aria-hidden="true" />
         </button>
@@ -272,6 +353,7 @@ export function SessionReplayPanel(props: {
             id={`${panelId}-playback-speed`}
             class={styles.speed}
             value={speed()}
+            disabled={exporting()}
             onChange={(ev) => {
               setSpeed(Number(ev.currentTarget.value))
             }}
@@ -315,7 +397,7 @@ export function SessionReplayPanel(props: {
                       onClick={() => {
                         player.seek(index())
                       }}
-                      disabled={props.blocked}
+                      disabled={interactionBlocked()}
                       aria-current={
                         player.stepIndex() === index() ? 'step' : undefined
                       }
@@ -344,6 +426,7 @@ export function SessionReplayPanel(props: {
                       }
                       aria-expanded={editing() === index()}
                       aria-controls={editorId}
+                      disabled={exporting()}
                     >
                       <Pencil class={styles.stepEditIcon} aria-hidden="true" />
                     </button>
@@ -421,47 +504,160 @@ export function SessionReplayPanel(props: {
           <div class={styles.footerActions}>
             <Show when={props.onExportVideo}>
               {(exportVideo) => (
-                <button
-                  type="button"
-                  class={styles.button}
-                  disabled={
-                    saving() ||
-                    exporting() ||
-                    session.unnamedWriteCount > 0 ||
-                    player.total === 0
-                  }
-                  aria-busy={exporting()}
-                  onClick={() => {
-                    const validated = validateSession(
-                      deepClone(unwrap(session)),
-                    )
-                    if (validated === undefined || saving() || exporting()) {
-                      return
+                <div class={styles.videoExport}>
+                  <div
+                    class={styles.videoModes}
+                    role="group"
+                    aria-label="Video export mode"
+                  >
+                    <button
+                      type="button"
+                      class={styles.videoMode}
+                      classList={{
+                        [styles.videoModeActive as string]:
+                          exportMode() === 'artwork',
+                      }}
+                      aria-pressed={exportMode() === 'artwork'}
+                      disabled={exporting()}
+                      onClick={() => {
+                        setExportMode('artwork')
+                        setExportError(undefined)
+                      }}
+                    >
+                      Artwork
+                    </button>
+                    <button
+                      type="button"
+                      class={styles.videoMode}
+                      classList={{
+                        [styles.videoModeActive as string]:
+                          exportMode() === 'interface',
+                      }}
+                      aria-pressed={exportMode() === 'interface'}
+                      disabled={exporting() || !interfaceCaptureAvailable()}
+                      title={
+                        interfaceCaptureAvailable()
+                          ? 'Record the actual app, spotlight and flame in real time'
+                          : 'Full-interface capture is unavailable in this browser'
+                      }
+                      onClick={() => {
+                        setExportMode('interface')
+                        setExportError(undefined)
+                      }}
+                    >
+                      Full interface
+                    </button>
+                  </div>
+                  <p id={`${panelId}-video-mode-help`} class={styles.videoHelp}>
+                    {exportMode() === 'artwork'
+                      ? 'Square branded MP4 · flame and captions · renders in the background.'
+                      : 'Live capture · actual panels, timeline and spotlight. Choose This Tab when asked and keep it visible.'}
+                  </p>
+                  <button
+                    type="button"
+                    class={styles.button}
+                    disabled={
+                      saving() ||
+                      exporting() ||
+                      session.unnamedWriteCount > 0 ||
+                      player.total === 0
                     }
+                    aria-busy={exporting()}
+                    aria-describedby={`${panelId}-video-mode-help`}
+                    onClick={() => {
+                      const validated = validateSession(
+                        deepClone(unwrap(session)),
+                      )
+                      if (validated === undefined || saving() || exporting()) {
+                        return
+                      }
 
-                    setExporting(true)
-                    void Promise.resolve()
-                      .then(() => exportVideo()(validated, speed()))
-                      .catch(() => {
-                        // The workspace owns the queue and reports the error.
-                      })
-                      .finally(() => {
+                      const mode = exportMode()
+                      const previousFollowCam = followCamEnabled()
+                      const request: ReplayVideoExportRequest =
+                        mode === 'interface'
+                          ? {
+                              mode,
+                              session: validated,
+                              playbackSpeed: speed(),
+                              prepareReplay: prepareLiveReplay,
+                              playReplay: playLiveReplay,
+                            }
+                          : {
+                              mode,
+                              session: validated,
+                              playbackSpeed: speed(),
+                            }
+
+                      setExportError(undefined)
+                      setExporting(true)
+                      setRecorderExportPending(true)
+                      try {
+                        // Invoke directly from the click. Full-interface mode
+                        // must reach getDisplayMedia while transient user
+                        // activation is still available.
+                        const result = exportVideo()(request)
+                        void Promise.resolve(result)
+                          .catch((error: unknown) => {
+                            setExportError(
+                              error instanceof Error
+                                ? error.message
+                                : 'Could not export the replay video',
+                            )
+                          })
+                          .finally(() => {
+                            if (mode === 'interface') {
+                              setFollowCamEnabled(previousFollowCam)
+                            }
+                            setRecorderExportPending(false)
+                            setExporting(false)
+                          })
+                      } catch (error: unknown) {
+                        if (mode === 'interface') {
+                          setFollowCamEnabled(previousFollowCam)
+                        }
+                        setExportError(
+                          error instanceof Error
+                            ? error.message
+                            : 'Could not export the replay video',
+                        )
+                        setRecorderExportPending(false)
                         setExporting(false)
-                      })
-                  }}
-                  title={
-                    session.unnamedWriteCount > 0
-                      ? 'Record a clean take before publishing a replay video'
-                      : player.total === 0
-                        ? 'Record at least one authored step before publishing a replay video'
-                        : exporting()
-                          ? 'Adding replay video to Exports'
-                          : 'Render a square, captioned creation replay as MP4'
-                  }
-                >
-                  <Download class={styles.buttonIcon} aria-hidden="true" />
-                  <span>{exporting() ? 'Queuing video…' : 'Export video'}</span>
-                </button>
+                      }
+                    }}
+                    title={
+                      session.unnamedWriteCount > 0
+                        ? 'Record a clean take before publishing a replay video'
+                        : player.total === 0
+                          ? 'Record at least one authored step before publishing a replay video'
+                          : exporting()
+                            ? exportMode() === 'interface'
+                              ? 'Recording the visible interface in real time'
+                              : 'Adding artwork video to Exports'
+                            : exportMode() === 'interface'
+                              ? 'Share this tab, replay the take and download the visible interface'
+                              : 'Render a square, captioned artwork replay as MP4'
+                    }
+                  >
+                    <Download class={styles.buttonIcon} aria-hidden="true" />
+                    <span>
+                      {exporting()
+                        ? exportMode() === 'interface'
+                          ? 'Recording interface…'
+                          : 'Queuing artwork…'
+                        : exportMode() === 'interface'
+                          ? 'Record full interface'
+                          : 'Export artwork'}
+                    </span>
+                  </button>
+                  <Show when={exportError()}>
+                    {(message) => (
+                      <div class={styles.exportError} role="alert">
+                        {message()}
+                      </div>
+                    )}
+                  </Show>
+                </div>
               )}
             </Show>
             <Show when={props.onSave}>

--- a/packages/app/src/components/SessionRecorder/SessionReplayPanel.tsx
+++ b/packages/app/src/components/SessionRecorder/SessionReplayPanel.tsx
@@ -1,6 +1,6 @@
 import { createEffect, createMemo, createSignal, createUniqueId, For, onCleanup, Show, untrack, } from 'solid-js'
 import { createStore, unwrap } from 'solid-js/store'
-import { ChevronLeft, ChevronRight, Focus, Pause, Pencil, PlayPause, SkipBack, } from '@/icons'
+import { ChevronLeft, ChevronRight, Download, Focus, Pause, Pencil, PlayPause, SkipBack, } from '@/icons'
 import { deriveReplayFocusPreparation } from '@/recorder/focusPreparation'
 import { createSessionPlayer, PLAYBACK_SPEEDS } from '@/recorder/player'
 import { MAX_ACTION_HOLD_MS, MAX_ACTION_NOTE_CHARS, validateSession, } from '@/recorder/schema'
@@ -30,6 +30,12 @@ export function SessionReplayPanel(props: {
   /** Persist the edited session (captions and holds). Absent = no editing
    *  affordance, which is what a read-only replay surface wants. */
   onSave?: (session: RecordedSession) => Promise<void>
+  /** Queue a publishable video using the currently edited captions, holds and
+   *  selected replay speed. */
+  onExportVideo?: (
+    session: RecordedSession,
+    playbackSpeed: number,
+  ) => Promise<void> | void
   onClose: () => void
   /** Lets the owning dock recede while timed replay is advancing. */
   onPlaybackChange?: (playing: boolean) => void
@@ -45,6 +51,7 @@ export function SessionReplayPanel(props: {
   const [speed, setSpeed] = createSignal(1)
   const [editing, setEditing] = createSignal<number>()
   const [saving, setSaving] = createSignal(false)
+  const [exporting, setExporting] = createSignal(false)
   const panelId = createUniqueId()
 
   /**
@@ -139,15 +146,15 @@ export function SessionReplayPanel(props: {
           data-recorder-replay-close
           type="button"
           class={styles.close}
-          disabled={saving()}
+          disabled={saving() || exporting()}
           onClick={() => {
             // Commit wherever we are, then hand the document back.
             player.stop()
             props.onClose()
           }}
           title={
-            saving()
-              ? 'Wait for the caption save to finish before closing'
+            saving() || exporting()
+              ? 'Wait for the recorder task to finish before closing'
               : 'Stop replaying and keep this step as the current flame'
           }
         >
@@ -410,39 +417,92 @@ export function SessionReplayPanel(props: {
             }}
           </For>
         </ol>
-        <Show when={props.onSave}>
-          {(save) => (
-            <button
-              type="button"
-              class={styles.button}
-              disabled={saving()}
-              aria-busy={saving()}
-              onClick={() => {
-                // The controls above constrain authored fields, and this
-                // store-boundary check makes the guarantee explicit even if a
-                // future editor adds another field without matching limits.
-                const validated = validateSession(deepClone(unwrap(session)))
-                if (validated === undefined || saving()) return
+        <Show when={props.onSave || props.onExportVideo}>
+          <div class={styles.footerActions}>
+            <Show when={props.onExportVideo}>
+              {(exportVideo) => (
+                <button
+                  type="button"
+                  class={styles.button}
+                  disabled={
+                    saving() ||
+                    exporting() ||
+                    session.unnamedWriteCount > 0 ||
+                    player.total === 0
+                  }
+                  aria-busy={exporting()}
+                  onClick={() => {
+                    const validated = validateSession(
+                      deepClone(unwrap(session)),
+                    )
+                    if (validated === undefined || saving() || exporting()) {
+                      return
+                    }
 
-                setSaving(true)
-                void save()(validated)
-                  .catch(() => {
-                    // The owner reports the storage error. Keeping the panel
-                    // mounted and editable is the recovery path here.
-                  })
-                  .finally(() => {
-                    setSaving(false)
-                  })
-              }}
-              title={
-                saving()
-                  ? 'Saving captions locally'
-                  : 'Save the captions and holds as a new recording'
-              }
-            >
-              {saving() ? 'Saving captions…' : 'Save captions'}
-            </button>
-          )}
+                    setExporting(true)
+                    void Promise.resolve()
+                      .then(() => exportVideo()(validated, speed()))
+                      .catch(() => {
+                        // The workspace owns the queue and reports the error.
+                      })
+                      .finally(() => {
+                        setExporting(false)
+                      })
+                  }}
+                  title={
+                    session.unnamedWriteCount > 0
+                      ? 'Record a clean take before publishing a replay video'
+                      : player.total === 0
+                        ? 'Record at least one authored step before publishing a replay video'
+                        : exporting()
+                          ? 'Adding replay video to Exports'
+                          : 'Render a square, captioned creation replay as MP4'
+                  }
+                >
+                  <Download class={styles.buttonIcon} aria-hidden="true" />
+                  <span>{exporting() ? 'Queuing video…' : 'Export video'}</span>
+                </button>
+              )}
+            </Show>
+            <Show when={props.onSave}>
+              {(save) => (
+                <button
+                  type="button"
+                  class={styles.button}
+                  disabled={saving() || exporting()}
+                  aria-busy={saving()}
+                  onClick={() => {
+                    // The controls above constrain authored fields, and this
+                    // store-boundary check makes the guarantee explicit even
+                    // if a future editor adds a field without matching limits.
+                    const validated = validateSession(
+                      deepClone(unwrap(session)),
+                    )
+                    if (validated === undefined || saving() || exporting()) {
+                      return
+                    }
+
+                    setSaving(true)
+                    void save()(validated)
+                      .catch(() => {
+                        // The owner reports the storage error. Keeping the
+                        // panel mounted and editable is the recovery path.
+                      })
+                      .finally(() => {
+                        setSaving(false)
+                      })
+                  }}
+                  title={
+                    saving()
+                      ? 'Saving captions locally'
+                      : 'Save the captions and holds as a new recording'
+                  }
+                >
+                  {saving() ? 'Saving captions…' : 'Save captions'}
+                </button>
+              )}
+            </Show>
+          </div>
         </Show>
       </Show>
     </div>

--- a/packages/app/src/components/SessionRecorder/SessionReplayPanel.tsx
+++ b/packages/app/src/components/SessionRecorder/SessionReplayPanel.tsx
@@ -550,7 +550,7 @@ export function SessionReplayPanel(props: {
                   </div>
                   <p id={`${panelId}-video-mode-help`} class={styles.videoHelp}>
                     {exportMode() === 'artwork'
-                      ? 'Square branded MP4 · flame and captions · renders in the background.'
+                      ? 'Widescreen 1080p MP4 · full flame and captions · renders in the background.'
                       : 'Live capture · actual panels, timeline and spotlight. Choose This Tab when asked and keep it visible.'}
                   </p>
                   <button
@@ -636,7 +636,7 @@ export function SessionReplayPanel(props: {
                               : 'Adding artwork video to Exports'
                             : exportMode() === 'interface'
                               ? 'Share this tab, replay the take and download the visible interface'
-                              : 'Render a square, captioned artwork replay as MP4'
+                              : 'Render a widescreen, captioned artwork replay as MP4'
                     }
                   >
                     <Download class={styles.buttonIcon} aria-hidden="true" />

--- a/packages/app/src/components/SessionRecorder/recorderUi.test.ts
+++ b/packages/app/src/components/SessionRecorder/recorderUi.test.ts
@@ -1,17 +1,19 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { examples } from '@/flame/examples'
 import { cancelSessionRecording, startSessionRecording, } from '@/recorder/recorder'
-import { recorderSavePending, recorderVisible, setRecorderSavePending, setRecorderVisible, } from './recorderUi'
+import { recorderExportPending, recorderSavePending, recorderVisible, setRecorderExportPending, setRecorderSavePending, setRecorderVisible, } from './recorderUi'
 
 describe('recorder visibility guard', () => {
   beforeEach(() => {
     cancelSessionRecording()
+    setRecorderExportPending(false)
     setRecorderSavePending(false)
     setRecorderVisible(true)
   })
 
   afterEach(() => {
     cancelSessionRecording()
+    setRecorderExportPending(false)
     setRecorderSavePending(false)
     setRecorderVisible(true)
   })
@@ -35,6 +37,18 @@ describe('recorder visibility guard', () => {
     expect(recorderVisible()).toBe(true)
 
     setRecorderSavePending(false)
+    setRecorderVisible(false)
+    expect(recorderVisible()).toBe(false)
+  })
+
+  it('keeps the recorder visible until a live interface export settles', () => {
+    setRecorderExportPending(true)
+    expect(recorderExportPending()).toBe(true)
+
+    setRecorderVisible(false)
+    expect(recorderVisible()).toBe(true)
+
+    setRecorderExportPending(false)
     setRecorderVisible(false)
     expect(recorderVisible()).toBe(false)
   })

--- a/packages/app/src/components/SessionRecorder/recorderUi.ts
+++ b/packages/app/src/components/SessionRecorder/recorderUi.ts
@@ -16,6 +16,14 @@ import { persistentSignal } from '@/utils/persistentSignal'
  * shared because both the dock and the floating toolbar can hide the panel. */
 export const [recorderSavePending, setRecorderSavePending] = createSignal(false)
 
+/** A full-interface replay export records the mounted editor in real time, so
+ * the recorder and active replay must remain mounted until capture settles. */
+export const [recorderExportPending, setRecorderExportPending] =
+  createSignal(false)
+
+export const recorderTaskPending = () =>
+  recorderSavePending() || recorderExportPending()
+
 /** Whether the dock is mounted at all. The toolbar's recorder toggle. */
 const [recorderVisibleValue, setRecorderVisibleValue] = persistentSignal(
   'recorder/visible',
@@ -30,7 +38,7 @@ export const recorderVisible = recorderVisibleValue
  * than only on the dock's close button.
  */
 export function setRecorderVisible(visible: boolean): void {
-  if (!visible && (isSessionRecording() || recorderSavePending())) return
+  if (!visible && (isSessionRecording() || recorderTaskPending())) return
   setRecorderVisibleValue(visible)
 }
 

--- a/packages/app/src/recorder/replayInterfaceVideo.test.ts
+++ b/packages/app/src/recorder/replayInterfaceVideo.test.ts
@@ -1,0 +1,201 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { examples } from '@/flame/examples'
+import { deepClone } from '@/utils/clone'
+import { captureReplayInterfaceVideo, fitReplayInterfaceVideoDimensions, } from './replayInterfaceVideo'
+import { SESSION_FORMAT_VERSION } from './schema'
+import type { ReplayInterfaceCaptureRuntime } from './replayInterfaceVideo'
+import type { RecordedSession } from './schema'
+
+function makeSession(): RecordedSession {
+  return {
+    version: SESSION_FORMAT_VERSION,
+    app: { version: 'test', flameSchemaVersion: '1.0' },
+    createdAt: new Date(0).toISOString(),
+    initial: deepClone(examples.example1),
+    actions: [
+      {
+        t: 100,
+        id: 'flame.setGamma',
+        args: [2.4],
+        label: 'Set gamma',
+      },
+    ],
+    unnamedWriteCount: 0,
+  }
+}
+
+function makeRuntime() {
+  const endedListeners = new Set<() => void>()
+  const bitmapClose = vi.fn()
+  const stop = vi.fn()
+  const drawFrame = vi.fn()
+  const encodeFrame = vi.fn((bitmap: ImageBitmap) => {
+    bitmap.close()
+    return Promise.resolve()
+  })
+  const finalize = vi.fn(() =>
+    Promise.resolve({
+      blob: new Blob(['captured'], { type: 'video/webm' }),
+      mimeType: 'video/webm',
+      usedFallback: true,
+    }),
+  )
+  const cancel = vi.fn()
+  const createEncoder = vi.fn(() =>
+    Promise.resolve({
+      usedFallback: true,
+      encodeFrame,
+      finalize,
+      cancel,
+    }),
+  )
+  const runtime: ReplayInterfaceCaptureRuntime = {
+    openCapture: vi.fn(() =>
+      Promise.resolve({
+        width: 2560,
+        height: 1440,
+        drawFrame,
+        onEnded: (listener: () => void) => {
+          endedListeners.add(listener)
+          return () => {
+            endedListeners.delete(listener)
+          }
+        },
+        stop,
+      }),
+    ),
+    createEncoder,
+    createSurface: () => ({
+      canvas: {} as HTMLCanvasElement,
+      context: {} as CanvasRenderingContext2D,
+    }),
+    createBitmap: vi.fn(() =>
+      Promise.resolve({ close: bitmapClose } as unknown as ImageBitmap),
+    ),
+    now: () => Date.now(),
+  }
+  return {
+    runtime,
+    endedListeners,
+    stop,
+    drawFrame,
+    createEncoder,
+    encodeFrame,
+    finalize,
+    cancel,
+    bitmapClose,
+  }
+}
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('full-interface replay video capture', () => {
+  it('preserves viewport aspect ratio inside the bounded encoder budget', () => {
+    expect(fitReplayInterfaceVideoDimensions(3840, 2160)).toEqual({
+      width: 1920,
+      height: 1080,
+    })
+    expect(fitReplayInterfaceVideoDimensions(1440, 2560)).toEqual({
+      width: 1080,
+      height: 1920,
+    })
+    expect(fitReplayInterfaceVideoDimensions(1201, 801)).toEqual({
+      width: 1200,
+      height: 800,
+    })
+    expect(() => fitReplayInterfaceVideoDimensions(0, 1080)).toThrow(
+      /invalid dimensions/,
+    )
+  })
+
+  it('captures the ordinary replay after the source is active and cleans up', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(0)
+    const capture = makeRuntime()
+    const order: string[] = []
+
+    const resultPromise = captureReplayInterfaceVideo(
+      {
+        mode: 'interface',
+        session: makeSession(),
+        playbackSpeed: 1,
+        prepareReplay: () => {
+          order.push('prepare')
+        },
+        playReplay: () => {
+          order.push('play')
+          return Promise.resolve()
+        },
+      },
+      capture.runtime,
+    )
+
+    await vi.advanceTimersByTimeAsync(2_500)
+    const result = await resultPromise
+
+    expect(order).toEqual(['prepare', 'play'])
+    expect(capture.runtime.openCapture).toHaveBeenCalledTimes(1)
+    expect(capture.createEncoder).toHaveBeenCalledWith({
+      codec: 'avc',
+      width: 1920,
+      height: 1080,
+      fps: 24,
+    })
+    expect(capture.drawFrame).toHaveBeenCalled()
+    expect(capture.encodeFrame).toHaveBeenCalled()
+    expect(capture.bitmapClose).toHaveBeenCalled()
+    expect(capture.finalize).toHaveBeenCalledTimes(1)
+    expect(capture.cancel).not.toHaveBeenCalled()
+    expect(capture.stop).toHaveBeenCalledTimes(1)
+    expect(result).toMatchObject({
+      mimeType: 'video/webm',
+      extension: 'webm',
+      width: 1920,
+      height: 1080,
+      embeddedSession: false,
+    })
+    expect(result.frames).toBeGreaterThan(0)
+  })
+
+  it('aborts safely when tab sharing stops before replay completion', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(0)
+    const capture = makeRuntime()
+
+    const resultPromise = captureReplayInterfaceVideo(
+      {
+        mode: 'interface',
+        session: makeSession(),
+        playbackSpeed: 1,
+        prepareReplay: () => {},
+        playReplay: (signal) =>
+          new Promise<void>((_resolve, reject) => {
+            signal.addEventListener(
+              'abort',
+              () => {
+                reject(
+                  signal.reason instanceof Error
+                    ? signal.reason
+                    : new Error('capture aborted'),
+                )
+              },
+              { once: true },
+            )
+          }),
+      },
+      capture.runtime,
+    )
+
+    await vi.advanceTimersByTimeAsync(1)
+    expect(capture.endedListeners.size).toBe(1)
+    for (const listener of capture.endedListeners) listener()
+
+    await expect(resultPromise).rejects.toThrow(
+      'Screen sharing stopped before the replay finished',
+    )
+    expect(capture.cancel).toHaveBeenCalledTimes(1)
+    expect(capture.stop).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/app/src/recorder/replayInterfaceVideo.ts
+++ b/packages/app/src/recorder/replayInterfaceVideo.ts
@@ -1,0 +1,435 @@
+import { deepClone } from '@/utils/clone'
+import { createMetadataPayload, injectMetadataIntoMp4, } from '@/utils/flameInMp4'
+import { createVideoEncoder } from '@/utils/videoEncoder'
+import { createReplayVideoSchedule, MAX_REPLAY_VIDEO_DURATION_MS, REPLAY_VIDEO_FPS, REPLAY_VIDEO_LEAD_IN_MS, REPLAY_VIDEO_TAIL_MS, replayVideoInitialTimelineSnapshot, } from './replayVideo'
+import { validateSession } from './schema'
+import type { RecordedSession } from './schema'
+import type { VideoEncoderConfig } from '@/utils/videoEncoder'
+
+/** Full-interface capture keeps the viewport aspect ratio, but caps the long
+ * edge and pixel count so a 4K/5K monitor cannot create an unbounded encoder
+ * workload. Portrait and landscape views receive the same pixel budget. */
+export const MAX_REPLAY_INTERFACE_LONG_EDGE = 1920
+export const MAX_REPLAY_INTERFACE_PIXELS = 1920 * 1080
+
+const MAX_CAPTURE_OVERRUN_MS = 5_000
+
+export type ReplayVideoExportMode = 'artwork' | 'interface'
+
+export type ReplayVideoExportRequest =
+  | {
+      mode: 'artwork'
+      session: RecordedSession
+      playbackSpeed: number
+    }
+  | {
+      mode: 'interface'
+      session: RecordedSession
+      playbackSpeed: number
+      /** Reset the real workspace/player to the recorded baseline after tab
+       * capture is active, so the reset itself is not mistaken for a step. */
+      prepareReplay: () => void
+      /** Run the ordinary replay player. The capture path observes exactly the
+       * DOM, spotlight, captions and flame the viewer sees. */
+      playReplay: (signal: AbortSignal) => Promise<void>
+    }
+
+export type ReplayInterfaceVideoResult = {
+  blob: Blob
+  mimeType: string
+  extension: 'mp4' | 'webm'
+  width: number
+  height: number
+  frames: number
+  embeddedSession: boolean
+}
+
+type DisplayCaptureSource = {
+  width: number
+  height: number
+  drawFrame: (
+    context: CanvasRenderingContext2D,
+    width: number,
+    height: number,
+  ) => void
+  onEnded: (listener: () => void) => () => void
+  stop: () => void
+}
+
+type CaptureEncoder = {
+  usedFallback: boolean
+  encodeFrame: (bitmap: ImageBitmap, frameIndex: number) => Promise<void>
+  finalize: () => Promise<{
+    blob: Blob
+    mimeType: string
+    usedFallback: boolean
+  }>
+  cancel: () => void
+}
+
+type CaptureSurface = {
+  canvas: HTMLCanvasElement
+  context: CanvasRenderingContext2D
+}
+
+/** Injectable only so the permission/real-time orchestration can be covered
+ * without opening a browser picker in unit tests. Production uses the default
+ * browser runtime below. */
+export type ReplayInterfaceCaptureRuntime = {
+  openCapture: (fps: number) => Promise<DisplayCaptureSource>
+  createEncoder: (config: VideoEncoderConfig) => Promise<CaptureEncoder>
+  createSurface: (width: number, height: number) => CaptureSurface
+  createBitmap: (canvas: HTMLCanvasElement) => Promise<ImageBitmap>
+  now: () => number
+}
+
+type DisplayMediaOptionsWithHints = DisplayMediaStreamOptions & {
+  preferCurrentTab?: boolean
+  selfBrowserSurface?: 'include' | 'exclude'
+  surfaceSwitching?: 'include' | 'exclude'
+}
+
+function captureError(error: unknown): Error {
+  if (error instanceof DOMException) {
+    if (error.name === 'NotAllowedError') {
+      return new Error(
+        'Full-interface recording was cancelled or screen sharing was denied',
+      )
+    }
+    if (error.name === 'InvalidStateError') {
+      return new Error(
+        'Start full-interface recording directly from the Export button',
+      )
+    }
+  }
+  return error instanceof Error
+    ? error
+    : new Error('Could not capture the interface')
+}
+
+function abortReason(signal: AbortSignal): Error {
+  return signal.reason instanceof Error
+    ? signal.reason
+    : new Error('Full-interface recording was cancelled')
+}
+
+function waitFor(ms: number, signal: AbortSignal): Promise<void> {
+  if (signal.aborted) return Promise.reject(abortReason(signal))
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(
+      () => {
+        signal.removeEventListener('abort', onAbort)
+        resolve()
+      },
+      Math.max(0, ms),
+    )
+    const onAbort = () => {
+      clearTimeout(timer)
+      reject(abortReason(signal))
+    }
+    signal.addEventListener('abort', onAbort, { once: true })
+  })
+}
+
+async function waitForVideo(video: HTMLVideoElement): Promise<void> {
+  if (video.videoWidth > 0 && video.videoHeight > 0) return
+  await new Promise<void>((resolve, reject) => {
+    const cleanup = () => {
+      video.removeEventListener('loadedmetadata', onReady)
+      video.removeEventListener('error', onError)
+    }
+    const onReady = () => {
+      cleanup()
+      resolve()
+    }
+    const onError = () => {
+      cleanup()
+      reject(new Error('The shared tab did not provide a video frame'))
+    }
+    video.addEventListener('loadedmetadata', onReady, { once: true })
+    video.addEventListener('error', onError, { once: true })
+  })
+}
+
+async function openBrowserCapture(fps: number): Promise<DisplayCaptureSource> {
+  if (!globalThis.isSecureContext) {
+    throw new Error('Full-interface recording requires a secure HTTPS page')
+  }
+  const mediaDevices = globalThis.navigator?.mediaDevices
+  if (!mediaDevices?.getDisplayMedia) {
+    throw new Error(
+      'This browser does not support recording the full interface',
+    )
+  }
+
+  let stream: MediaStream
+  try {
+    // These are hints only: browsers must let the person choose the source.
+    // The UI therefore explicitly asks for "This Tab" as well.
+    stream = await mediaDevices.getDisplayMedia({
+      video: {
+        frameRate: { ideal: fps, max: 30 },
+        displaySurface: 'browser',
+      },
+      audio: false,
+      preferCurrentTab: true,
+      selfBrowserSurface: 'include',
+      surfaceSwitching: 'exclude',
+    } as DisplayMediaOptionsWithHints)
+  } catch (error) {
+    throw captureError(error)
+  }
+
+  const track = stream.getVideoTracks()[0]
+  if (!track) {
+    stream.getTracks().forEach((item) => {
+      item.stop()
+    })
+    throw new Error('The selected share source did not provide video')
+  }
+  if (track.getSettings().displaySurface === 'monitor') {
+    stream.getTracks().forEach((item) => {
+      item.stop()
+    })
+    throw new Error(
+      'Choose This Tab or the browser window, not the entire screen',
+    )
+  }
+
+  const video = document.createElement('video')
+  video.autoplay = true
+  video.muted = true
+  video.playsInline = true
+  video.srcObject = stream
+  let rejectStoppedBeforeReady: ((reason: Error) => void) | undefined
+  const stoppedBeforeReady = new Promise<never>((_resolve, reject) => {
+    rejectStoppedBeforeReady = reject
+  })
+  const onStoppedBeforeReady = () => {
+    rejectStoppedBeforeReady?.(
+      new Error('Screen sharing stopped before capture started'),
+    )
+  }
+  track.addEventListener('ended', onStoppedBeforeReady, { once: true })
+  try {
+    await Promise.race([waitForVideo(video), stoppedBeforeReady])
+    await video.play()
+  } catch (error) {
+    stream.getTracks().forEach((item) => {
+      item.stop()
+    })
+    video.srcObject = null
+    throw captureError(error)
+  } finally {
+    track.removeEventListener('ended', onStoppedBeforeReady)
+  }
+
+  return {
+    width: video.videoWidth,
+    height: video.videoHeight,
+    drawFrame: (context, width, height) => {
+      context.drawImage(video, 0, 0, width, height)
+    },
+    onEnded: (listener) => {
+      track.addEventListener('ended', listener)
+      return () => {
+        track.removeEventListener('ended', listener)
+      }
+    },
+    stop: () => {
+      video.pause()
+      video.srcObject = null
+      stream.getTracks().forEach((item) => {
+        item.stop()
+      })
+    },
+  }
+}
+
+function browserRuntime(): ReplayInterfaceCaptureRuntime {
+  return {
+    openCapture: openBrowserCapture,
+    createEncoder: createVideoEncoder,
+    createSurface: (width, height) => {
+      const canvas = document.createElement('canvas')
+      canvas.width = width
+      canvas.height = height
+      const context = canvas.getContext('2d', { alpha: false })
+      if (!context) {
+        throw new Error('Could not create the interface capture surface')
+      }
+      return { canvas, context }
+    },
+    createBitmap: (canvas) => globalThis.createImageBitmap(canvas),
+    now: () => globalThis.performance.now(),
+  }
+}
+
+export function replayInterfaceCaptureSupported(): boolean {
+  return (
+    globalThis.isSecureContext &&
+    typeof globalThis.navigator?.mediaDevices?.getDisplayMedia === 'function' &&
+    ((typeof globalThis.VideoEncoder !== 'undefined' &&
+      typeof globalThis.VideoFrame !== 'undefined') ||
+      typeof globalThis.MediaRecorder !== 'undefined')
+  )
+}
+
+export function fitReplayInterfaceVideoDimensions(
+  sourceWidth: number,
+  sourceHeight: number,
+  maxLongEdge = MAX_REPLAY_INTERFACE_LONG_EDGE,
+  maxPixels = MAX_REPLAY_INTERFACE_PIXELS,
+): { width: number; height: number } {
+  if (
+    !Number.isFinite(sourceWidth) ||
+    !Number.isFinite(sourceHeight) ||
+    sourceWidth <= 0 ||
+    sourceHeight <= 0
+  ) {
+    throw new Error('The shared tab reported invalid dimensions')
+  }
+  const longEdgeScale = maxLongEdge / Math.max(sourceWidth, sourceHeight)
+  const pixelScale = Math.sqrt(maxPixels / (sourceWidth * sourceHeight))
+  const scale = Math.min(1, longEdgeScale, pixelScale)
+  return {
+    width: Math.max(2, Math.floor((sourceWidth * scale) / 2) * 2),
+    height: Math.max(2, Math.floor((sourceHeight * scale) / 2) * 2),
+  }
+}
+
+/**
+ * Record the actual visible app in real time. Unlike the deterministic artwork
+ * renderer, this intentionally uses the browser's screen-capture permission:
+ * standard web APIs cannot serialize arbitrary DOM/CSS/WebGPU pixels into an
+ * offscreen canvas. Capturing the current tab is what preserves the real
+ * sidebar, timeline, spotlight, captions and accumulated flame exactly.
+ */
+export async function captureReplayInterfaceVideo(
+  request: Extract<ReplayVideoExportRequest, { mode: 'interface' }>,
+  runtime: ReplayInterfaceCaptureRuntime = browserRuntime(),
+): Promise<ReplayInterfaceVideoResult> {
+  const session = validateSession(deepClone(request.session))
+  if (!session) throw new Error('The recording is not a valid replay session')
+  if (session.unnamedWriteCount > 0) {
+    throw new Error(
+      `This take has ${session.unnamedWriteCount} uncaptured edit${session.unnamedWriteCount === 1 ? '' : 's'}. Record a clean take before publishing it as video.`,
+    )
+  }
+  if (session.actions.length === 0) {
+    throw new Error('This take has no authored steps to publish as video.')
+  }
+  // Validates speed, authored holds and the two-minute resource budget before
+  // showing a privacy-sensitive capture chooser.
+  createReplayVideoSchedule(session, request.playbackSpeed)
+
+  // This call must remain on the direct Export-button stack. getDisplayMedia
+  // requires transient user activation and must prompt on every recording.
+  const source = await runtime.openCapture(REPLAY_VIDEO_FPS)
+  const { width, height } = fitReplayInterfaceVideoDimensions(
+    source.width,
+    source.height,
+  )
+  const surface = runtime.createSurface(width, height)
+  let encoder: CaptureEncoder | undefined
+  let captureOpen = true
+  let completed = false
+  let frameIndex = 0
+  let samplingError: Error | undefined
+  let sampling: Promise<void> | undefined
+  const controller = new AbortController()
+  const abort = (error: Error) => {
+    if (!controller.signal.aborted) controller.abort(error)
+  }
+  const unsubscribeEnded = source.onEnded(() => {
+    if (!completed) {
+      abort(new Error('Screen sharing stopped before the replay finished'))
+    }
+  })
+  const timeout = setTimeout(() => {
+    abort(new Error('Full-interface recording exceeded the two-minute limit'))
+  }, MAX_REPLAY_VIDEO_DURATION_MS + MAX_CAPTURE_OVERRUN_MS)
+
+  try {
+    encoder = await runtime.createEncoder({
+      codec: 'avc',
+      width,
+      height,
+      fps: REPLAY_VIDEO_FPS,
+    })
+    const intervalMs = 1000 / REPLAY_VIDEO_FPS
+    const captureStartedAt = runtime.now()
+    sampling = (async () => {
+      try {
+        while (captureOpen && !controller.signal.aborted) {
+          const deadline = captureStartedAt + frameIndex * intervalMs
+          await waitFor(deadline - runtime.now(), controller.signal)
+          if (!captureOpen || controller.signal.aborted) break
+          source.drawFrame(surface.context, width, height)
+          const bitmap = await runtime.createBitmap(surface.canvas)
+          if (!captureOpen || controller.signal.aborted) {
+            bitmap.close()
+            break
+          }
+          await encoder.encodeFrame(bitmap, frameIndex)
+          frameIndex++
+        }
+      } catch (error) {
+        if (!controller.signal.aborted) {
+          samplingError = captureError(error)
+          abort(samplingError)
+        }
+      }
+    })()
+
+    request.prepareReplay()
+    await waitFor(REPLAY_VIDEO_LEAD_IN_MS, controller.signal)
+    await request.playReplay(controller.signal)
+    await waitFor(REPLAY_VIDEO_TAIL_MS, controller.signal)
+    completed = true
+    captureOpen = false
+    await sampling
+    if (samplingError) throw samplingError
+    if (controller.signal.aborted) throw abortReason(controller.signal)
+
+    const encoded = await encoder.finalize()
+    let blob = encoded.blob
+    let embeddedSession = false
+    if (!encoded.usedFallback && encoded.mimeType === 'video/mp4') {
+      const timeline = replayVideoInitialTimelineSnapshot(session)
+      const payload = await createMetadataPayload(
+        session.initial,
+        timeline.tracks,
+        timeline.config,
+        session,
+      )
+      const buffer = await blob.arrayBuffer()
+      blob = new Blob([injectMetadataIntoMp4(buffer, payload)], {
+        type: 'video/mp4',
+      })
+      embeddedSession = true
+    }
+
+    return {
+      blob,
+      mimeType: encoded.mimeType,
+      extension: encoded.mimeType === 'video/mp4' ? 'mp4' : 'webm',
+      width,
+      height,
+      frames: frameIndex,
+      embeddedSession,
+    }
+  } catch (error) {
+    abort(captureError(error))
+    captureOpen = false
+    await sampling
+    encoder?.cancel()
+    throw captureError(error)
+  } finally {
+    completed = true
+    captureOpen = false
+    clearTimeout(timeout)
+    unsubscribeEnded()
+    source.stop()
+  }
+}

--- a/packages/app/src/recorder/replayVideo.test.ts
+++ b/packages/app/src/recorder/replayVideo.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { examples } from '@/flame/examples'
 import { deepClone } from '@/utils/clone'
-import { createReplayVideoDriver, createReplayVideoJobSpec, createReplayVideoSchedule, drawReplayVideoOverlay, MAX_REPLAY_VIDEO_DURATION_MS, REPLAY_VIDEO_FPS, REPLAY_VIDEO_SIZE, replayActionIndexAtFrame, replayFramesInStateRun, replayVideoFileName, replayVideoVisualFingerprint, } from './replayVideo'
+import { createReplayVideoDriver, createReplayVideoJobSpec, createReplayVideoSchedule, drawReplayVideoOverlay, MAX_REPLAY_VIDEO_DURATION_MS, REPLAY_VIDEO_DIMENSIONS, REPLAY_VIDEO_FPS, replayActionIndexAtFrame, replayFramesInStateRun, replayVideoFileName, replayVideoVisualFingerprint, } from './replayVideo'
 import { SESSION_FORMAT_VERSION } from './schema'
 import type { RecordedAction, RecordedSession } from './schema'
 
@@ -177,7 +177,7 @@ describe('createReplayVideoDriver', () => {
 })
 
 describe('createReplayVideoJobSpec', () => {
-  it('builds a detached square MP4 job from the edited take', () => {
+  it('builds a detached landscape MP4 without cropping the editor framing', () => {
     const session = makeSession([
       {
         t: 250,
@@ -197,10 +197,8 @@ describe('createReplayVideoJobSpec', () => {
     expect(replayVideoFileName(session, 'interface')).toBe(
       'Aurora-Study-interface-replay',
     )
-    expect(job.dimensions).toEqual({
-      width: REPLAY_VIDEO_SIZE,
-      height: REPLAY_VIDEO_SIZE,
-    })
+    expect(job.dimensions).toEqual(REPLAY_VIDEO_DIMENSIONS)
+    expect(job.dimensions.width / job.dimensions.height).toBeCloseTo(16 / 9)
     expect(job.fps).toBe(REPLAY_VIDEO_FPS)
     expect(job.codec).toBe('avc')
     expect(job.embedMetadata).toBe(true)

--- a/packages/app/src/recorder/replayVideo.test.ts
+++ b/packages/app/src/recorder/replayVideo.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { examples } from '@/flame/examples'
 import { deepClone } from '@/utils/clone'
-import { createReplayVideoDriver, createReplayVideoJobSpec, createReplayVideoSchedule, drawReplayVideoOverlay, MAX_REPLAY_VIDEO_DURATION_MS, REPLAY_VIDEO_FPS, REPLAY_VIDEO_SIZE, replayActionIndexAtFrame, replayFramesInStateRun, replayVideoVisualFingerprint, } from './replayVideo'
+import { createReplayVideoDriver, createReplayVideoJobSpec, createReplayVideoSchedule, drawReplayVideoOverlay, MAX_REPLAY_VIDEO_DURATION_MS, REPLAY_VIDEO_FPS, REPLAY_VIDEO_SIZE, replayActionIndexAtFrame, replayFramesInStateRun, replayVideoFileName, replayVideoVisualFingerprint, } from './replayVideo'
 import { SESSION_FORMAT_VERSION } from './schema'
 import type { RecordedAction, RecordedSession } from './schema'
 
@@ -194,6 +194,9 @@ describe('createReplayVideoJobSpec', () => {
     const job = createReplayVideoJobSpec(session, 2)
 
     expect(job.name).toBe('Aurora-Study-creation-replay')
+    expect(replayVideoFileName(session, 'interface')).toBe(
+      'Aurora-Study-interface-replay',
+    )
     expect(job.dimensions).toEqual({
       width: REPLAY_VIDEO_SIZE,
       height: REPLAY_VIDEO_SIZE,

--- a/packages/app/src/recorder/replayVideo.test.ts
+++ b/packages/app/src/recorder/replayVideo.test.ts
@@ -1,0 +1,298 @@
+import { describe, expect, it } from 'vitest'
+import { examples } from '@/flame/examples'
+import { deepClone } from '@/utils/clone'
+import { createReplayVideoDriver, createReplayVideoJobSpec, createReplayVideoSchedule, drawReplayVideoOverlay, MAX_REPLAY_VIDEO_DURATION_MS, REPLAY_VIDEO_FPS, REPLAY_VIDEO_SIZE, replayActionIndexAtFrame, replayFramesInStateRun, replayVideoVisualFingerprint, } from './replayVideo'
+import { SESSION_FORMAT_VERSION } from './schema'
+import type { RecordedAction, RecordedSession } from './schema'
+
+function makeSession(actions: RecordedAction[]): RecordedSession {
+  return {
+    version: SESSION_FORMAT_VERSION,
+    app: { version: 'test', flameSchemaVersion: '1.0' },
+    createdAt: new Date(0).toISOString(),
+    initial: deepClone(examples.example1),
+    actions,
+    unnamedWriteCount: 0,
+  }
+}
+
+describe('replay video timing', () => {
+  it('matches replay timestamp clamping, authored holds, and speed', () => {
+    const session = makeSession([
+      { t: 200, id: 'flame.setGamma', args: [1.5] },
+      { t: 1600, id: 'flame.setGamma', args: [2], holdMs: 800 },
+      { t: 1800, id: 'flame.setGamma', args: [2.5] },
+    ])
+    const schedule = createReplayVideoSchedule(session, 2, 10, 600, 1000)
+
+    expect(schedule.actionTimesMs).toEqual([700, 1400, 1800])
+    expect(schedule.durationMs).toBe(2800)
+    expect(schedule.totalFrames).toBe(28)
+    expect(replayActionIndexAtFrame(schedule, 6)).toBe(-1)
+    expect(replayActionIndexAtFrame(schedule, 7)).toBe(0)
+    expect(replayActionIndexAtFrame(schedule, 13)).toBe(0)
+    expect(replayActionIndexAtFrame(schedule, 14)).toBe(1)
+    expect(replayActionIndexAtFrame(schedule, 18)).toBe(2)
+    expect(replayFramesInStateRun(schedule, 7)).toBe(7)
+  })
+
+  it('refuses pathological videos before allocating an encoder', () => {
+    const session = makeSession([
+      {
+        t: 0,
+        id: 'flame.setGamma',
+        args: [1.5],
+        holdMs: MAX_REPLAY_VIDEO_DURATION_MS,
+      },
+      { t: 1, id: 'flame.setGamma', args: [2] },
+    ])
+
+    expect(() => createReplayVideoSchedule(session)).toThrow(
+      /Shorten long holds or choose a faster replay speed/,
+    )
+  })
+
+  it('gives simultaneous authored actions distinct video frames', () => {
+    const session = makeSession([
+      { t: 0, id: 'flame.setGamma', args: [1.5] },
+      { t: 0, id: 'flame.setContrast', args: [1.2] },
+      { t: 0, id: 'flame.setVibrancy', args: [0.8] },
+    ])
+    const schedule = createReplayVideoSchedule(session, 1, 10, 100, 100)
+
+    expect(schedule.actionFrames).toEqual([1, 2, 3])
+    expect(replayActionIndexAtFrame(schedule, 1)).toBe(0)
+    expect(replayActionIndexAtFrame(schedule, 2)).toBe(1)
+    expect(replayActionIndexAtFrame(schedule, 3)).toBe(2)
+  })
+
+  it('keeps the final step when an internal caller requests no tail', () => {
+    const schedule = createReplayVideoSchedule(
+      makeSession([{ t: 0, id: 'flame.setGamma', args: [1.5] }]),
+      1,
+      24,
+      0,
+      0,
+    )
+
+    expect(schedule.actionFrames).toEqual([0])
+    expect(schedule.totalFrames).toBe(1)
+    expect(replayActionIndexAtFrame(schedule, 0)).toBe(0)
+  })
+})
+
+describe('createReplayVideoDriver', () => {
+  it('replays registered commands in an isolated world without mutating input', () => {
+    const session = makeSession([
+      {
+        t: 0,
+        id: 'flame.setGamma',
+        args: [1.7],
+        label: 'Lower gamma',
+      },
+      { t: 100, id: 'view.setAdaptiveFilter', args: [false] },
+      { t: 200, id: 'camera.center', args: [] },
+    ])
+    session.initial.renderSettings.camera.position = [3, -2]
+    session.initial.renderSettings.camera.zoom = 4
+    const untouched = deepClone(session)
+    const driver = createReplayVideoDriver(session)
+
+    expect(driver.reset().actionIndex).toBe(-1)
+    const first = driver.advanceTo(0)
+    expect(first.flame.renderSettings.gamma).toBe(1.7)
+    expect(first.action?.label).toBe('Lower gamma')
+
+    const final = driver.advanceTo(2)
+    expect(final.adaptiveFilter).toBe(false)
+    expect(final.flame.renderSettings.camera.position).toEqual([0, 0])
+    expect(final.flame.renderSettings.camera.zoom).toBe(1)
+    expect(session).toEqual(untouched)
+  })
+
+  it('preserves timeline write-through and renders the held frame', () => {
+    const session = makeSession([
+      {
+        t: 0,
+        id: 'timeline.addKeyframe',
+        args: ['gamma', 1.25, 5, null, null],
+      },
+      {
+        t: 100,
+        id: 'timeline.setKeyframeValue',
+        args: ['gamma', 5, 2.75, null, null],
+      },
+    ])
+    session.initialTimeline = {
+      config: {
+        fps: 30,
+        timeScale: 1,
+        startFrame: 0,
+        endFrame: 20,
+        loop: false,
+      },
+      currentFrame: 5,
+      animationEnabled: true,
+      autoKeyframe: true,
+      previewHeld: true,
+      tracks: [],
+    }
+
+    const driver = createReplayVideoDriver(session)
+    expect(driver.advanceTo(0).flame.renderSettings.gamma).toBe(1.25)
+    expect(driver.advanceTo(1).flame.renderSettings.gamma).toBe(2.75)
+    expect(driver.advanceTo(-1).flame.renderSettings.gamma).toBe(
+      session.initial.renderSettings.gamma,
+    )
+  })
+
+  it('rejects an imported action before touching replay state', () => {
+    const session = makeSession([
+      { t: 0, id: 'definitely.not-a-command', args: [] },
+    ])
+    expect(() => createReplayVideoDriver(session)).toThrow(
+      /Unknown replay command/,
+    )
+  })
+
+  it('distinguishes visual steps from captions that can reuse artwork', () => {
+    const driver = createReplayVideoDriver(
+      makeSession([
+        {
+          t: 0,
+          id: 'flame.setMetadata',
+          args: ['name', 'Published study'],
+        },
+        { t: 100, id: 'flame.setGamma', args: [1.9] },
+      ]),
+    )
+
+    const baseline = replayVideoVisualFingerprint(driver.reset())
+    const metadata = replayVideoVisualFingerprint(driver.advanceTo(0))
+    const gamma = replayVideoVisualFingerprint(driver.advanceTo(1))
+
+    expect(metadata).toBe(baseline)
+    expect(gamma).not.toBe(baseline)
+  })
+})
+
+describe('createReplayVideoJobSpec', () => {
+  it('builds a detached square MP4 job from the edited take', () => {
+    const session = makeSession([
+      {
+        t: 250,
+        id: 'flame.setGamma',
+        args: [1.8],
+        note: 'Bring out the glow',
+      },
+    ])
+    session.initial.metadata = {
+      ...session.initial.metadata,
+      name: 'Aurora / Study',
+    }
+
+    const job = createReplayVideoJobSpec(session, 2)
+
+    expect(job.name).toBe('Aurora-Study-creation-replay')
+    expect(job.dimensions).toEqual({
+      width: REPLAY_VIDEO_SIZE,
+      height: REPLAY_VIDEO_SIZE,
+    })
+    expect(job.fps).toBe(REPLAY_VIDEO_FPS)
+    expect(job.codec).toBe('avc')
+    expect(job.embedMetadata).toBe(true)
+    expect(job.replayVideo?.playbackSpeed).toBe(2)
+    expect(job.frameEnd).toBeGreaterThan(job.frameStart)
+    expect(job.session).toEqual(session)
+
+    session.actions[0]!.note = 'Changed after enqueue'
+    expect(job.session?.actions[0]?.note).toBe('Bring out the glow')
+  })
+
+  it('refuses to publish a take with uncaptured edits', () => {
+    const session = makeSession([])
+    session.unnamedWriteCount = 2
+
+    expect(() => createReplayVideoJobSpec(session)).toThrow(
+      /2 uncaptured edits/,
+    )
+  })
+
+  it('refuses custom variation code that the portable session cannot package', () => {
+    const session = makeSession([{ t: 0, id: 'flame.setGamma', args: [1.5] }])
+    const firstTransform = Object.values(session.initial.transforms)[0]!
+    const firstVariation = Object.values(firstTransform.variations)[0]!
+    firstVariation.type = 'custom_local_only'
+
+    expect(() => createReplayVideoJobSpec(session)).toThrow(
+      /cannot yet package custom variation code used by the recording baseline/,
+    )
+  })
+
+  it('checks custom variations introduced by a later whole-flame step', () => {
+    const loaded = deepClone(examples.example1)
+    const firstTransform = Object.values(loaded.transforms)[0]!
+    const firstVariation = Object.values(firstTransform.variations)[0]!
+    firstVariation.type = 'custom_later_step'
+    const session = makeSession([
+      { t: 0, id: 'flame.load', args: [loaded, 'Load custom flame'] },
+    ])
+
+    expect(() => createReplayVideoJobSpec(session)).toThrow(
+      /cannot yet package custom variation code used by the step 1/,
+    )
+  })
+
+  it('checks custom variation ids carried by semantic add steps', () => {
+    const transformId = Object.keys(examples.example1.transforms)[0]!
+    const session = makeSession([
+      {
+        t: 0,
+        id: 'flame.addVariation',
+        args: [transformId, 'custom_local_only', 'variation-added'],
+      },
+    ])
+
+    expect(() => createReplayVideoJobSpec(session)).toThrow(
+      /cannot yet package custom variation code used by the step 1/,
+    )
+  })
+
+  it('refuses an empty take that has no creation sequence to publish', () => {
+    expect(() => createReplayVideoJobSpec(makeSession([]))).toThrow(
+      /no authored steps/,
+    )
+  })
+})
+
+describe('drawReplayVideoOverlay', () => {
+  it('keeps an unbroken authored caption inside the output safe width', () => {
+    const drawn: string[] = []
+    const context = {
+      save: () => {},
+      restore: () => {},
+      measureText: (text: string) => ({ width: text.length * 10 }),
+      createLinearGradient: () => ({ addColorStop: () => {} }),
+      fillText: (text: string) => drawn.push(text),
+      fillRect: () => {},
+      clearRect: () => {},
+    } as unknown as CanvasRenderingContext2D
+
+    drawReplayVideoOverlay(context, 200, 200, {
+      action: {
+        t: 0,
+        id: 'flame.setGamma',
+        args: [1.5],
+        note: 'x'.repeat(200),
+      },
+      actionIndex: 0,
+      totalActions: 1,
+      progress: 0.5,
+    })
+
+    const caption = drawn.find((text) => text.startsWith('x'))
+    expect(caption).toBeDefined()
+    expect(caption?.endsWith('…')).toBe(true)
+    expect((caption?.length ?? 0) * 10).toBeLessThanOrEqual(182)
+  })
+})

--- a/packages/app/src/recorder/replayVideo.ts
+++ b/packages/app/src/recorder/replayVideo.ts
@@ -1,0 +1,1033 @@
+// Register every command a session may contain before building the isolated
+// replay world. MainWorkspace imports the same barrel, but background exports
+// must not depend on the editor having mounted first.
+import '@/commands/builtins'
+import { vec2f } from 'typegpu/data'
+import { executeReplayCommand, preflightReplayCommand, } from '@/commands/registry'
+import { qualityPresets } from '@/components/Quality/QualityPresets'
+import { tryValidateFlame } from '@/flame/schema/flameSchema'
+import { defaultTimelineConfig } from '@/flame/schema/timeline'
+import { deepClone } from '@/utils/clone'
+import { applyTracksToFlame, getUserEndFrame, loopOptsFromConfig, resolveLoopValue, } from '@/utils/timeline'
+import { MAX_STEP_GAP_MS } from './player'
+import { paletteRestoreColorsAfterReplayCommand } from './replayPaletteState'
+import { validateSession } from './schema'
+import type { RecordedAction, RecordedSession, SessionViewSnapshot, TransformColorSnapshot, } from './schema'
+import type { SonificationSnapshot } from './sonificationState'
+import type { CommandContext } from '@/commands/types'
+import type { Palette } from '@/flame/colorMap'
+import type { AudioWiringSnapshot } from '@/flame/schema/audioWiring'
+import type { FlameDescriptor } from '@/flame/schema/flameSchema'
+import type { TimelineSnapshot } from '@/flame/schema/timeline'
+import type { HistorySetter } from '@/utils/createStoreHistory'
+import type { AnimationJobSpec } from '@/utils/exportJobs'
+
+export const REPLAY_VIDEO_FPS = 24
+export const REPLAY_VIDEO_SIZE = 1080
+export const REPLAY_VIDEO_LEAD_IN_MS = 650
+export const REPLAY_VIDEO_TAIL_MS = 1400
+export const MAX_REPLAY_VIDEO_DURATION_MS = 120_000
+
+// Custom variation definitions are global, executable WGSL today; they are not
+// part of the portable recorder schema. Publishing a take that references one
+// would therefore depend on whichever local registry happens to render it.
+const CUSTOM_VARIATION_TYPE_PREFIX = 'custom_'
+
+export type ReplayVideoSpec = {
+  version: 1
+  playbackSpeed: number
+  leadInMs: number
+  tailMs: number
+}
+
+export type ReplayVideoSchedule = {
+  fps: number
+  actionTimesMs: number[]
+  /** One distinct output frame per authored step, even for zero-gap actions. */
+  actionFrames: number[]
+  durationMs: number
+  totalFrames: number
+}
+
+export type ReplayVideoFrameState = {
+  flame: FlameDescriptor
+  palette: Palette | undefined
+  blendFlame: FlameDescriptor | undefined
+  blendWeight: number
+  adaptiveFilter: boolean
+  stochasticFilter: boolean
+  action: RecordedAction | undefined
+  actionIndex: number
+}
+
+export type ReplayVideoDriver = {
+  readonly session: RecordedSession
+  /** State after action `index`; -1 is the recorded baseline. */
+  advanceTo: (index: number) => ReplayVideoFrameState
+  reset: () => ReplayVideoFrameState
+}
+
+/** State identity that actually requires a fresh GPU render. Captions and
+ * presentation-only commands intentionally do not participate, so the video
+ * renderer can reuse the last artwork frame for those steps. */
+export function replayVideoVisualFingerprint(
+  state: ReplayVideoFrameState,
+): string {
+  return JSON.stringify({
+    renderSettings: state.flame.renderSettings,
+    transforms: state.flame.transforms,
+    finalTransform: state.flame.finalTransform,
+    palette: state.palette,
+    blendFlame: state.blendFlame,
+    blendWeight: state.blendWeight,
+    adaptiveFilter: state.adaptiveFilter,
+    stochasticFilter: state.stochasticFilter,
+  })
+}
+
+type TimelineSnapshotKeyframe =
+  TimelineSnapshot['tracks'][number]['keyframes'][number]
+type TimelineSnapshotValue = TimelineSnapshotKeyframe['value']
+
+type MutableTimeline = {
+  snapshot: TimelineSnapshot
+}
+
+function nextSetterValue<T>(current: T, next: T | ((value: T) => T)): T {
+  return typeof next === 'function' ? (next as (value: T) => T)(current) : next
+}
+
+function initialTimelineSnapshot(session: RecordedSession): TimelineSnapshot {
+  if (session.initialTimeline) return deepClone(session.initialTimeline)
+  return {
+    config: { ...defaultTimelineConfig(), timeScale: 1 },
+    currentFrame: 0,
+    animationEnabled: false,
+    autoKeyframe: true,
+    previewHeld: false,
+    tracks: [],
+  }
+}
+
+function initialViewSnapshot(session: RecordedSession): SessionViewSnapshot {
+  return deepClone(
+    session.initialView ?? {
+      qualityPreset: 'high',
+      pixelRatio: 1,
+      adaptiveFilter: true,
+      stochasticFilter: false,
+      flyMode: false,
+      showTimeline: false,
+      sidebarOpen: true,
+      paletteRestoreColors: {},
+    },
+  )
+}
+
+function initialAudioSnapshot(session: RecordedSession): AudioWiringSnapshot {
+  return deepClone(
+    session.initialAudio ?? {
+      mapping: { preset: 'custom', mappings: [] },
+      enabled: false,
+      source: 'file',
+    },
+  )
+}
+
+function findKeyframe(
+  timeline: MutableTimeline,
+  path: string,
+  frame: number,
+): TimelineSnapshotKeyframe | undefined {
+  return timeline.snapshot.tracks
+    .find((track) => track.parameterPath === path)
+    ?.keyframes.find((keyframe) => keyframe.frame === frame)
+}
+
+function setKeyframe(
+  timeline: MutableTimeline,
+  path: string,
+  frame: number,
+  value: TimelineSnapshotValue,
+  easing?: string,
+  interp?: string,
+): void {
+  const tracks = timeline.snapshot.tracks
+  let track = tracks.find((candidate) => candidate.parameterPath === path)
+  if (!track) {
+    track = { parameterPath: path, keyframes: [] }
+    tracks.push(track)
+  }
+  const existing = track.keyframes.find((keyframe) => keyframe.frame === frame)
+  if (existing) {
+    existing.value = deepClone(value)
+    if (easing !== undefined) {
+      existing.easing = easing as TimelineSnapshotKeyframe['easing']
+    }
+    if (interp !== undefined) {
+      existing.interp = interp as TimelineSnapshotKeyframe['interp']
+    }
+  } else {
+    track.keyframes.push({
+      frame,
+      value: deepClone(value),
+      easing: easing as TimelineSnapshotKeyframe['easing'],
+      interp: interp as TimelineSnapshotKeyframe['interp'],
+    })
+  }
+}
+
+function removeKeyframe(
+  timeline: MutableTimeline,
+  path: string,
+  frame: number,
+): void {
+  timeline.snapshot.tracks = timeline.snapshot.tracks
+    .map((track) =>
+      track.parameterPath === path
+        ? {
+            ...track,
+            keyframes: track.keyframes.filter(
+              (keyframe) => keyframe.frame !== frame,
+            ),
+          }
+        : track,
+    )
+    .filter((track) => track.keyframes.length > 0)
+}
+
+function writeTimelineValue(
+  flame: FlameDescriptor,
+  path: string,
+  value: TimelineSnapshotValue,
+): void {
+  // Reuse the renderer's canonical path application for camera, transform,
+  // variation and final-transform tracks.
+  applyTracksToFlame(
+    [
+      {
+        parameterPath: path,
+        keyframes: [{ frame: 0, value }],
+      },
+    ],
+    flame,
+    0,
+  )
+
+  // A few first-level settings are intentionally generic in the editor and
+  // are newer than applyTracksToFlame's explicit list. Preserve those too.
+  if (path === 'blendWeight' && typeof value === 'number') {
+    flame.renderSettings.blendWeight = value
+    return
+  }
+  if (!path.includes('.') && path in flame.renderSettings) {
+    ;(flame.renderSettings as unknown as Record<string, unknown>)[path] =
+      deepClone(value)
+  }
+}
+
+function applyTimelinePose(
+  base: FlameDescriptor,
+  timeline: TimelineSnapshot,
+): FlameDescriptor {
+  const posed = deepClone(base)
+  if (!timeline.animationEnabled || !timeline.previewHeld) return posed
+  const frame = timeline.currentFrame ?? timeline.config.startFrame
+  applyTracksToFlame(
+    timeline.tracks,
+    posed,
+    frame,
+    loopOptsFromConfig(timeline.config, timeline.tracks),
+  )
+
+  // Keep generic first-level render settings and blendWeight in sync with the
+  // live editor. applyTracksToFlame owns the structured path vocabulary.
+  for (const track of timeline.tracks) {
+    if (track.parameterPath.includes('.')) continue
+    const value = resolveLoopValue(
+      track.keyframes,
+      frame,
+      loopOptsFromConfig(timeline.config, timeline.tracks),
+    )
+    if (
+      value !== null &&
+      (track.parameterPath === 'blendWeight' ||
+        track.parameterPath in posed.renderSettings)
+    ) {
+      ;(posed.renderSettings as unknown as Record<string, unknown>)[
+        track.parameterPath
+      ] = deepClone(value)
+    }
+  }
+  return posed
+}
+
+function paletteFromFlame(flame: FlameDescriptor): Palette | undefined {
+  const palette = flame.renderSettings.palette
+  if (!palette) return undefined
+  return {
+    id: palette.id,
+    name: palette.name,
+    entries: palette.entries.map((entry) => ({ ...entry })),
+    source: 'imported',
+  }
+}
+
+function flameUsesCustomVariation(flame: FlameDescriptor): boolean {
+  return Object.values(flame.transforms).some((transform) =>
+    Object.values(transform.variations).some((variation) =>
+      variation.type.startsWith(CUSTOM_VARIATION_TYPE_PREFIX),
+    ),
+  )
+}
+
+export function assertReplayVideoStatePortable(
+  state: ReplayVideoFrameState,
+  actionIndex: number,
+): void {
+  if (
+    flameUsesCustomVariation(state.flame) ||
+    (state.blendFlame !== undefined &&
+      flameUsesCustomVariation(state.blendFlame))
+  ) {
+    const atStep =
+      actionIndex < 0 ? 'recording baseline' : `step ${actionIndex + 1}`
+    throw new Error(
+      `Replay video cannot yet package custom variation code used by the ${atStep}. Replace it with built-in variations before exporting this take.`,
+    )
+  }
+}
+
+function valueReferencesCustomVariation(value: unknown): boolean {
+  if (value === null || typeof value !== 'object') return false
+  if (Array.isArray(value)) {
+    return value.some(valueReferencesCustomVariation)
+  }
+  const record = value as Record<string, unknown>
+  if (
+    typeof record.type === 'string' &&
+    record.type.startsWith(CUSTOM_VARIATION_TYPE_PREFIX)
+  ) {
+    return true
+  }
+  return Object.values(record).some(valueReferencesCustomVariation)
+}
+
+function actionReferencesCustomVariation(action: RecordedAction): boolean {
+  if (
+    action.id === 'flame.addVariation' &&
+    typeof action.args[1] === 'string' &&
+    action.args[1].startsWith(CUSTOM_VARIATION_TYPE_PREFIX)
+  ) {
+    return true
+  }
+  // Randomizer configs carry variation ids as strings rather than descriptor
+  // objects. Current UI records their finished flame, but keep imported legacy
+  // actions honest too.
+  if (action.id === 'flame.randomize' || action.id === 'flame.mutate') {
+    const stack = [...action.args]
+    while (stack.length > 0) {
+      const value = stack.pop()
+      if (
+        typeof value === 'string' &&
+        value.startsWith(CUSTOM_VARIATION_TYPE_PREFIX)
+      ) {
+        return true
+      }
+      if (Array.isArray(value)) stack.push(...value)
+      else if (value !== null && typeof value === 'object') {
+        stack.push(...Object.values(value))
+      }
+    }
+  }
+  return action.args.some(valueReferencesCustomVariation)
+}
+
+function buildScheduleSpec(
+  playbackSpeed: number,
+  leadInMs = REPLAY_VIDEO_LEAD_IN_MS,
+  tailMs = REPLAY_VIDEO_TAIL_MS,
+): ReplayVideoSpec {
+  if (!Number.isFinite(playbackSpeed) || playbackSpeed <= 0) {
+    throw new Error('Replay video speed must be greater than zero')
+  }
+  return {
+    version: 1,
+    playbackSpeed,
+    leadInMs,
+    tailMs,
+  }
+}
+
+export function createReplayVideoSchedule(
+  session: RecordedSession,
+  playbackSpeed = 1,
+  fps = REPLAY_VIDEO_FPS,
+  leadInMs = REPLAY_VIDEO_LEAD_IN_MS,
+  tailMs = REPLAY_VIDEO_TAIL_MS,
+): ReplayVideoSchedule {
+  if (!Number.isFinite(fps) || fps <= 0) {
+    throw new Error('Replay video FPS must be greater than zero')
+  }
+  const spec = buildScheduleSpec(playbackSpeed, leadInMs, tailMs)
+  let cursor = spec.leadInMs
+  const actionTimesMs: number[] = []
+  const actionFrames: number[] = []
+  let previousActionFrame = -1
+  for (let index = 0; index < session.actions.length; index++) {
+    const action = session.actions[index]!
+    const previous = index > 0 ? session.actions[index - 1] : undefined
+    const gap =
+      previous?.holdMs !== undefined
+        ? previous.holdMs / spec.playbackSpeed
+        : Math.min(
+            MAX_STEP_GAP_MS,
+            Math.max(0, previous ? action.t - previous.t : action.t) /
+              spec.playbackSpeed,
+          )
+    cursor += gap
+    // Two companion commands can share a timestamp. A video cannot represent
+    // both on one frame, so advance at least one frame and never silently skip
+    // an authored step/caption.
+    const frame = Math.max(
+      previousActionFrame + 1,
+      Math.ceil((cursor * fps) / 1000),
+    )
+    previousActionFrame = frame
+    actionFrames.push(frame)
+    actionTimesMs.push((frame * 1000) / fps)
+  }
+  const finalActionTime = actionTimesMs.at(-1) ?? spec.leadInMs
+  const durationMs = Math.max(cursor, finalActionTime) + spec.tailMs
+  if (durationMs > MAX_REPLAY_VIDEO_DURATION_MS) {
+    throw new Error(
+      `Replay video is ${Math.ceil(durationMs / 1000)}s; the current limit is ${MAX_REPLAY_VIDEO_DURATION_MS / 1000}s. Shorten long holds or choose a faster replay speed.`,
+    )
+  }
+  return {
+    fps,
+    actionTimesMs,
+    actionFrames,
+    durationMs,
+    // Keep the final authored action representable even when a future caller
+    // deliberately asks for no tail. Frame indexes are zero-based, so an
+    // action landing on frame N needs at least N + 1 output frames.
+    totalFrames: Math.max(
+      1,
+      (actionFrames.at(-1) ?? -1) + 1,
+      Math.ceil((durationMs * fps) / 1000),
+    ),
+  }
+}
+
+export function replayActionIndexAtFrame(
+  schedule: ReplayVideoSchedule,
+  frameIndex: number,
+): number {
+  let result = -1
+  for (let index = 0; index < schedule.actionFrames.length; index++) {
+    if (schedule.actionFrames[index]! > frameIndex) break
+    result = index
+  }
+  return result
+}
+
+/** Number of consecutive frames sharing the same semantic replay state. */
+export function replayFramesInStateRun(
+  schedule: ReplayVideoSchedule,
+  frameIndex: number,
+): number {
+  const actionIndex = replayActionIndexAtFrame(schedule, frameIndex)
+  let count = 1
+  while (
+    frameIndex + count < schedule.totalFrames &&
+    replayActionIndexAtFrame(schedule, frameIndex + count) === actionIndex
+  ) {
+    count++
+  }
+  return count
+}
+
+export function createReplayVideoDriver(
+  inputSession: RecordedSession,
+): ReplayVideoDriver {
+  const validatedSession = validateSession(deepClone(inputSession))
+  if (!validatedSession) {
+    throw new Error('The recording is not a valid replay session')
+  }
+  const session: RecordedSession = validatedSession
+  for (let index = 0; index < session.actions.length; index++) {
+    const action = session.actions[index]!
+    const reason = preflightReplayCommand(action.id, action.args)
+    if (reason !== undefined) {
+      throw new Error(`Step ${index + 1}: ${reason}`)
+    }
+  }
+
+  let flame = deepClone(session.initial)
+  const timeline: MutableTimeline = {
+    snapshot: initialTimelineSnapshot(session),
+  }
+  let view = initialViewSnapshot(session)
+  let audio = initialAudioSnapshot(session)
+  let sonification: SonificationSnapshot | undefined =
+    session.initialSonification === undefined
+      ? undefined
+      : deepClone(session.initialSonification)
+  let paletteRestoreColors: TransformColorSnapshot = deepClone(
+    view.paletteRestoreColors ?? {},
+  )
+  let sidebarOpen = view.sidebarOpen
+  let lastApplied = -1
+
+  const setFlameDescriptor: HistorySetter<FlameDescriptor> = (mutate) => {
+    const draft = deepClone(flame)
+    const replacement = mutate(draft)
+    flame = deepClone(replacement ?? draft)
+  }
+
+  const context: CommandContext = {
+    flameDescriptor: () => flame,
+    setFlameDescriptor,
+    paletteRestoreColors: () => paletteRestoreColors,
+    blendFlame: () =>
+      tryValidateFlame(deepClone(flame.renderSettings.blendFlame)),
+    setBlendFlame: (next) => {
+      setFlameDescriptor((draft) => {
+        if (next === undefined) delete draft.renderSettings.blendFlame
+        else draft.renderSettings.blendFlame = deepClone(next)
+      })
+    },
+    blendWeight: () => flame.renderSettings.blendWeight ?? 0,
+    setBlendWeight: (next) => {
+      setFlameDescriptor((draft) => {
+        draft.renderSettings.blendWeight = next
+      })
+    },
+    pixelRatio: () => view.pixelRatio ?? 1,
+    setPixelRatio: (next) => {
+      const value = nextSetterValue(view.pixelRatio ?? 1, next)
+      view.pixelRatio = value as 1 | 0.5 | 0.25
+      return value
+    },
+    zoom: () => flame.renderSettings.camera.zoom,
+    setZoom: (next) => {
+      const value = nextSetterValue(flame.renderSettings.camera.zoom, next)
+      setFlameDescriptor((draft) => {
+        draft.renderSettings.camera.zoom = value
+      })
+      return value
+    },
+    position: () => vec2f(...flame.renderSettings.camera.position),
+    setPosition: (next) => {
+      const current = vec2f(...flame.renderSettings.camera.position)
+      const value = nextSetterValue(current, next)
+      setFlameDescriptor((draft) => {
+        draft.renderSettings.camera.position = [value[0], value[1]]
+      })
+      return value
+    },
+    sidebar: {
+      open: () => sidebarOpen,
+      setOpen: (next) => {
+        sidebarOpen = nextSetterValue(sidebarOpen, next)
+        return sidebarOpen
+      },
+    },
+    timeline: {
+      tracks: () => timeline.snapshot.tracks,
+      setTracks: (next) => {
+        timeline.snapshot.tracks = deepClone(
+          nextSetterValue(timeline.snapshot.tracks, next),
+        )
+        return timeline.snapshot.tracks
+      },
+      animationEnabled: () => timeline.snapshot.animationEnabled ?? false,
+      setAnimationEnabled: (next) => {
+        const value = nextSetterValue(
+          timeline.snapshot.animationEnabled ?? false,
+          next,
+        )
+        timeline.snapshot.animationEnabled = value
+        return value
+      },
+      duration: () => timeline.snapshot.config.endFrame,
+      setDuration: (duration) => {
+        timeline.snapshot.config.endFrame = duration
+      },
+      currentFrame: () =>
+        timeline.snapshot.currentFrame ?? timeline.snapshot.config.startFrame,
+      setCurrentFrame: (next) => {
+        const current =
+          timeline.snapshot.currentFrame ?? timeline.snapshot.config.startFrame
+        const value = Math.max(
+          timeline.snapshot.config.startFrame,
+          Math.min(
+            timeline.snapshot.config.endFrame,
+            nextSetterValue(current, next),
+          ),
+        )
+        timeline.snapshot.currentFrame = value
+        timeline.snapshot.previewHeld = true
+        return value
+      },
+      setPreviewHeld: (next) => {
+        const value = nextSetterValue(
+          timeline.snapshot.previewHeld ?? false,
+          next,
+        )
+        timeline.snapshot.previewHeld = value
+        return value
+      },
+      play: () => {},
+      setLoop: (loop) => {
+        timeline.snapshot.config.loop = loop
+      },
+      setFps: (fps) => {
+        timeline.snapshot.config.fps = fps
+      },
+      setAutoFps: (enabled) => {
+        timeline.snapshot.config.autoFps = enabled
+      },
+      setTimeScale: (scale) => {
+        timeline.snapshot.config.timeScale = scale
+      },
+      addKeyframe: (path, frame, value, easing, interp) => {
+        setKeyframe(timeline, path, frame, value, easing, interp)
+        if (frame === timeline.snapshot.currentFrame) {
+          writeTimelineValue(flame, path, value)
+        }
+      },
+      edit: {
+        removeKeyframe: (path, frame) => {
+          removeKeyframe(timeline, path, frame)
+        },
+        setKeyframeValue: (path, frame, value, easing, interp) => {
+          setKeyframe(timeline, path, frame, value, easing, interp)
+          if (frame === timeline.snapshot.currentFrame) {
+            writeTimelineValue(flame, path, value)
+          }
+        },
+        setKeyframeInterp: (path, frame, interp) => {
+          const keyframe = findKeyframe(timeline, path, frame)
+          if (keyframe) {
+            keyframe.interp = interp as TimelineSnapshotKeyframe['interp']
+          }
+        },
+        moveKeyframe: (path, from, to) => {
+          const keyframe = findKeyframe(timeline, path, from)
+          if (!keyframe) return
+          removeKeyframe(timeline, path, from)
+          setKeyframe(
+            timeline,
+            path,
+            to,
+            keyframe.value,
+            keyframe.easing,
+            keyframe.interp,
+          )
+        },
+        relocateKeyframe: (path, from, to) => {
+          if (findKeyframe(timeline, path, to)) return
+          const keyframe = findKeyframe(timeline, path, from)
+          if (!keyframe) return
+          removeKeyframe(timeline, path, from)
+          setKeyframe(
+            timeline,
+            path,
+            to,
+            keyframe.value,
+            keyframe.easing,
+            keyframe.interp,
+          )
+        },
+        addKeyframeValuesAtFrame: (writes, frame) => {
+          for (const [path, value] of writes) {
+            setKeyframe(timeline, path, frame, value)
+            if (frame === timeline.snapshot.currentFrame) {
+              writeTimelineValue(flame, path, value)
+            }
+          }
+        },
+        removeTrack: (path) => {
+          timeline.snapshot.tracks = timeline.snapshot.tracks.filter(
+            (track) => track.parameterPath !== path,
+          )
+        },
+        clearTracks: () => {
+          timeline.snapshot.tracks = []
+          timeline.snapshot.previewHeld = false
+        },
+        setLoopMode: (mode) => {
+          const config = timeline.snapshot.config
+          config.loopMode = mode
+          if (mode !== 'off') config.loop = true
+          if (mode === 'seamless') {
+            const userEnd = getUserEndFrame(
+              timeline.snapshot.tracks,
+              config.startFrame,
+            )
+            const span = Math.max(1, userEnd - config.startFrame)
+            if (config.endFrame <= userEnd) config.endFrame = userEnd + span
+          }
+        },
+        setAutoKeyframe: (enabled) => {
+          timeline.snapshot.autoKeyframe = enabled
+        },
+        snapshot: () => deepClone(timeline.snapshot),
+        load: (snapshot) => {
+          timeline.snapshot = deepClone(snapshot)
+        },
+      },
+    },
+    audio: {
+      snapshot: () => deepClone(audio),
+      canEnable: () => false,
+      setMapping: (mapping) => {
+        audio.mapping = deepClone(mapping)
+      },
+      setEnabled: (enabled) => {
+        // Session files carry no resource bytes. Keep the data state but never
+        // attach an unrelated runtime resource to a deterministic export.
+        audio.enabled = enabled
+      },
+      setSource: (source) => {
+        audio.source = source
+      },
+    },
+    sonification: {
+      snapshot: () =>
+        deepClone(
+          sonification ?? {
+            version: 1,
+            enabled: false,
+            config: {
+              model: 'orchestral',
+              volume: 0.5,
+              updateRate: 30,
+              scale: 'pentatonicMajor',
+              voiceCount: 6,
+              harmonicDensity: 1,
+              triggerRate: 4,
+              spatialSpread: 0.5,
+              reverbMix: 0.25,
+            },
+          },
+        ),
+      setConfig: (config) => {
+        sonification = {
+          version: 1,
+          enabled: sonification?.enabled ?? false,
+          config: deepClone(config),
+        }
+      },
+      setEnabled: (enabled) => {
+        if (sonification) sonification.enabled = enabled
+      },
+    },
+    view: {
+      setQualityPreset: (key) => {
+        if (key in qualityPresets) view.qualityPreset = key
+      },
+      setAdaptiveFilter: (enabled) => {
+        view.adaptiveFilter = enabled
+      },
+      setStochasticFilter: (enabled) => {
+        view.stochasticFilter = enabled
+      },
+      setFlyMode: (enabled) => {
+        view.flyMode = enabled
+      },
+      setShowTimeline: (shown) => {
+        view.showTimeline = shown
+      },
+    },
+    camera: {
+      center: () => {
+        setFlameDescriptor((draft) => {
+          draft.renderSettings.camera.position = [0, 0]
+          draft.renderSettings.camera.zoom = 1
+        })
+      },
+    },
+    modal: { open: () => {} },
+  }
+
+  function frameState(index: number): ReplayVideoFrameState {
+    const posed = applyTimelinePose(flame, timeline.snapshot)
+    const blendDescriptor = posed.renderSettings.blendFlame
+    const blendFlame =
+      blendDescriptor === undefined
+        ? undefined
+        : tryValidateFlame(deepClone(blendDescriptor))
+    return {
+      flame: posed,
+      palette: paletteFromFlame(posed),
+      blendFlame,
+      blendWeight: posed.renderSettings.blendWeight ?? 0,
+      adaptiveFilter: view.adaptiveFilter,
+      stochasticFilter: view.stochasticFilter,
+      action: index < 0 ? undefined : session.actions[index],
+      actionIndex: index,
+    }
+  }
+
+  function reset(): ReplayVideoFrameState {
+    flame = deepClone(session.initial)
+    timeline.snapshot = initialTimelineSnapshot(session)
+    view = initialViewSnapshot(session)
+    audio = initialAudioSnapshot(session)
+    sonification =
+      session.initialSonification === undefined
+        ? undefined
+        : deepClone(session.initialSonification)
+    paletteRestoreColors = deepClone(view.paletteRestoreColors ?? {})
+    sidebarOpen = view.sidebarOpen
+    lastApplied = -1
+    return frameState(-1)
+  }
+
+  function advanceTo(index: number): ReplayVideoFrameState {
+    const target = Math.min(
+      session.actions.length - 1,
+      Math.max(-1, Math.floor(index)),
+    )
+    if (target < lastApplied) reset()
+    for (
+      let actionIndex = lastApplied + 1;
+      actionIndex <= target;
+      actionIndex++
+    ) {
+      const action = session.actions[actionIndex]!
+      const nextPaletteRestoreColors = paletteRestoreColorsAfterReplayCommand(
+        action.id,
+        action.args,
+        flame,
+        paletteRestoreColors,
+      )
+      if (
+        !executeReplayCommand(action.id, context, ...deepClone(action.args))
+      ) {
+        throw new Error(`Step ${actionIndex + 1} could not be replayed`)
+      }
+      paletteRestoreColors = deepClone(nextPaletteRestoreColors)
+      lastApplied = actionIndex
+    }
+    return frameState(target)
+  }
+
+  return { session, advanceTo, reset }
+}
+
+export function createReplayVideoSpec(playbackSpeed = 1): ReplayVideoSpec {
+  return buildScheduleSpec(playbackSpeed)
+}
+
+/** Build a detached, background-export job from the edited replay session. */
+export function createReplayVideoJobSpec(
+  inputSession: RecordedSession,
+  playbackSpeed = 1,
+): AnimationJobSpec {
+  const session = validateSession(deepClone(inputSession))
+  if (!session) throw new Error('The recording is not a valid replay session')
+  if (session.unnamedWriteCount > 0) {
+    throw new Error(
+      `This take has ${session.unnamedWriteCount} uncaptured edit${session.unnamedWriteCount === 1 ? '' : 's'}. Record a clean take before publishing it as video.`,
+    )
+  }
+  if (session.actions.length === 0) {
+    throw new Error('This take has no authored steps to publish as video.')
+  }
+  if (valueReferencesCustomVariation(session.initial)) {
+    throw new Error(
+      'Replay video cannot yet package custom variation code used by the recording baseline. Replace it with built-in variations before exporting this take.',
+    )
+  }
+  const customVariationStep = session.actions.findIndex(
+    actionReferencesCustomVariation,
+  )
+  if (customVariationStep >= 0) {
+    throw new Error(
+      `Replay video cannot yet package custom variation code used by the step ${customVariationStep + 1}. Replace it with built-in variations before exporting this take.`,
+    )
+  }
+  const schedule = createReplayVideoSchedule(session, playbackSpeed)
+  const replayVideo = createReplayVideoSpec(playbackSpeed)
+  const driver = createReplayVideoDriver(session)
+  const initial = driver.reset()
+  assertReplayVideoStatePortable(initial, -1)
+  const timeline = initialTimelineSnapshot(session)
+  return {
+    name: replayVideoFileName(session),
+    flame: deepClone(session.initial),
+    quality: 0.9,
+    dimensions: { width: REPLAY_VIDEO_SIZE, height: REPLAY_VIDEO_SIZE },
+    fps: schedule.fps,
+    frameStart: 0,
+    frameEnd: schedule.totalFrames - 1,
+    playCount: 1,
+    codec: 'avc',
+    embedMetadata: true,
+    palette: initial.palette,
+    blendFlame: initial.blendFlame,
+    blendWeight: initial.blendWeight,
+    tracks: deepClone(timeline.tracks),
+    config: deepClone(timeline.config),
+    session: deepClone(session),
+    replayVideo,
+  }
+}
+
+export type ReplayVideoOverlayFrame = {
+  action: RecordedAction | undefined
+  actionIndex: number
+  totalActions: number
+  progress: number
+  flameName?: string
+}
+
+function fitCaptionLines(
+  context: CanvasRenderingContext2D,
+  text: string,
+  maxWidth: number,
+  maxLines = 2,
+): string[] {
+  const words = text.trim().split(/\s+/).filter(Boolean)
+  if (words.length === 0) return []
+  const lines: string[] = []
+  let current = ''
+  for (const word of words) {
+    const candidate = current === '' ? word : `${current} ${word}`
+    if (context.measureText(candidate).width <= maxWidth) {
+      current = candidate
+      continue
+    }
+    if (current !== '') lines.push(current)
+    current = word
+    if (lines.length === maxLines - 1) break
+  }
+  if (current !== '' && lines.length < maxLines) lines.push(current)
+  const fitWithEllipsis = (line: string): string => {
+    if (context.measureText(line).width <= maxWidth) return line
+    const characters = Array.from(line)
+    let low = 0
+    let high = characters.length
+    while (low < high) {
+      const middle = Math.ceil((low + high) / 2)
+      if (
+        context.measureText(`${characters.slice(0, middle).join('')}…`).width <=
+        maxWidth
+      ) {
+        low = middle
+      } else {
+        high = middle - 1
+      }
+    }
+    return `${characters.slice(0, low).join('').trimEnd()}…`
+  }
+
+  for (let index = 0; index < lines.length; index++) {
+    lines[index] = fitWithEllipsis(lines[index]!)
+  }
+  const consumed = lines.join(' ').split(/\s+/).filter(Boolean).length
+  if (consumed < words.length && lines.length > 0) {
+    const last = lines.at(-1)?.replace(/…$/, '') ?? ''
+    lines[lines.length - 1] = fitWithEllipsis(`${last}…`)
+  }
+  return lines
+}
+
+/** Burn the replay identity, caption and progress into one publishable frame. */
+export function drawReplayVideoOverlay(
+  context: CanvasRenderingContext2D,
+  width: number,
+  height: number,
+  frame: ReplayVideoOverlayFrame,
+): void {
+  const unit = Math.min(width, height)
+  const margin = unit * 0.047
+  const tagFont = Math.max(13, Math.round(unit * 0.018))
+  const captionFont = Math.max(22, Math.round(unit * 0.038))
+  const detailFont = Math.max(12, Math.round(unit * 0.016))
+  const caption =
+    frame.action?.note ??
+    frame.action?.label ??
+    frame.action?.id ??
+    frame.flameName ??
+    'Starting flame'
+
+  context.save()
+  context.textBaseline = 'top'
+  context.shadowColor = 'rgba(0, 0, 0, 0.72)'
+  context.shadowBlur = unit * 0.012
+
+  context.font = `700 ${tagFont}px ui-sans-serif, system-ui, sans-serif`
+  // Match the orange identity used by Benchmark Lab share cards so exported
+  // replays read as part of the same Lumen Apeiron publishing system.
+  context.fillStyle = 'rgba(255, 116, 72, 0.98)'
+  context.fillText('LUMEN APEIRON', margin, margin)
+  context.font = `600 ${detailFont}px ui-sans-serif, system-ui, sans-serif`
+  context.fillStyle = 'rgba(217, 231, 255, 0.78)'
+  context.fillText('CREATION REPLAY', margin, margin + tagFont * 1.45)
+
+  const textWidth = width - margin * 2
+  context.font = `650 ${captionFont}px ui-sans-serif, system-ui, sans-serif`
+  const lines = fitCaptionLines(context, caption, textWidth, 2)
+  const lineHeight = captionFont * 1.18
+  const blockHeight = Math.max(1, lines.length) * lineHeight
+  const captionY = height - margin - blockHeight - unit * 0.045
+  const gradient = context.createLinearGradient(
+    0,
+    captionY - unit * 0.08,
+    0,
+    height,
+  )
+  gradient.addColorStop(0, 'rgba(3, 7, 14, 0)')
+  gradient.addColorStop(0.42, 'rgba(3, 7, 14, 0.58)')
+  gradient.addColorStop(1, 'rgba(3, 7, 14, 0.9)')
+  context.shadowBlur = 0
+  context.fillStyle = gradient
+  context.fillRect(
+    0,
+    captionY - unit * 0.08,
+    width,
+    height - captionY + unit * 0.08,
+  )
+
+  context.shadowColor = 'rgba(0, 0, 0, 0.8)'
+  context.shadowBlur = unit * 0.012
+  context.font = `650 ${captionFont}px ui-sans-serif, system-ui, sans-serif`
+  context.fillStyle = 'rgba(255, 255, 255, 0.98)'
+  lines.forEach((line, index) => {
+    context.fillText(line, margin, captionY + index * lineHeight)
+  })
+
+  const step = Math.max(0, frame.actionIndex + 1)
+  context.font = `600 ${detailFont}px ui-monospace, SFMono-Regular, monospace`
+  context.fillStyle = 'rgba(217, 231, 255, 0.78)'
+  context.textAlign = 'right'
+  context.fillText(
+    `${String(step).padStart(2, '0')} / ${String(frame.totalActions).padStart(2, '0')}`,
+    width - margin,
+    height - margin - detailFont,
+  )
+
+  const progressY = height - unit * 0.012
+  context.shadowBlur = 0
+  context.fillStyle = 'rgba(255, 255, 255, 0.18)'
+  context.fillRect(0, progressY, width, unit * 0.012)
+  context.fillStyle = 'rgba(255, 116, 72, 0.96)'
+  context.fillRect(
+    0,
+    progressY,
+    width * Math.min(1, Math.max(0, frame.progress)),
+    unit * 0.012,
+  )
+  context.restore()
+}
+
+export function replayVideoFileName(session: RecordedSession): string {
+  const raw = session.initial.metadata?.name?.trim() || 'flame'
+  const safe = raw.replace(/[^a-zA-Z0-9._-]+/g, '-').replace(/^-+|-+$/g, '')
+  return `${safe || 'flame'}-creation-replay`
+}

--- a/packages/app/src/recorder/replayVideo.ts
+++ b/packages/app/src/recorder/replayVideo.ts
@@ -97,7 +97,9 @@ function nextSetterValue<T>(current: T, next: T | ((value: T) => T)): T {
   return typeof next === 'function' ? (next as (value: T) => T)(current) : next
 }
 
-function initialTimelineSnapshot(session: RecordedSession): TimelineSnapshot {
+export function replayVideoInitialTimelineSnapshot(
+  session: RecordedSession,
+): TimelineSnapshot {
   if (session.initialTimeline) return deepClone(session.initialTimeline)
   return {
     config: { ...defaultTimelineConfig(), timeScale: 1 },
@@ -466,7 +468,7 @@ export function createReplayVideoDriver(
 
   let flame = deepClone(session.initial)
   const timeline: MutableTimeline = {
-    snapshot: initialTimelineSnapshot(session),
+    snapshot: replayVideoInitialTimelineSnapshot(session),
   }
   let view = initialViewSnapshot(session)
   let audio = initialAudioSnapshot(session)
@@ -774,7 +776,7 @@ export function createReplayVideoDriver(
 
   function reset(): ReplayVideoFrameState {
     flame = deepClone(session.initial)
-    timeline.snapshot = initialTimelineSnapshot(session)
+    timeline.snapshot = replayVideoInitialTimelineSnapshot(session)
     view = initialViewSnapshot(session)
     audio = initialAudioSnapshot(session)
     sonification =
@@ -856,7 +858,7 @@ export function createReplayVideoJobSpec(
   const driver = createReplayVideoDriver(session)
   const initial = driver.reset()
   assertReplayVideoStatePortable(initial, -1)
-  const timeline = initialTimelineSnapshot(session)
+  const timeline = replayVideoInitialTimelineSnapshot(session)
   return {
     name: replayVideoFileName(session),
     flame: deepClone(session.initial),
@@ -1026,8 +1028,11 @@ export function drawReplayVideoOverlay(
   context.restore()
 }
 
-export function replayVideoFileName(session: RecordedSession): string {
+export function replayVideoFileName(
+  session: RecordedSession,
+  mode: 'artwork' | 'interface' = 'artwork',
+): string {
   const raw = session.initial.metadata?.name?.trim() || 'flame'
   const safe = raw.replace(/[^a-zA-Z0-9._-]+/g, '-').replace(/^-+|-+$/g, '')
-  return `${safe || 'flame'}-creation-replay`
+  return `${safe || 'flame'}-${mode === 'interface' ? 'interface' : 'creation'}-replay`
 }

--- a/packages/app/src/recorder/replayVideo.ts
+++ b/packages/app/src/recorder/replayVideo.ts
@@ -23,7 +23,17 @@ import type { HistorySetter } from '@/utils/createStoreHistory'
 import type { AnimationJobSpec } from '@/utils/exportJobs'
 
 export const REPLAY_VIDEO_FPS = 24
-export const REPLAY_VIDEO_SIZE = 1080
+/**
+ * Artwork replays use the same landscape framing the editor is authored in.
+ * Camera2D fixes the vertical world extent and widens horizontally with the
+ * canvas aspect, so rendering onto a square plate crops the left and right of
+ * an otherwise unchanged flame. Keep this explicit until composition presets
+ * can offer deliberate fit/crop controls for square and portrait exports.
+ */
+export const REPLAY_VIDEO_DIMENSIONS = {
+  width: 1920,
+  height: 1080,
+} as const
 export const REPLAY_VIDEO_LEAD_IN_MS = 650
 export const REPLAY_VIDEO_TAIL_MS = 1400
 export const MAX_REPLAY_VIDEO_DURATION_MS = 120_000
@@ -863,7 +873,7 @@ export function createReplayVideoJobSpec(
     name: replayVideoFileName(session),
     flame: deepClone(session.initial),
     quality: 0.9,
-    dimensions: { width: REPLAY_VIDEO_SIZE, height: REPLAY_VIDEO_SIZE },
+    dimensions: { ...REPLAY_VIDEO_DIMENSIONS },
     fps: schedule.fps,
     frameStart: 0,
     frameEnd: schedule.totalFrames - 1,

--- a/packages/app/src/utils/exportJobs.ts
+++ b/packages/app/src/utils/exportJobs.ts
@@ -4,6 +4,7 @@ import type { TimelineConfig, TimelineTrack } from './timeline'
 import type { VideoEncoderConfig } from './videoEncoder'
 import type { Palette } from '@/flame/colorMap'
 import type { FlameDescriptor } from '@/flame/schema/flameSchema'
+import type { ReplayVideoSpec } from '@/recorder/replayVideo'
 import type { RecordedSession } from '@/recorder/schema'
 
 /**
@@ -70,6 +71,8 @@ export type AnimationJobSpec = {
   config: TimelineConfig
   /** Recording association captured when the job was enqueued. */
   session: RecordedSession | undefined
+  /** Present for a branded creation replay rather than a timeline render. */
+  replayVideo?: ReplayVideoSpec
   audioBuffer?: AudioBuffer
   audioMapping?: AudioMappingEntry[]
 }

--- a/packages/app/src/utils/sessionsDB.test.ts
+++ b/packages/app/src/utils/sessionsDB.test.ts
@@ -4,7 +4,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 import { examples } from '@/flame/examples'
 import { MAX_ACTION_NOTE_CHARS, SESSION_FORMAT_VERSION, } from '@/recorder/schema'
 import { deepClone } from './clone'
-import { loadStoredSessions, storeSession } from './sessionsDB'
+import { loadStoredSessions, storeImportedSession, storeSession, } from './sessionsDB'
 import type { RecordedSession } from '@/recorder/schema'
 
 function validSession(): RecordedSession {
@@ -38,6 +38,39 @@ describe('recording session persistence boundary', () => {
     expect(stored[0]?.name).toBe('Bounded recording')
     expect(stored[0]?.actionCount).toBe(1)
     expect(stored[0]?.session.actions[0]?.id).toBe('flame.setGamma')
+  })
+
+  it('imports the same take once and derives a readable name from its file', async () => {
+    const session = validSession()
+
+    const [first, second] = await Promise.all([
+      storeImportedSession(session, 'Flame creation.steps.json'),
+      storeImportedSession(deepClone(session), 'Renamed copy.steps.json'),
+    ])
+
+    expect([first.added, second.added].sort()).toEqual([false, true])
+    expect(first.name).toBe(second.name)
+    expect(['Flame creation', 'Renamed copy']).toContain(first.name)
+    await expect(loadStoredSessions()).resolves.toHaveLength(1)
+  })
+
+  it('keeps an edited import as a distinct recording', async () => {
+    const original = validSession()
+    const edited = deepClone(original)
+    edited.actions[0] = {
+      ...edited.actions[0]!,
+      note: 'Hold on the final color',
+    }
+
+    await storeImportedSession(original, 'Original.steps.json')
+    const result = await storeImportedSession(edited, 'Captioned.steps.json')
+
+    expect(result.added).toBe(true)
+    await expect(
+      loadStoredSessions().then((sessions) =>
+        sessions.map((entry) => entry.name).sort(),
+      ),
+    ).resolves.toEqual(['Captioned', 'Original'])
   })
 
   it('rejects an invalid session before writing to IndexedDB', async () => {

--- a/packages/app/src/utils/sessionsDB.ts
+++ b/packages/app/src/utils/sessionsDB.ts
@@ -27,6 +27,12 @@ export type StoredSession = {
  *  cannot grow without bound across a long project. */
 export const MAX_STORED_SESSIONS = 100
 
+export type ImportedSessionResult = {
+  added: boolean
+  /** The existing entry's name when an identical take was already stored. */
+  name: string
+}
+
 class SessionsDatabase extends Dexie {
   sessions!: Dexie.Table<StoredSession, number>
 
@@ -38,13 +44,7 @@ class SessionsDatabase extends Dexie {
 
 const db = new SessionsDatabase()
 
-/** Newest first. */
-export async function loadStoredSessions(): Promise<StoredSession[]> {
-  const rows = await db.sessions
-    .orderBy('timestamp')
-    .reverse()
-    .limit(MAX_STORED_SESSIONS)
-    .toArray()
+function validatedStoredSessions(rows: StoredSession[]): StoredSession[] {
   return rows.flatMap((row) => {
     const session = validateSession(row.session)
     return session === undefined
@@ -60,6 +60,35 @@ export async function loadStoredSessions(): Promise<StoredSession[]> {
   })
 }
 
+async function pruneStoredSessions() {
+  const all = await db.sessions.orderBy('timestamp').reverse().toArray()
+  const surplus = all.slice(MAX_STORED_SESSIONS)
+  if (surplus.length > 0) {
+    await db.sessions.bulkDelete(surplus.flatMap((e) => (e.id ? [e.id] : [])))
+  }
+}
+
+async function addStoredSession(session: RecordedSession, name: string) {
+  await db.sessions.add({
+    name,
+    timestamp: Date.now(),
+    actionCount: session.actions.length,
+    unnamedWriteCount: session.unnamedWriteCount,
+    session,
+  })
+  await pruneStoredSessions()
+}
+
+/** Newest first. */
+export async function loadStoredSessions(): Promise<StoredSession[]> {
+  const rows = await db.sessions
+    .orderBy('timestamp')
+    .reverse()
+    .limit(MAX_STORED_SESSIONS)
+    .toArray()
+  return validatedStoredSessions(rows)
+}
+
 export async function storeSession(
   session: RecordedSession,
   name: string,
@@ -71,19 +100,81 @@ export async function storeSession(
   if (validated === undefined) {
     throw new Error('Cannot store an invalid recording session')
   }
-  await db.sessions.add({
-    name,
-    timestamp: Date.now(),
-    actionCount: validated.actions.length,
-    unnamedWriteCount: validated.unnamedWriteCount,
-    session: validated,
+  await db.transaction('rw', db.sessions, async () => {
+    await addStoredSession(validated, name)
   })
-  const all = await db.sessions.orderBy('timestamp').reverse().toArray()
-  const surplus = all.slice(MAX_STORED_SESSIONS)
-  if (surplus.length > 0) {
-    await db.sessions.bulkDelete(surplus.flatMap((e) => (e.id ? [e.id] : [])))
-  }
   return loadStoredSessions()
+}
+
+/**
+ * Imports a recording without filling the library with duplicates when the
+ * same file is opened more than once. The comparison uses the fully validated
+ * session value, so caption edits and other authored changes remain distinct
+ * recordings even when they share the same creation timestamp.
+ */
+export async function storeImportedSession(
+  session: RecordedSession,
+  sourceFileName: string,
+): Promise<ImportedSessionResult> {
+  const validated = validateSession(session)
+  if (validated === undefined) {
+    throw new Error('Cannot import an invalid recording session')
+  }
+
+  const encoded = JSON.stringify(validated)
+  const importedName = importedSessionName(sourceFileName, validated)
+  let added = false
+  let resolvedName = importedName
+
+  // The read and conditional add share one IndexedDB transaction, so two
+  // simultaneous drops of the same take cannot race into duplicate rows.
+  await db.transaction('rw', db.sessions, async () => {
+    const rows = await db.sessions
+      .orderBy('timestamp')
+      .reverse()
+      .limit(MAX_STORED_SESSIONS)
+      .toArray()
+    // Creation time and the cheap denormalised counters reduce an exact
+    // compare to the handful of plausible matches. Avoid serialising every
+    // potentially multi-megabyte take in a full library on each import.
+    const existing = validatedStoredSessions(rows)
+      .filter(
+        (entry) =>
+          entry.session.createdAt === validated.createdAt &&
+          entry.actionCount === validated.actions.length &&
+          entry.unnamedWriteCount === validated.unnamedWriteCount,
+      )
+      .find((entry) => JSON.stringify(entry.session) === encoded)
+    if (existing) {
+      resolvedName = existing.name
+      return
+    }
+
+    await addStoredSession(validated, importedName)
+    added = true
+  })
+
+  return {
+    added,
+    name: resolvedName,
+  }
+}
+
+export function importedSessionName(
+  sourceFileName: string,
+  session: RecordedSession,
+): string {
+  const stem = sourceFileName
+    .trim()
+    .replace(/\.steps\.json$/i, '')
+    .replace(/\.(?:json|png|mp4)$/i, '')
+    .trim()
+  if (stem !== '') return stem
+
+  const flameName = session.initial.metadata?.name?.trim()
+  if (flameName) return flameName
+
+  return `Recording ${session.createdAt.slice(0, 16).replace('T', ' ')}`
 }
 
 export async function deleteStoredSession(

--- a/packages/app/src/utils/useAppDragAndDrop.test.ts
+++ b/packages/app/src/utils/useAppDragAndDrop.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from 'vitest'
+import { examples } from '@/flame/examples'
+import { SESSION_FORMAT_VERSION } from '@/recorder/schema'
+import { deepClone } from './clone'
+import { useAppDragAndDrop } from './useAppDragAndDrop'
+import type { RecordedSession } from '@/recorder/schema'
+
+const { loadFlameFromFileMock } = vi.hoisted(() => ({
+  loadFlameFromFileMock: vi.fn(),
+}))
+
+vi.mock('@/utils/useLoadFlameFromFile', () => ({
+  useLoadFlameFromFile: () => loadFlameFromFileMock,
+}))
+
+function session(): RecordedSession {
+  return {
+    version: SESSION_FORMAT_VERSION,
+    app: { version: 'test', flameSchemaVersion: 'test' },
+    createdAt: '2026-08-21T12:00:00.000Z',
+    initial: deepClone(examples.example1),
+    actions: [],
+    unnamedWriteCount: 0,
+  }
+}
+
+describe('useAppDragAndDrop recording imports', () => {
+  it('passes the source file with a dropped steps session', async () => {
+    const droppedSession = session()
+    const sourceFile = new File(['steps'], 'Dropped take.steps.json')
+    loadFlameFromFileMock.mockResolvedValue({ session: droppedSession })
+    const onSessionDropped = vi.fn()
+    const onDrop = useAppDragAndDrop(
+      { replace: vi.fn() },
+      vi.fn(),
+      onSessionDropped,
+    )
+
+    await onDrop(sourceFile)
+
+    expect(onSessionDropped).toHaveBeenCalledWith(droppedSession, sourceFile)
+  })
+})

--- a/packages/app/src/utils/useAppDragAndDrop.ts
+++ b/packages/app/src/utils/useAppDragAndDrop.ts
@@ -11,8 +11,11 @@ export function useAppDragAndDrop(
     flame: FlameDescriptor
     tracks: TimelineTrack[]
   }) => void,
-  /** Offered the session a dropped PNG carried, if any (M5). */
-  onSessionDropped?: (session: RecordedSession) => void,
+  /** Offered the session and source file carried by a dropped artifact. */
+  onSessionDropped?: (
+    session: RecordedSession,
+    sourceFile: File,
+  ) => Promise<void> | void,
 ) {
   const loadFlameFromFile = useLoadFlameFromFile()
 
@@ -22,7 +25,7 @@ export function useAppDragAndDrop(
     // A bare .steps.json carries no flame: there is nothing to load, only a
     // session to offer against whatever is already open.
     if (!result.flame) {
-      if (result.session) onSessionDropped?.(result.session)
+      if (result.session) await onSessionDropped?.(result.session, file)
       return
     }
     const flame = result.flame
@@ -45,7 +48,7 @@ export function useAppDragAndDrop(
     })
     // After the flame is in place, so replaying starts from the same
     // document the file describes.
-    if (result.session) onSessionDropped?.(result.session)
+    if (result.session) await onSessionDropped?.(result.session, file)
   }
 
   return onDrop


### PR DESCRIPTION
## Summary\n\n- keep the deterministic Artwork export: a landscape 1920 × 1080 branded flame video with edited captions, authored holds, replay speed, and embedded recorder metadata\n- preserve the editor camera's landscape framing instead of cropping it into a square plate\n- add a Full interface export that records the actual in-app replay, including the live WebGPU flame, editor panels, timeline, follow-cam spotlight, captions, and recorder presentation\n- guide the browser capture flow toward This Tab, fail clearly when the chosen surface is invalid, and restore the replay/editor state cleanly after capture or cancellation\n- snapshot recorder-session metadata when export starts so later edits cannot change the video association\n- import opened, dropped, and embedded recorder sessions into Recordings automatically, deduplicating exact reimports while preserving edited variants\n- protect recorder controls while capture is active and document the staged social-video roadmap\n\n## Verification\n\n- pnpm test: 129 test files / 1,772 tests, plus 4 script tests\n- recorder import/library/replay coverage: 23 files / 290 tests\n- focused import and deduplication coverage: 4 files / 34 tests\n- full lint\n- exact app TypeScript check\n- Prettier check\n- WGSL validation\n- production app build\n- Chromium smoke: 7 tests\n- recorder UI design detector\n- git diff --check\n- repository pre-push gate\n\n## Export modes\n\n- **Artwork** — deterministic 1920 × 1080, 24 fps MP4 rendered in the background export queue. Its 16:9 plate preserves the full landscape flame framing, leaves the live editor untouched, and is ideal for a clean, minimal post.\n- **Full interface** — real-time capture of the current browser tab while the normal replay runs. It preserves the complete editor, timeline, spotlight, captions, and flame exactly as shown in the app. Choose **This Tab** in the browser prompt. MP4 is used when the browser supports it, with WebM fallback.\n\nFull-interface capture requires the standard browser screen-share permission each time. Artwork export remains silent and rejects unbundled custom WGSL variations until recorder sessions can package those definitions safely.\n\nOpening a valid recorder session now means importing it into Recordings and opening it. Exact repeats reuse the existing entry; captioned or otherwise edited variants remain separate so no authored replay is lost.