### PR TITLE
fix(arcade): Cinema playback polish — no looping, incremental keyframes, play on finish

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -5,7 +5,8 @@
       "name": "chaos-master-dev",
       "runtimeExecutable": "pnpm",
       "runtimeArgs": ["--filter", "chaos-master", "start"],
-      "port": 5173
+      "port": 5173,
+      "url": "https://localhost:5173"
     }
   ]
 }

--- a/packages/app/src/arcade/animatablePaths.test.ts
+++ b/packages/app/src/arcade/animatablePaths.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { createTestFlame } from '@/webmcp/testUtils'
 import { buildAnimatableCatalog, buildTimelineSnapshot, } from './animatablePaths'
+import type { TimelineTrack } from '@/utils/timeline'
 
 describe('animatable catalog', () => {
   const flame = createTestFlame()
@@ -51,7 +52,9 @@ describe('animatable catalog', () => {
       fps: 30,
       endFrame: 120,
       loopMode: 'seamless',
-      loop: true,
+      // Never on for an agent take: the GPU would run the animation for as
+      // long as the agent thinks about its next call.
+      loop: false,
     })
     expect(built.snapshot.tracks[0]).toMatchObject({
       parameterPath: 'camera.zoom',
@@ -60,6 +63,97 @@ describe('animatable catalog', () => {
       frame: 120,
       easing: 'linear',
       interp: 'linear',
+    })
+  })
+
+  it('merges with the tracks already placed when mode is "add"', () => {
+    const existing: TimelineTrack[] = [
+      {
+        parameterPath: 'exposure',
+        keyframes: [
+          { frame: 0, value: 0.25, easing: 'linear', interp: 'linear' },
+          { frame: 60, value: 0.5, easing: 'linear', interp: 'linear' },
+        ],
+      },
+      {
+        parameterPath: 'camera.zoom',
+        keyframes: [{ frame: 0, value: 1, easing: 'linear', interp: 'linear' }],
+      },
+    ]
+    const built = buildTimelineSnapshot(
+      {
+        durationFrames: 60,
+        mode: 'add',
+        tracks: [
+          {
+            path: 'camera.zoom',
+            keyframes: [
+              { frame: 0, value: 1 },
+              { frame: 60, value: 3 },
+            ],
+          },
+          { path: 't2.v2', keyframes: [{ frame: 30, value: 0.9 }] },
+        ],
+      },
+      catalog,
+      existing,
+    )
+    expect(built.ok).toBe(true)
+    if (!built.ok) return
+    expect(built.snapshot.tracks.map((t) => t.parameterPath)).toEqual([
+      'exposure',
+      'camera.zoom',
+      't2.v2',
+    ])
+    // The path sent this time wins, so a second pass is a correction rather
+    // than a duplicate track.
+    expect(built.snapshot.tracks[1]?.keyframes).toHaveLength(2)
+    expect(built.keyframeCount).toBe(5)
+  })
+
+  it('replaces everything when mode is left out', () => {
+    const built = buildTimelineSnapshot(
+      {
+        durationFrames: 60,
+        tracks: [{ path: 't2.v2', keyframes: [{ frame: 0, value: 0.7 }] }],
+      },
+      catalog,
+      [
+        {
+          parameterPath: 'exposure',
+          keyframes: [
+            { frame: 0, value: 0.25, easing: 'linear', interp: 'linear' },
+          ],
+        },
+      ] satisfies TimelineTrack[],
+    )
+    expect(built.ok).toBe(true)
+    if (!built.ok) return
+    expect(built.snapshot.tracks.map((t) => t.parameterPath)).toEqual(['t2.v2'])
+  })
+
+  it('refuses to cut an existing track short when adding', () => {
+    expect(
+      buildTimelineSnapshot(
+        {
+          durationFrames: 30,
+          mode: 'add',
+          tracks: [{ path: 't2.v2', keyframes: [{ frame: 0, value: 0.7 }] }],
+        },
+        catalog,
+        [
+          {
+            parameterPath: 'exposure',
+            keyframes: [
+              { frame: 0, value: 0.25, easing: 'linear', interp: 'linear' },
+              { frame: 90, value: 0.5, easing: 'linear', interp: 'linear' },
+            ],
+          },
+        ] satisfies TimelineTrack[],
+      ),
+    ).toMatchObject({
+      ok: false,
+      error: expect.stringContaining('would cut the existing track'),
     })
   })
 

--- a/packages/app/src/arcade/animatablePaths.ts
+++ b/packages/app/src/arcade/animatablePaths.ts
@@ -3,6 +3,7 @@ import { TIMELINE_PARAMETERS } from '@/utils/timeline'
 import * as v from '@/valibot'
 import type { FlameDescriptor } from '@/flame/schema/flameSchema'
 import type { TimelineSnapshot } from '@/flame/schema/timeline'
+import type { TimelineTrack } from '@/utils/timeline'
 
 export type CatalogType = 'number' | 'string' | 'color'
 export type CatalogEntry = {
@@ -146,6 +147,7 @@ export const SetKeyframesInput = v.object({
     v.maxValue(MAX_CINEMA_FRAMES),
   ),
   loopMode: v.optional(v.picklist(['off', 'seamless', 'cycle']), 'off'),
+  mode: v.optional(v.picklist(['replace', 'add']), 'replace'),
   tracks: v.pipe(
     v.array(TrackInput),
     v.nonEmpty(),
@@ -174,6 +176,17 @@ function valueType(value: unknown): CatalogType {
 export function buildTimelineSnapshot(
   raw: unknown,
   catalog: CatalogEntry[],
+  /**
+   * What the timeline already holds, for `mode: 'add'`.
+   *
+   * A whole animation arriving as one call is one step in the log and one
+   * thing for the viewer to watch, which is the wrong shape for both: the
+   * lesson reads as a single opaque jump, and nobody sees a beat land. Adding
+   * lets the agent send one idea at a time without resending everything it
+   * has already placed. A path present in both wins from the new call, so a
+   * second pass over the same track is a correction rather than a duplicate.
+   */
+  existingTracks: readonly TimelineTrack[] = [],
 ):
   | { ok: true; snapshot: TimelineSnapshot; keyframeCount: number }
   | { ok: false; error: string } {
@@ -228,27 +241,56 @@ export function buildTimelineSnapshot(
       keyframeCount++
     }
   }
+  const additions = input.tracks.map((track) => ({
+    parameterPath: track.path,
+    keyframes: track.keyframes.map((keyframe) => ({
+      frame: keyframe.frame,
+      value: keyframe.value,
+      easing: keyframe.easing ?? 'linear',
+      interp: keyframe.interp ?? 'linear',
+    })),
+  }))
+  const kept =
+    input.mode === 'add'
+      ? existingTracks.filter((track) => !seen.has(track.parameterPath))
+      : []
+  for (const track of kept) {
+    const last = track.keyframes.at(-1)
+    if (last !== undefined && last.frame > input.durationFrames) {
+      return {
+        ok: false,
+        error: `durationFrames ${input.durationFrames} would cut the existing track "${track.parameterPath}", which runs to frame ${last.frame}. Keep the same duration or send mode "replace".`,
+      }
+    }
+  }
+  const merged = [...kept, ...additions]
+  if (merged.length > MAX_CINEMA_TRACKS) {
+    return {
+      ok: false,
+      error: `That would leave ${merged.length} tracks; the limit is ${MAX_CINEMA_TRACKS}.`,
+    }
+  }
+  for (const track of kept) {
+    keyframeCount += track.keyframes.length
+  }
+
   const snapshot = {
     config: {
       fps: input.fps,
       timeScale: 1,
       startFrame: 0,
       endFrame: input.durationFrames,
-      loop: true,
+      // Never looping. An agent's preview plays once and stops, because the
+      // agent cannot see the result and would otherwise leave the GPU running
+      // the animation for the whole time it spends thinking about the next
+      // call. The viewer turns looping on themselves once the take is theirs.
+      loop: false,
       autoFps: false,
       loopMode: input.loopMode,
     },
     currentFrame: 0,
     animationEnabled: true,
-    tracks: input.tracks.map((track) => ({
-      parameterPath: track.path,
-      keyframes: track.keyframes.map((keyframe) => ({
-        frame: keyframe.frame,
-        value: keyframe.value,
-        easing: keyframe.easing ?? 'linear',
-        interp: keyframe.interp ?? 'linear',
-      })),
-    })),
+    tracks: merged,
   }
   const validated = tryValidateTimelineSnapshot(snapshot)
   if (!validated) {

--- a/packages/app/src/arcade/guard.test.ts
+++ b/packages/app/src/arcade/guard.test.ts
@@ -42,6 +42,16 @@ describe('guardCommand', () => {
       guardCommand('view.setQualityPreset', ['nonsense'], driving),
     ).toMatch(/Quality/)
   })
+  it('keeps timeline looping off while the agent drives', () => {
+    const state: PilotState = { ...driving, allowed: ['timeline.'] }
+    expect(guardCommand('timeline.setLoop', [true], state)).toMatch(
+      /Looping playback stays off/,
+    )
+    expect(guardCommand('timeline.setLoop', [], state)).toMatch(
+      /Looping playback stays off/,
+    )
+    expect(guardCommand('timeline.setLoop', [false], state)).toBeUndefined()
+  })
   it('locks point count, dimensions and quality render settings', () => {
     const state: PilotState = { ...driving, allowed: ['flame.'] }
     expect(

--- a/packages/app/src/arcade/guard.ts
+++ b/packages/app/src/arcade/guard.ts
@@ -39,6 +39,13 @@ export function guardCommand(
     const scope = state.topic ? `${state.mode}/${state.topic}` : state.mode
     return `${commandId} is not allowed in ${scope}. Allowed: ${state.allowed.join(', ')}`
   }
+  // Looping playback is the one transport setting that keeps the GPU busy
+  // indefinitely, and an agent has no way to see that it is happening: it
+  // would leave the animation running for the whole time it spends composing
+  // the next call. The viewer turns it on themselves afterwards.
+  if (commandId === 'timeline.setLoop' && args[0] !== false) {
+    return 'Looping playback stays off while the AI drives; the viewer can turn it on afterwards'
+  }
   if (commandId === 'view.setQualityPreset') {
     const rank = qualityRank(args[0])
     if (rank < 0 || rank > state.qualityRankAtStart) {
@@ -58,9 +65,7 @@ export function guardCommand(
     commandId === 'flame.updateRenderSettings' &&
     args[0] !== null &&
     typeof args[0] === 'object' &&
-    Object.keys(args[0]).some((key) =>
-      LOCKED_RENDER_SETTING.test(key),
-    )
+    Object.keys(args[0]).some((key) => LOCKED_RENDER_SETTING.test(key))
   ) {
     return 'Point count, dimensions and quality are locked while the AI drives'
   }

--- a/packages/app/src/arcade/topics.ts
+++ b/packages/app/src/arcade/topics.ts
@@ -142,7 +142,7 @@ ${WEBMCP_FALLBACK_NOTE}`
 export function cinemaPromptCard(description: string): string {
   const wish =
     description.trim() || 'a slow, cinematic move that suits this flame'
-  return `Animate my current flame in Lumen Apeiron: ${wish}. Call arcade_start_cinema, then arcade_get_animatable_paths to see what you can keyframe, then arcade_set_keyframes with tracks that realise the description (use easing, keep it under 10 seconds unless I say otherwise). Playback starts as soon as the keyframes land. Narrate your choices with arcade_narrate. Ask me if you want changes, and finish with arcade_end_cinema.
+  return `Animate my current flame in Lumen Apeiron: ${wish}. Call arcade_start_cinema, then arcade_get_animatable_paths to see what you can keyframe, then build the animation up with arcade_set_keyframes: one call per idea (camera move, then colour drift, then transform sway), each with mode "add" and the same durationFrames, so I watch each beat land and can replay it. Use easing, keep it under 10 seconds unless I say otherwise. Playback runs once per call. Narrate your choices with arcade_narrate. Ask me if you want changes, and finish with arcade_end_cinema.
 
 ${WEBMCP_FALLBACK_NOTE}`
 }

--- a/packages/app/src/components/Arcade/PilotOverlay.test.tsx
+++ b/packages/app/src/components/Arcade/PilotOverlay.test.tsx
@@ -10,6 +10,22 @@ const take = {
   actions: [{ t: 0, id: 'flame.setExposure', args: [0.3] }],
 } as unknown as RecordedSession
 
+function endCinema() {
+  startPilot({
+    mode: 'cinema',
+    title: 'Animating your flame',
+    stepBudget: 25,
+    allowed: ['timeline.'],
+    qualityRankAtStart: 1,
+  })
+  endPilot('finished', {
+    title: 'Pendulum waltz',
+    sessionName: 'Cinema: Pendulum waltz',
+    session: take,
+  })
+  notePilotSaveResult(true)
+}
+
 function endWithSave(saved: boolean) {
   startPilot({
     mode: 'teach',
@@ -49,6 +65,38 @@ describe('PilotOverlay end card', () => {
         'Could not save "Lesson: Colour and tone" to your library',
       ),
     ).toBeTruthy()
+  })
+
+  it('plays a Cinema take from the top once the card is dismissed', () => {
+    endCinema()
+    const ctx = createMockCommandContext()
+    ctx.timeline.tracks = () =>
+      [
+        {
+          parameterPath: 'camera.zoom',
+          keyframes: [
+            { frame: 0, value: 1, easing: 'linear', interp: 'linear' },
+          ],
+        },
+      ] as unknown as ReturnType<typeof ctx.timeline.tracks>
+    render(() => <PilotOverlay ctx={ctx} />)
+
+    screen.getByRole('button', { name: 'Play the animation' }).click()
+
+    // Looping stays off — the viewer gets one pass, not a take that runs
+    // until they find the transport.
+    expect(ctx.timeline.setLoop).toHaveBeenCalledWith(false)
+    expect(ctx.timeline.setCurrentFrame).toHaveBeenCalledWith(0)
+    expect(ctx.timeline.play).toHaveBeenCalled()
+    expect(screen.queryByRole('dialog')).toBeNull()
+  })
+
+  it('does not offer playback for a Teach take', () => {
+    endWithSave(true)
+    render(() => <PilotOverlay ctx={createMockCommandContext()} />)
+    expect(
+      screen.queryByRole('button', { name: 'Play the animation' }),
+    ).toBeNull()
   })
 
   it('offers Replay and the saved line after a successful save', () => {

--- a/packages/app/src/components/Arcade/PilotOverlay.tsx
+++ b/packages/app/src/components/Arcade/PilotOverlay.tsx
@@ -164,11 +164,33 @@ export function PilotOverlay(props: { ctx: CommandContext }) {
                 )}
               </Show>
               <div class={ui.endActions}>
+                <Show
+                  when={
+                    end().mode === 'cinema' &&
+                    props.ctx.timeline.tracks().length > 0
+                  }
+                >
+                  {/* The take is an animation nobody has watched at speed
+                      yet: playback during the session runs once per call and
+                      stops, and the card covers the canvas. This closes the
+                      card and plays it from the first frame. */}
+                  <button
+                    type="button"
+                    class={ui.primary}
+                    onClick={() => {
+                      resetPilot()
+                      props.ctx.timeline.setLoop(false)
+                      props.ctx.timeline.setCurrentFrame(0)
+                      props.ctx.timeline.play()
+                    }}
+                  >
+                    Play the animation
+                  </button>
+                </Show>
                 <Show when={lastPilotSession()}>
                   {(session) => (
                     <button
                       type="button"
-                      class={ui.primary}
                       // Offered even when the library write failed: the take
                       // is still in memory, so it is still replayable. The
                       // card says separately that it did not reach the library.

--- a/packages/app/src/recorder/recorder.ts
+++ b/packages/app/src/recorder/recorder.ts
@@ -1,4 +1,5 @@
 import { createSignal } from 'solid-js'
+import { agentDriving } from '@/arcade/pilot'
 import { latestSchemaVersion } from '@/flame/schema/flameSchema'
 import { deepClone } from '@/utils/clone'
 import { currentUndoSeq } from '@/utils/undoJournal'
@@ -782,6 +783,13 @@ export function reportTimelineWrite(description?: string): void {
  * the log and therefore skip this hook while `commandDepth > 0`. */
 export function reportTimelineTransport(description: string): void {
   if (commandDepth > 0 || suppressDepth > 0) return
+  // An Arcade pilot's playback is the tool's own preview, started so the
+  // viewer can see the animation, and the session deliberately does not claim
+  // to reproduce it — a replay applies the keyframes and leaves Play to the
+  // viewer. Counting it would mark every Cinema take as unfaithful for doing
+  // exactly what it was designed to do. A human scrubbing during their own
+  // recording is a different thing and still counts.
+  if (agentDriving()) return
   noteLiveWorkspaceMutation()
   if (!active) {
     invalidateLastFinishedSession()

--- a/packages/app/src/webmcp/testUtils.ts
+++ b/packages/app/src/webmcp/testUtils.ts
@@ -134,6 +134,7 @@ export function createMockCommandContext(): CommandContext {
       currentFrame: () => 0,
       setCurrentFrame: vi.fn(),
       play: vi.fn(),
+      setLoop: vi.fn(),
       edit: {
         snapshot: vi.fn(() => ({
           config: {

--- a/packages/app/src/webmcp/tools/arcadeCinema.ts
+++ b/packages/app/src/webmcp/tools/arcadeCinema.ts
@@ -70,7 +70,7 @@ export const arcadeStartCinema: WebMcpTool = {
       allowedCommands: describeAllowedCommands(allowed),
       tips: [
         'Call arcade_get_animatable_paths first.',
-        'arcade_set_keyframes replaces the whole animation; send all tracks each time.',
+        'Build the animation one idea at a time: arcade_set_keyframes with mode "add" per group of related tracks, keeping the same durationFrames. Each call is a step the viewer watches land and can replay.',
         'Keep it under 10 seconds unless asked; use easeInOut for camera moves.',
       ],
     }
@@ -166,7 +166,7 @@ export const arcadeGetAnimatablePaths: WebMcpTool = {
 export const arcadeSetKeyframes: WebMcpTool = {
   name: 'arcade_set_keyframes',
   description:
-    'Replace the animation with the given tracks (validated against arcade_get_animatable_paths) and start playing it. fps 1-60, durationFrames 2-1800, loopMode off|seamless|cycle, each track { path, keyframes: [{ frame, value, easing?, interp? }] }. Applied as one undoable, recorded step. Requires an active Cinema session.',
+    'Apply animation tracks (validated against arcade_get_animatable_paths) and play them once. mode "add" keeps the tracks already placed, "replace" (default) discards them. Prefer one call per idea: each is a recorded step the viewer watches land. fps 1-60, durationFrames 2-1800, track { path, keyframes: [{ frame, value, easing?, interp? }] }. Needs an active Cinema session.',
   inputSchema: {
     type: 'object',
     properties: {
@@ -176,6 +176,12 @@ export const arcadeSetKeyframes: WebMcpTool = {
       },
       durationFrames: { type: 'integer', description: 'Total frames, 2-1800' },
       loopMode: { type: 'string', enum: ['off', 'seamless', 'cycle'] },
+      mode: {
+        type: 'string',
+        enum: ['replace', 'add'],
+        description:
+          'add = merge with the tracks already placed (same path wins from this call); replace = start over (default)',
+      },
       play: {
         type: 'boolean',
         description: 'Start playback after applying (default true)',
@@ -226,6 +232,7 @@ export const arcadeSetKeyframes: WebMcpTool = {
     const built = buildTimelineSnapshot(
       input,
       buildAnimatableCatalog(ctx.flameDescriptor()),
+      ctx.timeline.tracks(),
     )
     if (!built.ok) return { error: built.error }
     const invalid = preflightReplayCommand('timeline.loadTimeline', [
@@ -260,7 +267,7 @@ export const arcadeSetKeyframes: WebMcpTool = {
       ),
       playing: play,
       remaining,
-      next: 'Narrate with arcade_narrate, refine by calling this again with all tracks, and finish with arcade_end_cinema.',
+      next: 'Narrate with arcade_narrate, add the next idea with mode "add", and finish with arcade_end_cinema.',
     }
   },
 }


### PR DESCRIPTION
Polish from watching Opus animate a flame in Cinema mode.

## Looping playback is off while the agent drives

The agent cannot see the canvas, so a looping preview is pure cost: with
`loop` on, the GPU runs the animation for the whole time the agent spends
composing its next call, and the viewer ends up with a take that never stops
on its own.

- The snapshot `arcade_set_keyframes` builds sets `loop: false`. Playback runs
  once and stops.
- `timeline.setLoop` is refused by the Arcade guard while a pilot drives, so
  the agent cannot turn it back on. The viewer still can, afterwards.
- Playback transport no longer counts against a take's fidelity. It is the
  tool's own preview, and a replay deliberately applies the keyframes and
  leaves Play to the viewer — counting it reported every Cinema take as
  unfaithful for doing exactly what it was designed to do.

## The animation can be built one idea at a time

`arcade_set_keyframes` takes `mode: "add"`, which keeps the tracks already
placed instead of replacing them. The agent can land the camera move, then
the colour drift, then the transform sway — each its own recorded step the
viewer watches land and can replay afterwards. A path sent twice wins from
the newer call, so a second pass over the same track is a correction rather
than a duplicate.

Adding refuses to cut an existing track short (a smaller `durationFrames`
than a placed track needs), and the merged track count is held to the same
`MAX_CINEMA_TRACKS` limit as a single call. The Cinema brief and the
`/arcade` prompt card both recommend the incremental shape; nothing enforces
it, so an agent that prefers one call still works.

## "Play the animation" on the end card

The end card covers the canvas, and each keyframe call plays once and stops,
so when the card appears nobody has watched the finished animation at speed.
A Cinema take whose timeline has tracks now gets a first action that closes
the card and plays from frame zero, looping still off.

## Verification

- `pnpm typecheck`, `pnpm lint`, `pnpm validate-wgsl`, `prettier --check` clean.
- `pnpm --filter chaos-master exec vitest run` — 151 files, 1899 tests passed.
- Driven end to end in a real browser against the dev server (headed Chromium,
  real GPU) through the dev `window.webmcp` mock: `arcade_start_cinema` →
  `arcade_get_animatable_paths` → `arcade_set_keyframes` (1 track) →
  `arcade_set_keyframes` with `mode: "add"` (returns `trackCount: 2`,
  `keyframeCount: 4`) → `arcade_end_cinema`.

## On the unrecorded step

The reported take carried `unnamedWriteCount: 1` — one timeline undo entry
pushed outside any command, which is the recorder's honest "this is not
replayable" marker. I could not reproduce it: two full Cinema runs in a real
browser, including one with looping restored and 45 s of continuous playback,
produced zero unnamed writes. The transport path is now excluded for pilot
takes, which removes the one mechanism I could name; if it reappears, the
recorder still logs the description to the console
(`[recorder] Unnamed write during recording`), which is what identifies it.
