### PR TITLE
fix(flame-import): stop flam3 aliases shadowing exact registry variations

### DIFF
--- a/packages/app/src/flame/flameXml.test.ts
+++ b/packages/app/src/flame/flameXml.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from 'vitest'
 import { rgbToOklab } from './flam3PaletteParser'
 import { FLAM3_SAMPLES } from './flam3Samples'
-import { exportFlameXml, extractFlamePalette, isFlameXmlContent, parseFlameXml, resolveVariationType, } from './flameXml'
-import { isVariationType } from './variations'
+import { exportFlameXml, extractFlamePalette, FLAM3_ALIASES_RAW, isFlameXmlContent, parseFlameXml, resolveVariationType, } from './flameXml'
+import { isVariationType, variationTypes } from './variations'
+import { getNormalizedVariationName } from './variations/utils'
 
 // ── helpers ───────────────────────────────────────────────────────────────
 
@@ -114,7 +115,8 @@ describe('resolveVariationType', () => {
 
   it('applies explicit aliases', () => {
     expect(resolveVariationType('sinusodial')).toBe('sinusoidalVar')
-    expect(resolveVariationType('blur')).toBe('circleBlurVar')
+    expect(resolveVariationType('flatten')).toBe('preFlattenVar')
+    expect(resolveVariationType('post_mirror')).toBe('postMirrorWfVar')
   })
 
   // flam3 var #1 is sin(x)/sin(y) — `sinusoidalVar`, not `sinVar` (the complex
@@ -124,6 +126,31 @@ describe('resolveVariationType', () => {
     expect(resolveVariationType('sinusoidal')).toBe('sinusoidalVar')
     expect(resolveVariationType('sinusodial')).toBe('sinusoidalVar')
     expect(resolveVariationType('sin')).toBe('sinVar')
+  })
+
+  // flam3 var #29 is a uniform-radius disc — `blurVar`. `circleBlurVar` uses a
+  // sqrt-distributed radius (uniform over the disc's area), a visibly different
+  // density. No alias: the registry resolves `blur` on its own.
+  it('resolves blur to blurVar, not the sqrt-radius circle blur', () => {
+    expect(resolveVariationType('blur')).toBe('blurVar')
+    expect(resolveVariationType('circle_blur')).toBe('circleBlurVar')
+  })
+
+  // Guards the whole class of bug this file has now hit twice: an alias whose
+  // key the registry can already resolve silently overrides the exact match,
+  // because resolveVariationType consults aliases first.
+  it('never aliases a name the registry can already resolve', () => {
+    for (const flam3Name of Object.keys(FLAM3_ALIASES_RAW)) {
+      const key = flam3Name.replace(/_/g, '').toLowerCase()
+      const fromRegistry = variationTypes.filter(
+        (t) =>
+          getNormalizedVariationName(t).replace(/_/g, '').toLowerCase() === key,
+      )
+      expect(
+        fromRegistry,
+        `alias "${flam3Name}" shadows registry type(s) ${fromRegistry.join(', ')}; drop the alias and let the registry resolve it`,
+      ).toEqual([])
+    }
   })
 
   it('returns undefined for unknown variations (does not invent a type)', () => {

--- a/packages/app/src/flame/flameXml.test.ts
+++ b/packages/app/src/flame/flameXml.test.ts
@@ -113,9 +113,17 @@ describe('resolveVariationType', () => {
   })
 
   it('applies explicit aliases', () => {
-    expect(resolveVariationType('sinusoidal')).toBe('sinVar')
-    expect(resolveVariationType('sinusodial')).toBe('sinVar')
+    expect(resolveVariationType('sinusodial')).toBe('sinusoidalVar')
     expect(resolveVariationType('blur')).toBe('circleBlurVar')
+  })
+
+  // flam3 var #1 is sin(x)/sin(y) — `sinusoidalVar`, not `sinVar` (the complex
+  // sine, sin(x)cosh(y)/cos(x)sinh(y)). It resolves from the registry, not an
+  // alias; the misspelling is aliased to the same target.
+  it('resolves sinusoidal to sinusoidalVar, not the complex sine', () => {
+    expect(resolveVariationType('sinusoidal')).toBe('sinusoidalVar')
+    expect(resolveVariationType('sinusodial')).toBe('sinusoidalVar')
+    expect(resolveVariationType('sin')).toBe('sinVar')
   })
 
   it('returns undefined for unknown variations (does not invent a type)', () => {

--- a/packages/app/src/flame/flameXml.ts
+++ b/packages/app/src/flame/flameXml.ts
@@ -41,12 +41,15 @@ const NORMALIZED_TO_TYPE: Map<string, string> = (() => {
 // listed here.
 // (gaussian_blur, pre_blur, wedge_julia, julian, juliascope, pie, ngon, … all
 // resolve straight from the registry by normalized name — no alias needed.)
-const FLAM3_ALIASES_RAW: Record<string, string> = {
+// Exported so `flameXml.test.ts` can assert the no-shadowing invariant.
+export const FLAM3_ALIASES_RAW: Record<string, string> = {
   // NOTE: `sinusoidal` itself is NOT aliased — it resolves straight from the
   // registry to `sinusoidalVar` (flam3 var #1, sin(x)/sin(y)). Only the
   // misspelling needs a hand-written entry.
   sinusodial: 'sinusoidalVar', // historical flam3 misspelling of "sinusoidal"
-  blur: 'circleBlurVar', // flam3 "blur" fills a disc — closest CM blur
+  // NOTE: `blur` is likewise NOT aliased — the registry resolves it to
+  // `blurVar` (flam3 var #29: uniform angle, uniform radius). `circleBlurVar`
+  // is a different distribution (sqrt-radius, uniform over the disc's area).
   flatten: 'preFlattenVar', // flam3 flatten (zeros z) ↔ CM preFlatten
   post_mirror: 'postMirrorWfVar', // Apophysis post_mirror plugin
 }
@@ -60,10 +63,16 @@ const FLAM3_ALIASES: Record<string, string> = Object.fromEntries(
   }),
 )
 
-// These aliases are useful fallbacks, but they are not mathematically exact.
-// Keep them importable while making the compatibility report honest about the
-// visual difference.
-const APPROXIMATE_FLAM3_ALIASES = new Set(['blur'])
+// Aliases that are useful fallbacks but not mathematically exact. Listing one
+// here keeps it importable while making the compatibility report honest about
+// the visual difference.
+//
+// Currently empty, and that is the accurate state: every alias above is an
+// exact equivalent. `blur` used to sit here, but only because it was aliased to
+// `circleBlurVar`; now that it resolves to the exact `blurVar`, flagging it
+// would be a false warning. Kept as the extension point for the next
+// genuinely-approximate alias.
+const APPROXIMATE_FLAM3_ALIASES = new Set<string>()
 
 /**
  * Resolve a flam3 variation name to a chaos-master internal type, or `undefined`

--- a/packages/app/src/flame/flameXml.ts
+++ b/packages/app/src/flame/flameXml.ts
@@ -42,8 +42,10 @@ const NORMALIZED_TO_TYPE: Map<string, string> = (() => {
 // (gaussian_blur, pre_blur, wedge_julia, julian, juliascope, pie, ngon, … all
 // resolve straight from the registry by normalized name — no alias needed.)
 const FLAM3_ALIASES_RAW: Record<string, string> = {
-  sinusoidal: 'sinVar', // flam3 var #1 — registry has no "sinusoidalVar"
-  sinusodial: 'sinVar', // historical flam3 misspelling
+  // NOTE: `sinusoidal` itself is NOT aliased — it resolves straight from the
+  // registry to `sinusoidalVar` (flam3 var #1, sin(x)/sin(y)). Only the
+  // misspelling needs a hand-written entry.
+  sinusodial: 'sinusoidalVar', // historical flam3 misspelling of "sinusoidal"
   blur: 'circleBlurVar', // flam3 "blur" fills a disc — closest CM blur
   flatten: 'preFlattenVar', // flam3 flatten (zeros z) ↔ CM preFlatten
   post_mirror: 'postMirrorWfVar', // Apophysis post_mirror plugin

--- a/packages/app/src/flame/flameXmlCompatibility.test.ts
+++ b/packages/app/src/flame/flameXmlCompatibility.test.ts
@@ -76,7 +76,7 @@ describe('analyzeFlameXmlBatch', () => {
     expect(first.summary.invalidFlames).toBe(0)
   })
 
-  it('marks every unsupported or approximate active behavior as lossy', () => {
+  it('marks every unsupported active behavior as lossy', () => {
     const xml = `<flames>
       <flame name="Unknown final attr" size="800 600">
         <xform weight="1" linear="1" coefs="1 0 0 1 0 0"/>
@@ -91,15 +91,12 @@ describe('analyzeFlameXmlBatch', () => {
       <flame name="Chaos matrix" size="800 600">
         <xform weight="1" linear="1" chaos="0 0" animate="1" plots="2" coefs="1 0 0 1 0 0"/>
       </flame>
-      <flame name="Approximate alias" size="800 600">
-        <xform weight="1" blur="1" coefs="1 0 0 1 0 0"/>
-      </flame>
     </flames>`
     const report = analyzeFlameXmlBatch([
       { path: 'lossy.flame', xml, bytes: xml.length },
     ])
 
-    expect(report.summary.importableWithLoss).toBe(4)
+    expect(report.summary.importableWithLoss).toBe(3)
     expect(flameXmlCompatibilityFailed(report)).toBe(false)
     expect(flameXmlCompatibilityFailed(report, true)).toBe(true)
     expect(
@@ -115,9 +112,26 @@ describe('analyzeFlameXmlBatch', () => {
       'animate',
     )
     expect(report.files[0]!.flames[2]!.diagnostics.join(' ')).toContain('plots')
-    expect(report.files[0]!.flames[3]!.diagnostics.join(' ')).toContain(
-      'Approximated',
-    )
+  })
+
+  // flam3 `blur` resolves to the exact `blurVar`, so it must import cleanly —
+  // no "Approximated" caveat. It used to alias to `circleBlurVar` (a different
+  // radius distribution) and was reported as lossy for that reason.
+  it('imports flam3 blur exactly, with no approximation warning', () => {
+    const xml = `<flames>
+      <flame name="Exact blur" size="800 600">
+        <xform weight="1" linear="1" coefs="1 0 0 1 0 0"/>
+        <xform weight="1" blur="1" coefs="1 0 0 1 0 0"/>
+      </flame>
+    </flames>`
+    const report = analyzeFlameXmlBatch([
+      { path: 'blur.flame', xml, bytes: xml.length },
+    ])
+
+    const flame = report.files[0]!.flames[0]!
+    expect(flame.status).toBe('importable')
+    expect(flame.variationTypes).toContain('blurVar')
+    expect(flame.diagnostics.join(' ')).not.toContain('Approximated')
   })
 
   it('ignores inactive unknown attributes and rejects negative probabilities', () => {


### PR DESCRIPTION
Two flam3 import aliases pointed at the wrong variation, each under a stale comment claiming the registry had no exact match. It does, in both cases. `resolveVariationType` consults `FLAM3_ALIASES` at step 1, **before** the registry-derived `NORMALIZED_TO_TYPE` lookup at step 2, so the alias silently shadowed the correct variation and every affected `.flame` / Apophysis file rendered a different shape than its source.

## 1. `sinusoidal` → was `sinVar`, now `sinusoidalVar`

```ts
sinusoidal: 'sinVar', // flam3 var #1 — registry has no "sinusoidalVar"
```

`sinusoidalVar` **is** in the 2D registry (`variations/simple/general/index.ts`) and is exactly flam3 variation #1:

```ts
vec2f(sin(pos.x), sin(pos.y)).mul(varInfo.weight)
```

`sinVar` is a different variation — the complex sine:

```ts
vec2f(sin(pos.x) * cosh(pos.y), cos(pos.x) * sinh(pos.y)).mul(varInfo.weight)
```

Alias dropped; `sinusoidal` now falls through to the registry. The historical `sinusodial` misspelling is kept (the registry can't resolve it by name) and repointed at `sinusoidalVar`.

## 2. `blur` → was `circleBlurVar`, now `blurVar`

```ts
blur: 'circleBlurVar', // flam3 "blur" fills a disc — closest CM blur
```

`blurVar` is in the registry, normalizes to `blur`, and is exactly flam3 variation #29 — uniform angle, **uniform radius**:

```ts
rand = random(); angle = 2π · random()
vec2f(cos(angle), sin(angle)) * rand * weight
```

`circleBlurVar` uses a **sqrt-distributed** radius — uniform over the disc's *area*, a visibly different density. The repo's own docs describe it that way: "a random angle and a square-root distributed radius".

This one compounded: `blur` was also in `APPROXIMATE_FLAM3_ALIASES`, so every import of flam3's most common blur emitted an `Approximated` warning *while silently using the wrong distribution*. Dropping the alias makes it exact and removes the false warning.

`APPROXIMATE_FLAM3_ALIASES` is now empty — the accurate state, since every remaining alias is an exact equivalent. The mechanism is kept as the extension point for the next genuinely-approximate alias. Happy to delete it instead if reviewers would rather not carry an unused facility.

`flatten` and `post_mirror` have no registry match and remain aliased.

## Regression guard

Added a test over `FLAM3_ALIASES_RAW` asserting that no alias key is one the registry can already resolve — this file has now hit that bug twice, and it fails silently by changing import output rather than breaking anything.

Verified non-vacuous: re-adding `blur: 'circleBlurVar'` fails it with

```
alias "blur" shadows registry type(s) blurVar; drop the alias and let the registry resolve it
```

## Behaviour change

Flames imported **before** this branch have `sinVar` / `circleBlurVar` baked into their saved descriptors and will not change retroactively; they need a re-import. Accepted deliberately — the app is pre-production, so this is the right time to correct it rather than after going live.

Every other `sinusoidalVar` reference in the repo (examples, benchmarks, `arcade/commandHints.ts`) already used the correct type. This makes the importer agree with them.

## Blast radius checked

- `flameXml.test.ts` was the only place pinning `sinVar`/`circleBlurVar` for these names — updated, plus regression tests asserting `sin` → `sinVar` and `circle_blur` → `circleBlurVar` so the pairs can no longer be conflated.
- `flameXmlCompatibility.test.ts` used `blur` as its approximate-alias fixture; that flame is replaced with a positive test that flam3 `blur` imports cleanly with no `Approximated` caveat.
- `scripts/flam3-compat.mjs` hardcodes no expectations; it runs the real importer.
- No `.flame` fixtures on disk. `flam3Samples.ts` uses neither name.
- 3D is unaffected: `transformFunction3D.ts` maps `sinusoidal` → `sinusoidal3D` through a separate table.

## Verification

From the repo root, all exit 0:

- `pnpm typecheck`
- `pnpm lint` (1 pre-existing warning in `AncestryTreeModal.tsx`, unrelated)
- `pnpm --filter chaos-master exec vitest run` — 151 files, **1897 tests passed**

End-to-end through the real importer (`pnpm --filter chaos-master flam3:compat --json`) on probe files carrying every spelling:

| input | resolves to |
| --- | --- |
| `sinusoidal` | `sinusoidalVar` |
| `sinusodial` | `sinusoidalVar` |
| `sin` | `sinVar` |
| `blur` | `blurVar` |
| `circle_blur` | `circleBlurVar` |

Both probes report status `importable` with empty `diagnostics` — the blur probe previously came back `importable-with-loss`.

## Context

Found while reviewing #141, which deliberately used `sinusoidalVar` for the Solar Seraph archetype rather than what `resolveVariationType` returned. That PR left the alias alone because changing it changes import behaviour.
