### PR TITLE
fix(arena): use real variation names in the opponent archetypes

### DIFF
--- a/packages/app/src/webmcp/tools/arenaArchetypes.test.ts
+++ b/packages/app/src/webmcp/tools/arenaArchetypes.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from 'vitest'
+import { transformVariations } from '@/flame/variations'
+import { transformVariations3D } from '@/flame/variations3D'
 import { ARCHETYPE_IDS, ARENA_ARCHETYPES, generateArchetypeOpponent, TACTICAL_STANCES, } from './arenaArchetypes'
 import type { FlameDescriptor } from '@/flame/schema/flameSchema'
 
@@ -68,6 +70,25 @@ describe('arenaArchetypes', () => {
       expect(arch.lore.length).toBeGreaterThan(10)
       expect(arch.allowedVariations.length).toBeGreaterThan(0)
     }
+  })
+
+  // Regression guard: the archetype pools once held bare Apophysis names
+  // ("cross", "polar", "julia"), none of which exist in the registry — the
+  // generated opponents carried variation types the shader compiler could not
+  // resolve, and every clash logged
+  //   [createFlameWgsl] skipping unsupported variation type "cross"
+  // then saved the broken flame to Recents so it resurfaced on every reload.
+  it('only lists variation names that exist in the live registries', () => {
+    const known = new Set([
+      ...Object.keys(transformVariations),
+      ...Object.keys(transformVariations3D),
+    ])
+    const unknown = ARCHETYPE_IDS.flatMap((id) =>
+      ARENA_ARCHETYPES[id].allowedVariations
+        .filter((name) => !known.has(name))
+        .map((name) => `${id}: ${name}`),
+    )
+    expect(unknown).toEqual([])
   })
 
   it('defines tactical stances with distinct stat multipliers', () => {

--- a/packages/app/src/webmcp/tools/arenaArchetypes.ts
+++ b/packages/app/src/webmcp/tools/arenaArchetypes.ts
@@ -2,6 +2,8 @@ import { mutateFlameSeeded } from '@/flame/randomize'
 import { deepClone } from '@/utils/clone'
 import { calculateFlameStats } from '@/webmcp/tools/scoreFlame'
 import type { FlameDescriptor } from '@/flame/schema/flameSchema'
+import type { TransformVariationType } from '@/flame/variations'
+import type { TransformVariationType3D } from '@/flame/variations3D'
 
 export type TacticalStance = 'resonance' | 'bastion' | 'entropy' | 'balanced'
 
@@ -92,7 +94,17 @@ export interface OpponentArchetype {
   color: string
   paletteHue: number
   mutationStrength: number
-  allowedVariations: string[]
+  /**
+   * Variation pool `generateArchetypeOpponent` draws from. These must be live
+   * registry keys (`transformVariations` / `transformVariations3D`), i.e. the
+   * `…Var` / `…3D` names — NOT the bare Apophysis names (`polar`, `cross`).
+   * A bare name reaches the shader compiler unresolved, gets dropped with
+   * `[createFlameWgsl] skipping unsupported variation type "…"`, and is then
+   * persisted to Recents so it warns again on every reload. The type alone
+   * cannot enforce this (`TransformVariationType` carries a `string & {}`
+   * escape hatch), so `arenaArchetypes.test.ts` pins it against the registry.
+   */
+  allowedVariations: (TransformVariationType | TransformVariationType3D)[]
 }
 
 export const ARENA_ARCHETYPES: Record<ArchetypeId, OpponentArchetype> = {
@@ -105,14 +117,14 @@ export const ARENA_ARCHETYPES: Record<ArchetypeId, OpponentArchetype> = {
     paletteHue: 0.55,
     mutationStrength: 0.35,
     allowedVariations: [
-      'polar',
-      'polar2',
-      'julia',
-      'juliaN',
-      'cylinder',
-      'disc',
-      'square',
-      'cross',
+      'polarVar',
+      'polar2Var',
+      'juliaVar',
+      'juliaNVar',
+      'cylinderVar',
+      'discVar',
+      'squareVar',
+      'crossVar',
     ],
   },
   chaos_lord: {
@@ -124,14 +136,14 @@ export const ARENA_ARCHETYPES: Record<ArchetypeId, OpponentArchetype> = {
     paletteHue: 0.98,
     mutationStrength: 0.65,
     allowedVariations: [
-      'swirl',
-      'spherical',
-      'exponential',
-      'bubble',
-      'bent',
-      'waves',
-      'pdj',
-      'gaussian',
+      'swirlVar',
+      'sphericalVar',
+      'exponentialVar',
+      'bubbleVar',
+      'bentVar',
+      'wavesVar',
+      'pdjVar',
+      'gaussianVar',
     ],
   },
   spiral_leviathan: {
@@ -143,14 +155,14 @@ export const ARENA_ARCHETYPES: Record<ArchetypeId, OpponentArchetype> = {
     paletteHue: 0.5,
     mutationStrength: 0.45,
     allowedVariations: [
-      'spiral',
-      'swirl',
-      'rings',
-      'rings2',
-      'eyefish',
-      'fisheye',
-      'curl',
-      'waves',
+      'spiralVar',
+      'swirlVar',
+      'ringsVar',
+      'rings2Var',
+      'eyefishVar',
+      'fisheyeVar',
+      'curlVar',
+      'wavesVar',
     ],
   },
   quantum_siren: {
@@ -162,13 +174,16 @@ export const ARENA_ARCHETYPES: Record<ArchetypeId, OpponentArchetype> = {
     paletteHue: 0.78,
     mutationStrength: 0.5,
     allowedVariations: [
-      'ex',
-      'diamond',
-      'handkerchief',
-      'heart',
-      'starfield',
-      'cylinder',
-      'bubble',
+      'exVar',
+      'diamondVar',
+      'handkerchiefVar',
+      'heartVar',
+      // `starfield` is 3D-only (`starfield3D`). `noiseVar` is the 2D registry's
+      // stochastic scatter — the nearest kin to starfield's randomized point
+      // cloud, and it reads as the Siren's flickering probability field.
+      'noiseVar',
+      'cylinderVar',
+      'bubbleVar',
     ],
   },
   solar_seraph: {
@@ -180,12 +195,15 @@ export const ARENA_ARCHETYPES: Record<ArchetypeId, OpponentArchetype> = {
     paletteHue: 0.12,
     mutationStrength: 0.4,
     allowedVariations: [
-      'sinusoidal',
-      'spherical',
-      'linear',
-      'linearT',
-      'hemisphere',
-      'cylinder',
+      'sinusoidalVar',
+      'sphericalVar',
+      'linearVar',
+      'linearTVar',
+      // `hemisphere` is 3D-only (`hemisphere3D`, `pos / sqrt(|pos|² + 1)`).
+      // `bubbleVar` is the same dome projection in 2D — a bounded radiant orb,
+      // which is exactly the Seraph's solar disc.
+      'bubbleVar',
+      'cylinderVar',
     ],
   },
   void_stalker: {
@@ -197,13 +215,13 @@ export const ARENA_ARCHETYPES: Record<ArchetypeId, OpponentArchetype> = {
     paletteHue: 0.85,
     mutationStrength: 0.55,
     allowedVariations: [
-      'spherical',
-      'scry',
-      'power',
-      'eyefish',
-      'fisheye',
-      'square',
-      'cross',
+      'sphericalVar',
+      'scryVar',
+      'powerVar',
+      'eyefishVar',
+      'fisheyeVar',
+      'squareVar',
+      'crossVar',
     ],
   },
 }


### PR DESCRIPTION
## What was broken

`ARENA_ARCHETYPES` in `packages/app/src/webmcp/tools/arenaArchetypes.ts` gives each of the six Flame Clash opponents an `allowedVariations` pool. That pool is handed straight to `mutateFlameSeeded` (`packages/app/src/flame/randomize.ts`) as the set of variation types a generated opponent may use.

Every one of the 44 names in those six pools was a bare Apophysis/flam3 name — `linear`, `polar`, `julia`, `swirl`, `spherical`, `cross`, … — but the app's 2D registry keys all end in `Var` (`linearVar`, `polarVar`, `juliaVar`, …). Checked against the live registries, **0 of 44 existed** in `transformVariations` or `transformVariations3D`.

So every generated opponent carried variation types the shader compiler could not resolve. `createFlameWgsl` filters them out and logs:

```
[createFlameWgsl] skipping unsupported variation type "cross"
```

Those flames are then saved to Recents, so the warning resurfaces on every later load or replay — and the opponent renders with a fraction of the variations its archetype was supposed to give it.

Two of the names (`starfield`, `hemisphere`) have no 2D equivalent at all; they exist only as `starfield3D` / `hemisphere3D`.

## How it was verified

Measured by driving the real generator over a bundled example flame (`example1`), 6 archetypes x 5 seeds, and counting both unresolvable descriptor types and the actual `createFlameWgsl` warnings:

| | generated variations | unresolvable | shader warnings |
|---|---|---|---|
| before | 258 | **78** | **78** |
| after | 256 | **0** | **0** |

## Mapping applied

Names were converted with `resolveVariationType` from `packages/app/src/flame/flameXml.ts` — the registry-derived Apophysis-name resolver the `.flame` importer already uses — rather than hand-mapped. It resolves 42 of the 44 unambiguously.

| archetype | before | after |
|---|---|---|
| Symmetry Monolith | `polar`, `polar2`, `julia`, `juliaN`, `cylinder`, `disc`, `square`, `cross` | `polarVar`, `polar2Var`, `juliaVar`, `juliaNVar`, `cylinderVar`, `discVar`, `squareVar`, `crossVar` |
| Chaos Lord | `swirl`, `spherical`, `exponential`, `bubble`, `bent`, `waves`, `pdj`, `gaussian` | `swirlVar`, `sphericalVar`, `exponentialVar`, `bubbleVar`, `bentVar`, `wavesVar`, `pdjVar`, `gaussianVar` |
| Spiral Leviathan | `spiral`, `swirl`, `rings`, `rings2`, `eyefish`, `fisheye`, `curl`, `waves` | `spiralVar`, `swirlVar`, `ringsVar`, `rings2Var`, `eyefishVar`, `fisheyeVar`, `curlVar`, `wavesVar` |
| Quantum Siren | `ex`, `diamond`, `handkerchief`, `heart`, **`starfield`**, `cylinder`, `bubble` | `exVar`, `diamondVar`, `handkerchiefVar`, `heartVar`, **`noiseVar`**, `cylinderVar`, `bubbleVar` |
| Solar Seraph | **`sinusoidal`**, `spherical`, `linear`, `linearT`, **`hemisphere`**, `cylinder` | **`sinusoidalVar`**, `sphericalVar`, `linearVar`, `linearTVar`, **`bubbleVar`**, `cylinderVar` |
| Void Stalker | `spherical`, `scry`, `power`, `eyefish`, `fisheye`, `square`, `cross` | `sphericalVar`, `scryVar`, `powerVar`, `eyefishVar`, `fisheyeVar`, `squareVar`, `crossVar` |

### The three judgement calls

**`starfield` -> `noiseVar`** (Quantum Siren). No 2D `starfield` exists. `starfield3D` discards its input and scatters points onto ~240 fixed random directions — a stochastic scatter, categorised `'blur'`. `noiseVar` is the 2D registry's stochastic scatter (random radius x random angle) and is the closest kin. It also matches the Siren's lore directly: "flickering through overlapping probability fields". `starBlurVar` was considered and rejected — despite the name it fills a solid star polygon, it is not a scattered field.

**`hemisphere` -> `bubbleVar`** (Solar Seraph). No 2D `hemisphere` exists. `hemisphere3D` is `pos / sqrt(|pos|² + 1)` — a radial projection onto a dome. `bubbleVar` is `pos · w/((x²+y²)/4 + 1)`, the same dome-projection family in 2D, and it renders as a bounded radiant orb, which is exactly the Seraph's solar disc.

**`sinusoidal` -> `sinusoidalVar`, not `sinVar`.** This is the one place the mapping deliberately departs from `resolveVariationType`. That function returns `sinVar` because of a `FLAM3_ALIASES` entry whose comment says *"registry has no sinusoidalVar"*. That is no longer true: `sinusoidalVar` exists and is exactly flam3's `(sin x, sin y)`, whereas `sinVar` is the complex sine `(sin x · cosh y, cos x · sinh y)` — a different variation. The Seraph gets the mathematically correct one.

> Side finding, **not** changed here: that stale alias means `.flame` import still maps flam3's `sinusoidal` to `sinVar` rather than `sinusoidalVar`. Worth a separate look — fixing it changes import output for existing files, which does not belong in this PR.

## Type tightening

`allowedVariations` went from `string[]` to `(TransformVariationType | TransformVariationType3D)[]`, matching `GenerateRandomFlameConfig.allowedVariations` in `randomize.ts`. It compiles cleanly and required no refactor.

Being honest about what it buys: **nothing at compile time.** `TransformVariationType` is declared as `…literal | (string & {})`, so it widens to `string` and any typo still type-checks. The change is documentation — it points a reader at the registry types and aligns the declaration with its consumer. The real guard is the test.

## Test

`arenaArchetypes.test.ts` gains one case asserting every archetype entry exists in the union of the live 2D and 3D registries. Against the unfixed code it fails listing all 44 offenders:

```
AssertionError: expected [ 'symmetry_monolith: polar', …(43) ] to deeply equal []
+   "symmetry_monolith: polar",
+   "symmetry_monolith: polar2",
    ... (44 entries)
+   "void_stalker: cross",
```

## Verification

Run from the worktree root, all passing:

| command | result |
|---|---|
| `pnpm typecheck` | pass, no errors |
| `pnpm lint` | exit 0 (1 pre-existing warning in `AncestryTreeModal.tsx`, untouched) |
| `pnpm validate-wgsl` | `OK — no WGSL reserved words found in struct property names.` |
| `pnpm --filter chaos-master exec vitest run` | 151 files, 1894 tests, all passed |

`git status --porcelain` is empty. Only the two files above changed.

`prettier --check` reports one pre-existing issue in `packages/app/src/arcade/guard.ts`, which is byte-identical to `origin/main` and untouched by this branch.

## On `VARIATION_2D_TO_3D_MAP` — checked, deliberately not changed

`VARIATION_2D_TO_3D_MAP` in `packages/app/src/flame/transformFunction3D.ts` has 52 keys and looks like it has the same problem. It does not. Splitting the keys against the live registries:

- **11 are real 2D registry names** and are load-bearing: `bubbleVar`, `cylinderVar`, `cylinder2Var`, `cylinderApoVar`, `gaussianVar`, `blurVar`, `squareVar`, `scryVar`, `crossVar`, `curlVar`, `pdjVar`. In a 3D flame these upgrade a real 2D variation to its native 3D counterpart. Removing them would be a regression.
- **41 are bare Apophysis names** matching nothing in either registry (`linear`, `spherical`, `polar`, … plus `sphereVar`, which has no 2D definition either).

Are those 41 reachable? Scanning all 64 bundled example flames (379 variations): **zero** carry a bare type. Every other producer of variation types — the `.flame` importer via `resolveVariationType`, random generation via `variationTypes`/`variationTypes3D`, the registry itself — emits canonical names. The only path that ever fed bare names into a flame descriptor was `ARENA_ARCHETYPES`, and this PR closes it.

Note the asymmetry that hid the bug: in a **3D** flame, `resolveVariationType3D` silently rescued `cross` -> `cross3D` through this map; in a **2D** flame, `createFlameWgsl` has no such fallback and dropped it with the warning. That is why the symptom read as 2D-only.

So the map is not broken — the 41 bare keys are dead but harmless defensive fallbacks, and there is no evidence-backed reason to touch it. Left alone deliberately. If someone wants to prune them later that is a separate, purely cosmetic change.
