### PR TITLE
feat(arcade): three more Teach lessons and one-click Cinema presets

### DIFF
--- a/packages/app/src/arcade/topics.test.ts
+++ b/packages/app/src/arcade/topics.test.ts
@@ -1,17 +1,55 @@
+import '@/commands/builtins'
 import { describe, expect, it } from 'vitest'
-import { CINEMA_ALLOWED, cinemaPromptCard, isTopicId, LESSON_TOPICS, teachPromptCard, TOPIC_IDS, } from './topics'
+import { getAllCommands } from '@/commands/registry'
+import { CINEMA_ALLOWED, CINEMA_PRESETS, cinemaPromptCard, isTopicId, LESSON_TOPICS, teachPromptCard, TOPIC_IDS, } from './topics'
 
 describe('lesson topics', () => {
-  it('has four P0 topics with goals, budgets and allow-lists', () => {
-    expect(TOPIC_IDS).toEqual(['variations', 'affine', 'color', 'camera'])
+  it('has every topic with a goal, a budget and an allow-list', () => {
+    expect(TOPIC_IDS).toEqual([
+      'variations',
+      'affine',
+      'color',
+      'camera',
+      'genetics',
+      'sonification',
+      'render',
+    ])
     for (const id of TOPIC_IDS) {
       const t = LESSON_TOPICS[id]
       expect(t.goal.length).toBeGreaterThan(40)
-      expect(t.stepBudget).toBeGreaterThanOrEqual(20)
+      expect(t.stepBudget).toBeGreaterThanOrEqual(18)
       expect(t.allowed.length).toBeGreaterThan(0)
     }
     expect(isTopicId('color')).toBe(true)
     expect(isTopicId('audio')).toBe(false)
+  })
+
+  // Every allow-list entry has to name something the registry actually has,
+  // or the lesson silently teaches nothing: the guard refuses the command and
+  // the agent burns its budget on rejections.
+  it('only allows commands that exist', () => {
+    const known = new Set(getAllCommands().map((command) => command.id))
+    const missing = TOPIC_IDS.flatMap((id) =>
+      LESSON_TOPICS[id].allowed
+        .filter((entry) => !entry.endsWith('.') && !known.has(entry))
+        .map((entry) => `${id}: ${entry}`),
+    )
+    expect(missing).toEqual([])
+  })
+
+  it('offers cinema presets that fill the wish with a full sentence', () => {
+    expect(CINEMA_PRESETS.map((preset) => preset.id)).toEqual([
+      'small',
+      'big',
+      'surprise',
+    ])
+    for (const preset of CINEMA_PRESETS) {
+      expect(preset.label.length).toBeGreaterThan(3)
+      expect(preset.wish.length).toBeGreaterThan(30)
+      // The wish is pasted into the prompt card verbatim, so it has to read as
+      // part of the sentence "Animate my current flame: <wish>."
+      expect(cinemaPromptCard(preset.wish)).toContain(preset.wish)
+    }
   })
 
   it('prompt cards name the tools the agent must call', () => {

--- a/packages/app/src/arcade/topics.ts
+++ b/packages/app/src/arcade/topics.ts
@@ -1,4 +1,11 @@
-export type TopicId = 'variations' | 'affine' | 'color' | 'camera'
+export type TopicId =
+  | 'variations'
+  | 'affine'
+  | 'color'
+  | 'camera'
+  | 'genetics'
+  | 'sonification'
+  | 'render'
 
 export interface LessonTopic {
   id: TopicId
@@ -91,6 +98,49 @@ export const LESSON_TOPICS: Record<TopicId, LessonTopic> = {
     stepBudget: 20,
     defaultStartFrom: 'current',
   },
+  genetics: {
+    id: 'genetics',
+    title: 'Randomness and mutation',
+    goal: 'Teach how the randomizer and the mutator explore flame space. Draw a few fresh flames, then mutate one of them repeatedly so the family resemblance between generations is visible. Pick the strengths yourself.',
+    allowed: [
+      'flame.randomize',
+      'flame.mutate',
+      'flame.setExposure',
+      'camera.center',
+      'camera.zoomTo',
+    ],
+    stepBudget: 20,
+    defaultStartFrom: 'current',
+  },
+  sonification: {
+    id: 'sonification',
+    title: 'Sound and sonification',
+    goal: 'Teach how this flame is turned into sound. Switch sonification on, then change the model, the scale and the voice count one at a time so each is audible on its own. Say what to listen for before each change.',
+    allowed: [
+      'sonification.setEnabled',
+      'sonification.setConfig',
+      'camera.center',
+      'camera.zoomTo',
+    ],
+    stepBudget: 18,
+    defaultStartFrom: 'current',
+  },
+  render: {
+    id: 'render',
+    title: 'Noise and convergence',
+    goal: 'Teach how the picture converges: what the quality preset, the skipped iterations and the two filters change about noise and detail, and what each costs. Lowering quality is allowed, raising it is not.',
+    allowed: [
+      'view.setQualityPreset',
+      'view.setPixelRatio',
+      'view.setAdaptiveFilter',
+      'view.setStochasticFilter',
+      'flame.setSkipIters',
+      'flame.setDrawMode',
+      'camera.zoomTo',
+    ],
+    stepBudget: 18,
+    defaultStartFrom: 'current',
+  },
 }
 
 export const TOPIC_IDS = Object.keys(LESSON_TOPICS) as TopicId[]
@@ -109,6 +159,39 @@ export const BLANK_CANVAS_STEPS: readonly (readonly [string, ...unknown[]])[] =
     ['camera.center'],
     ['camera.zoomTo', 1],
   ]
+
+/**
+ * One-click starting points for a Cinema wish.
+ *
+ * A blank description is the worst moment in the flow: it asks the viewer to
+ * art-direct a fractal before they have seen the mode work. Each preset fills
+ * the field with a sentence they can then edit, and names a scope as well as
+ * an ambition — "small" alone tells the agent how much to move but not what,
+ * which is the half that decides whether the take reads.
+ */
+export interface CinemaPreset {
+  id: string
+  label: string
+  wish: string
+}
+
+export const CINEMA_PRESETS: readonly CinemaPreset[] = [
+  {
+    id: 'small',
+    label: 'Small and slow',
+    wish: 'one idea only, moved slowly — about five seconds, so the change reads clearly',
+  },
+  {
+    id: 'big',
+    label: 'Big and cinematic',
+    wish: 'a full take with the camera, the colour and the transforms all moving together, about nine seconds, building to a resolve',
+  },
+  {
+    id: 'surprise',
+    label: 'Surprise me',
+    wish: 'surprise me — read the flame first and pick whichever move suits it, then tell me why you chose it',
+  },
+]
 
 export const CINEMA_ALLOWED = [
   'timeline.',

--- a/packages/app/src/commands/registry.test.ts
+++ b/packages/app/src/commands/registry.test.ts
@@ -3,7 +3,8 @@ import { describe, expect, it, vi } from 'vitest'
 import { examples } from '@/flame/examples'
 import { isTimelineParameterPath, MAX_TIMELINE_FRAME, MAX_TIMELINE_KEYFRAMES, MAX_TIMELINE_PARAMETER_PATH_LENGTH, MAX_TIMELINE_PLAYBACK_FPS, MAX_TIMELINE_TIME_SCALE, tryValidateTimelineSnapshot, } from '@/flame/schema/timeline'
 import { snapshotOrigin } from '@/recorder/snapshotOrigin'
-import { executeCommand, getAllCommands, hasExplicitReplayPolicy, preflightReplayCommand, registerCommand, } from './registry'
+import { createMockCommandContext } from '@/webmcp/testUtils'
+import { executeCommand, getAllCommands, hasExplicitReplayPolicy, preflightLiveCommand, preflightReplayCommand, registerCommand, } from './registry'
 import type { CommandContext } from './types'
 
 function timelineSnapshot(
@@ -335,5 +336,44 @@ describe('timeline snapshot budgets', () => {
         undefined,
       ]),
     ).toBeDefined()
+  })
+})
+
+describe('preflightLiveCommand', () => {
+  const ctx = createMockCommandContext()
+
+  // The whole point of the live path: these two commands exist to turn what an
+  // agent can reasonably type into what replay needs, and the replay policy
+  // applied to the raw args rejects both.
+  it('normalizes before applying the replay policy', () => {
+    expect(preflightReplayCommand('flame.mutate', [])).toMatch(/expects a seed/)
+    const mutate = preflightLiveCommand('flame.mutate', ctx, [])
+    expect('args' in mutate).toBe(true)
+    if (!('args' in mutate)) return
+    expect(mutate.args).toHaveLength(3)
+    expect(typeof mutate.args[0]).toBe('number')
+
+    expect(preflightReplayCommand('sonification.setEnabled', [true])).toMatch(
+      /bounded snapshot/,
+    )
+    const sonify = preflightLiveCommand('sonification.setEnabled', ctx, [true])
+    expect('args' in sonify).toBe(true)
+  })
+
+  it('still refuses unknown ids, unreplayable commands and bad args', () => {
+    expect(preflightLiveCommand('nope.nothing', ctx, [])).toEqual({
+      error: 'Unknown command "nope.nothing"',
+    })
+    expect(
+      preflightLiveCommand('flame.setExposure', ctx, ['loud']),
+    ).toHaveProperty('error')
+    expect(preflightLiveCommand('timeline.play', ctx, [])).toHaveProperty(
+      'error',
+    )
+  })
+
+  it('passes ordinary args through unchanged', () => {
+    const result = preflightLiveCommand('flame.setExposure', ctx, [0.4])
+    expect(result).toEqual({ args: [0.4] })
   })
 })

--- a/packages/app/src/commands/registry.ts
+++ b/packages/app/src/commands/registry.ts
@@ -501,6 +501,55 @@ export function preflightReplayCommand(
 }
 
 /**
+ * Validate one command an agent is about to run live.
+ *
+ * The replay policy is the right standard — whatever the agent runs is
+ * recorded, and a recorded action has to survive replay — but it must be
+ * applied to the args that will actually be recorded, which is what
+ * `normalizeArgs` produces. Checking the raw args instead makes every command
+ * whose whole job is normalization unreachable: `flame.mutate` mints its seed
+ * there, `sonification.setEnabled` turns a boolean into the bounded snapshot
+ * replay needs, and both refuse an agent that passes exactly what their own
+ * argument shape advertises.
+ *
+ * The size guard still runs first, on the raw args, so nothing hostile is
+ * allocated before it — which is the reason `preflightReplayCommand` checks
+ * before normalizing on the replay path, and that path is unchanged.
+ */
+export function preflightLiveCommand(
+  id: string,
+  ctx: CommandContext,
+  args: readonly unknown[],
+): { error: string } | { args: unknown[] } {
+  const cmd = commandRegistry.get(id)
+  if (!cmd) return { error: `Unknown command "${id}"` }
+  if (cmd.replayable === false)
+    return { error: `${cmd.label} is not replayable` }
+  const validator =
+    cmd.validateReplayArgs ??
+    (Object.hasOwn(REPLAY_ARG_POLICIES, id)
+      ? REPLAY_ARG_POLICIES[id]
+      : undefined)
+  if (!validator) return { error: `${cmd.label} has no explicit replay policy` }
+  const budgetError = replayArgBudgetError(args)
+  if (budgetError !== undefined) return { error: budgetError }
+  let normalized: unknown[]
+  try {
+    normalized = cmd.normalizeArgs
+      ? cmd.normalizeArgs(ctx, [...args])
+      : [...args]
+  } catch (error) {
+    return {
+      error: `Could not prepare arguments: ${error instanceof Error ? error.message : String(error)}`,
+    }
+  }
+  const policyError = replayArgBudgetError(normalized) ?? validator(normalized)
+  return policyError === undefined
+    ? { args: normalized }
+    : { error: policyError }
+}
+
+/**
  * Execute one action loaded from a `.steps.json` file.
  *
  * Unlike ordinary in-app dispatch, this rejects unknown commands and applies

--- a/packages/app/src/components/Arcade/ArcadeModePanel.tsx
+++ b/packages/app/src/components/Arcade/ArcadeModePanel.tsx
@@ -1,5 +1,5 @@
 import { createSignal, For, Match, onMount, Show, Switch } from 'solid-js'
-import { cinemaPromptCard, LESSON_TOPICS, teachPromptCard, TOPIC_IDS, } from '@/arcade/topics'
+import { CINEMA_PRESETS, cinemaPromptCard, LESSON_TOPICS, teachPromptCard, TOPIC_IDS, } from '@/arcade/topics'
 import { Copy, Cross } from '@/icons'
 import ui from './ArcadeHub.module.css'
 import type { TopicId } from '@/arcade/topics'
@@ -117,9 +117,27 @@ export function ArcadeModePanel(props: {
         </Match>
         <Match when={props.mode === 'cinema'}>
           <p>
-            Describe the move you want. The AI reads your flame, keyframes it,
-            and plays it back.
+            Describe the move you want, or start from one of these. The AI reads
+            your flame, keyframes it, and plays it back.
           </p>
+          <div class={ui.chips} aria-label="Animation presets">
+            <For each={CINEMA_PRESETS}>
+              {(preset) => (
+                <button
+                  type="button"
+                  classList={{
+                    [ui.chip!]: true,
+                    [ui.chipActive!]: description() === preset.wish,
+                  }}
+                  // Fills the field rather than replacing it: the preset is a
+                  // starting sentence the viewer can edit, not a mode.
+                  onClick={() => setDescription(preset.wish)}
+                >
+                  {preset.label}
+                </button>
+              )}
+            </For>
+          </div>
           <label class={ui.field}>
             <span>Describe the animation</span>
             <textarea

--- a/packages/app/src/webmcp/testUtils.ts
+++ b/packages/app/src/webmcp/testUtils.ts
@@ -121,6 +121,27 @@ export function createMockCommandContext(): CommandContext {
     camera: {
       center: vi.fn(),
     },
+    // Present so commands whose normalizeArgs expands a boolean into the
+    // bounded snapshot replay needs can be exercised without a workspace.
+    sonification: {
+      snapshot: () => ({
+        version: 1 as const,
+        enabled: false,
+        config: {
+          model: 'orchestral' as const,
+          volume: 0.3,
+          updateRate: 20,
+          scale: 'pentatonicMajor' as const,
+          voiceCount: 8,
+          harmonicDensity: 1,
+          triggerRate: 4,
+          spatialSpread: 0.7,
+          reverbMix: 0.3,
+        },
+      }),
+      setConfig: vi.fn(),
+      setEnabled: vi.fn(),
+    },
     modal: {
       open: vi.fn(),
     },

--- a/packages/app/src/webmcp/tools/arcadeTeach.ts
+++ b/packages/app/src/webmcp/tools/arcadeTeach.ts
@@ -45,7 +45,7 @@ export const arcadeStatus: WebMcpTool = {
 export const arcadeStartLesson: WebMcpTool = {
   name: 'arcade_start_lesson',
   description:
-    'Start a Teach session: locks the editor, starts recording, and returns the lesson brief (goal, allowed commands with their argument shapes, step budget). Topics: variations, affine, color, camera. Then use arcade_narrate and execute_command, and finish with arcade_end_lesson.',
+    'Start a Teach session: locks the editor, starts recording, and returns the lesson brief (goal, allowed commands with their argument shapes, step budget). Topics: variations, affine, color, camera, genetics, sonification, render. Then use arcade_narrate and execute_command, and finish with arcade_end_lesson.',
   inputSchema: {
     type: 'object',
     properties: {

--- a/packages/app/src/webmcp/tools/executeCommand.ts
+++ b/packages/app/src/webmcp/tools/executeCommand.ts
@@ -1,6 +1,6 @@
 import { guardCommand } from '@/arcade/guard'
 import { appendPilotLog, drivingState, notePilotStep, pilotStepsRemaining, } from '@/arcade/pilot'
-import { executeCommand, getCommand, preflightReplayCommand, } from '@/commands/registry'
+import { executeCommand, getCommand, preflightLiveCommand, } from '@/commands/registry'
 import { getWebMcpContext } from '@/webmcp/contextBridge'
 import type { WebMcpTool } from '@/webmcp/types'
 
@@ -82,9 +82,12 @@ export const executeCommandTool: WebMcpTool = {
       }
     }
 
-    const preflightError = preflightReplayCommand(commandId, args)
-    if (preflightError !== undefined) {
-      return { error: preflightError }
+    // Checked against the args that will be RECORDED, not the ones the agent
+    // typed: `preflightLiveCommand` normalizes first, so a command that mints
+    // its own seed or expands a boolean into a snapshot is reachable.
+    const preflight = preflightLiveCommand(commandId, ctx, args)
+    if ('error' in preflight) {
+      return { error: preflight.error }
     }
 
     try {


### PR DESCRIPTION
Three more Teach lessons, one-click Cinema presets, and the fix that was needed to make two of the lessons work at all.

## execute_command checked the wrong arguments

`execute_command` validated the **raw** args against the replay policy before
dispatching. That makes every command whose entire purpose is normalization
unreachable by an agent:

- `flame.mutate` mints its seed and resolves its generator config in
  `normalizeArgs` — the policy demands all three arguments, so `[]` is refused.
- `sonification.setEnabled` turns a boolean into the bounded snapshot replay
  needs — the policy demands the snapshot, so `[true]` is refused.

Both refuse exactly the arguments their own shape advertises, and there is no
way for an agent to construct what they want. `preflightLiveCommand` normalizes
first, then applies the same policy to the args that will actually be recorded.
The size guard still runs on the raw args before anything is allocated, which
is why `preflightReplayCommand` checks before normalizing — that path, used by
`.steps.json` replay, is unchanged.

## Three new lessons

- **Randomness and mutation** — `flame.randomize`, `flame.mutate`. Draw a few
  fresh flames, then mutate one repeatedly so the family resemblance between
  generations is visible.
- **Sound and sonification** — `sonification.setEnabled`, `sonification.setConfig`.
  Model, scale and voice count changed one at a time so each is audible on its
  own. Self-contained: no audio file needed, unlike the audio-reactive panel.
- **Noise and convergence** — quality preset, pixel ratio, the two filters and
  skipped iterations, and what each costs. Lowering quality is allowed; the
  Arcade guard already refuses raising it.

Light, tone and palettes are deliberately **not** new topics: the existing
Colour and tone lesson already allows `flame.applyPalette`, `setExposure`,
`setGamma`, `setVibrancy`, `setContrast` and `setDrawMode`, so a separate one
would duplicate it.

## Cinema presets

Three pills — **Small and slow**, **Big and cinematic**, **Surprise me** — that
fill the wish field with a sentence the viewer can then edit. A blank
description is the worst moment in the flow: it asks someone to art-direct a
fractal before they have seen the mode work. Each preset names a scope as well
as an ambition, because "small" says how much to move but not what, and the
scope is the half that decides whether the take reads.

## Verification

- `pnpm typecheck`, `prettier --check` clean; `pnpm --filter chaos-master exec
  vitest run` — 154 files, 1928 tests passed.
- New tests: every topic's allow-list is pinned against the live command
  registry (an entry naming a command that does not exist would silently teach
  nothing — the guard refuses it and the agent burns budget on rejections); the
  brief-budget test already loops over `TOPIC_IDS` and now covers seven;
  `preflightLiveCommand` is tested against both commands it unblocks and
  against unknown ids, unreplayable commands and bad args.
- Driven in a real browser against the dev server: each of the three lessons
  starts, runs one allowed command through `execute_command` and ends cleanly.
  Briefs are 621, 622 and 702 bytes against the 1.5 KB result budget. The
  Cinema pills fill the field and the prompt card picks the text up; the Teach
  panel shows all seven topics.
