### PR TITLE
fix(arcade): stop calling the WebMCP fallback a dev mock in production

### DIFF
--- a/packages/app/src/components/Arcade/WebMcpStatusPill.test.tsx
+++ b/packages/app/src/components/Arcade/WebMcpStatusPill.test.tsx
@@ -1,0 +1,66 @@
+import { cleanup, render, screen } from '@solidjs/testing-library'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { webMcpStatusLabel, WebMcpStatusPill } from './WebMcpStatusPill'
+
+const withMock = (installed: boolean) => {
+  const win = window as unknown as { webmcp?: unknown }
+  if (installed) win.webmcp = {}
+  else delete win.webmcp
+}
+
+describe('webMcpStatusLabel', () => {
+  it('names the dev mock only in a development build', () => {
+    expect(webMcpStatusLabel('mock', true)).toBe('WebMCP dev mock active')
+    expect(webMcpStatusLabel('mock', false)).toBe(
+      'WebMCP not detected in this browser',
+    )
+  })
+
+  it('words the other two states the same either way', () => {
+    for (const isDev of [true, false]) {
+      expect(webMcpStatusLabel('detected', isDev)).toBe('WebMCP detected')
+      expect(webMcpStatusLabel('none', isDev)).toBe(
+        'WebMCP not detected in this browser',
+      )
+    }
+  })
+})
+
+describe('WebMcpStatusPill', () => {
+  afterEach(() => {
+    cleanup()
+    withMock(false)
+  })
+
+  it('publishes the raw state so tests can still see the mock', () => {
+    withMock(true)
+    render(() => <WebMcpStatusPill />)
+
+    // The label softens in production, but `data-state` never does: Playwright
+    // and the console read this, not the copy.
+    expect(screen.getByTestId('webmcp-status').dataset.state).toBe('mock')
+  })
+
+  it('does not call the fallback a dev mock in a production build', () => {
+    vi.stubEnv('DEV', false)
+    withMock(true)
+    render(() => <WebMcpStatusPill />)
+
+    expect(screen.getByTestId('webmcp-status').textContent).toContain(
+      'WebMCP not detected in this browser',
+    )
+    expect(screen.getByTestId('webmcp-status').textContent).not.toContain(
+      'dev mock',
+    )
+    vi.unstubAllEnvs()
+  })
+
+  it('keeps the browser instructions next to the label', () => {
+    render(() => <WebMcpStatusPill />)
+
+    const body = screen.getByTestId('webmcp-status').textContent ?? ''
+    expect(body).toContain("ChatGPT's desktop browser")
+    expect(body).toContain('Chrome 149+')
+    expect(body).toContain('chrome://flags/#enable-webmcp-testing')
+  })
+})

--- a/packages/app/src/components/Arcade/WebMcpStatusPill.tsx
+++ b/packages/app/src/components/Arcade/WebMcpStatusPill.tsx
@@ -3,10 +3,30 @@ import { detectWebMcp } from '@/arcade/webmcpDetect'
 import ui from './ArcadeHub.module.css'
 import type { WebMcpAvailability } from '@/arcade/webmcpDetect'
 
+const NOT_DETECTED = 'WebMCP not detected in this browser'
+
 const LABELS: Record<WebMcpAvailability, string> = {
   detected: 'WebMCP detected',
   mock: 'WebMCP dev mock active',
-  none: 'WebMCP not detected',
+  none: NOT_DETECTED,
+}
+
+/**
+ * What the pill says out loud.
+ *
+ * `registerWebMcp` installs the dev mock on `window.webmcp` for every browser
+ * without `document.modelContext`, so on a deployed URL the `mock` state means
+ * nothing more than "this browser has no WebMCP" — and saying "dev mock active"
+ * there tells a visitor the production site is a development build. The state
+ * itself stays `mock` and is still published as `data-state`, so Playwright and
+ * the console can tell the two apart.
+ */
+export function webMcpStatusLabel(
+  state: WebMcpAvailability,
+  isDev: boolean,
+): string {
+  if (state === 'mock' && !isDev) return NOT_DETECTED
+  return LABELS[state]
 }
 
 export function WebMcpStatusPill() {
@@ -21,7 +41,9 @@ export function WebMcpStatusPill() {
   })
   return (
     <details class={ui.pill} data-state={state()} data-testid="webmcp-status">
-      <summary aria-live="polite">{LABELS[state()]}</summary>
+      <summary aria-live="polite">
+        {webMcpStatusLabel(state(), import.meta.env.DEV)}
+      </summary>
       <div class={ui.pillBody}>
         <p>
           Open this page in ChatGPT's desktop browser, or in Chrome 149+ with{' '}


### PR DESCRIPTION
## Summary

On a deployed URL the Arcade status pill read "WebMCP dev mock active" in every browser without WebMCP, because `registerWebMcp` installs the `window.webmcp` mock whenever `document.modelContext` and `navigator.modelContext` are both missing. A judge opening the production link in plain Chrome or Safari was told the site is a development build.

Outside `import.meta.env.DEV` the pill now reads **"WebMCP not detected in this browser"** for that state. The state itself is unchanged: `detectWebMcp` still returns `mock`, and the pill still publishes `data-state="mock"`, so Playwright and the console can tell a mocked browser from a bare one.

The `none` label was reworded to the same sentence, so a visitor never sees two subtly different phrasings for the same fact. `detected` is untouched.

## What the pill says now

| State | Development | Production |
| --- | --- | --- |
| `detected` | WebMCP detected | WebMCP detected |
| `mock` | WebMCP dev mock active | WebMCP not detected in this browser |
| `none` | WebMCP not detected in this browser | WebMCP not detected in this browser |

The help text inside the pill is unchanged and still explains both routes to a real WebMCP browser: ChatGPT's desktop browser, or Chrome 149+ with `chrome://flags/#enable-webmcp-testing` enabled, plus the Model Context Tool Inspector extension and the WebGPU requirement. A test now pins that copy so it cannot be dropped by accident.

## Changes

- `packages/app/src/components/Arcade/WebMcpStatusPill.tsx` — new exported pure function `webMcpStatusLabel(state, isDev)`; the component calls it with `import.meta.env.DEV`. No change to detection, to `data-state`, or to the help text.
- `packages/app/src/components/Arcade/WebMcpStatusPill.test.tsx` (new) — 5 cases: the label in both environments for all three states; the rendered pill still exposes `data-state="mock"`; a `vi.stubEnv('DEV', false)` render asserts the production copy and that "dev mock" is absent; and the help text still names Chrome 149+, the flag URL and ChatGPT's desktop browser.

Verified the new render test is red against the previous behaviour: with the label call swapped back to the unconditional lookup it fails with `expected 'WebMCP dev mock active...' to contain 'WebMCP not detected in this browser'`.

## Verification

| Command | Result |
| --- | --- |
| `pnpm typecheck` | pass, 0 errors |
| `pnpm lint` | 0 errors, 1 warning (pre-existing, `AncestryTreeModal.tsx:57`) |
| `pnpm --filter chaos-master exec vitest run src/components/Arcade src/arcade src/webmcp` | 17 files, 96 tests passed |
| `pnpm test:e2e -- tests/arcade.spec.ts` | 5 passed |

Branched off `main` at `b88c73d`.
