### PR TITLE
fix(examples): make the Menger sponge legible

### DIFF
--- a/packages/app/src/flame/examples/classics.test.ts
+++ b/packages/app/src/flame/examples/classics.test.ts
@@ -286,4 +286,29 @@ describe('classic affine IFS descriptors', () => {
       expectPoint3D(apply3D(affine, expected[index]!), expected[index]!)
     })
   })
+
+  // The geometry above was always exact; what made the sponge illegible was
+  // tone and framing. Pinned because the settings look arbitrary next to the
+  // other classics and would be "tidied" back to the shared defaults, which
+  // is what produced the fog: at exposure 0.2 / gamma 2.8 the render had a
+  // mean luminance of 0.04 with over 80% of the frame at pure black, and the
+  // near-axis camera collapsed the cube onto one face.
+  it('renders the sponge from the corner, lit and properly exposed', () => {
+    const rs = mengerSponge.renderSettings
+    expect(rs.exposure).toBe(2)
+    expect(rs.gamma).toBe(2.2)
+    expect(rs.lightPower).toBe(2.5)
+    expect(rs.depthColorPower).toBe(1.2)
+    // The shared isometric corner view: every visible face at the same angle
+    // to the camera, so none of them integrates enough samples to blow out.
+    expect(rs.camera3D?.theta).toBeCloseTo(Math.PI / 4, 6)
+    expect(rs.camera3D?.phi).toBeCloseTo(Math.acos(1 / Math.sqrt(3)), 6)
+  })
+
+  it('leaves the other 3D classics on the shared tone defaults', () => {
+    const rs = sierpinskiTetrahedron.renderSettings
+    expect(rs.gamma).toBe(2.8)
+    expect(rs.lightPower).toBe(0.1)
+    expect(rs.depthColorPower).toBe(0.4)
+  })
 })

--- a/packages/app/src/flame/examples/classics.ts
+++ b/packages/app/src/flame/examples/classics.ts
@@ -107,6 +107,19 @@ function createClassic3D(config: {
   exposure?: number
   theta?: number
   phi?: number
+  /**
+   * Per-flame tone overrides.
+   *
+   * The shared defaults suit a set that is mostly surface, like the
+   * tetrahedron. A denser attractor lands far lower on the tone curve and
+   * needs its own exposure, gamma and directional light or it renders as fog.
+   */
+  tone?: {
+    gamma?: number
+    contrast?: number
+    lightPower?: number
+    depthColorPower?: number
+  }
 }) {
   const count = config.maps.length
   return defineExample3D({
@@ -126,11 +139,11 @@ function createClassic3D(config: {
       pointInitMode: 'pointInitUnitBall',
       backgroundColor: [0, 0, 0],
       vibrancy: 0.9,
-      contrast: 1.2,
-      gamma: 2.8,
-      depthColorPower: 0.4,
+      contrast: config.tone?.contrast ?? 1.2,
+      gamma: config.tone?.gamma ?? 2.8,
+      depthColorPower: config.tone?.depthColorPower ?? 0.4,
       lightDirection: [-0.45, 0.65, -0.65],
-      lightPower: 0.1,
+      lightPower: config.tone?.lightPower ?? 0.1,
       highlightPower: 0.8,
       densityEstimationQuality: 0.8,
       estimatorCurve: 0.5,
@@ -345,9 +358,22 @@ export const mengerSponge = createClassic3D({
   description:
     'Classic IFS · Twenty exact 3D affine branches remove every face center and the cube core, forever.',
   radius: 3.4,
-  exposure: 0.2,
-  theta: 0.28,
-  phi: 1.32,
+  // The sponge has Hausdorff dimension log(20)/log(3) = 2.73, so it is nearly
+  // solid and lands far lower on the tone curve than the other classics: at
+  // the shared exposure it rendered with a mean luminance of 0.04 and over
+  // 80% of the frame at pure black, which is where the "mushy" reading came
+  // from. Exposure 2 does not clip anything here — measured, no flat white
+  // regions — and gamma 2.2 stops the midtones being crushed.
+  exposure: 2,
+  tone: { gamma: 2.2, lightPower: 2.5, depthColorPower: 1.2 },
+  // Deliberately NOT overriding theta/phi any more. The old 0.28/1.32 was
+  // barely off an axis, which projects the sponge onto a single face: you look
+  // straight down its square tunnels and the whole object degenerates into a
+  // mottled flat rectangle with no third face and no cubic silhouette. The
+  // shared isometric corner view is what makes it read as a cube, and it also
+  // keeps every visible face at the same angle to the camera — a face seen
+  // edge-on integrates far more samples per pixel and blows out, because the
+  // accumulator has no occlusion.
   maps: [-1, 0, 1].flatMap((z) =>
     [-1, 0, 1].flatMap((y) =>
       [-1, 0, 1]


### PR DESCRIPTION
The maths was never wrong. The IFS is 20 maps with a uniform 1/3 contraction to the subcube centres at `(2X/3, 2Y/3, 2Z/3)`, which tile the parent cube exactly — the existing geometry test already pins that. What made it render as fog was framing and tone.

## The camera was the dominant cause

The sponge overrode `createClassic3D`'s isometric default with `theta: 0.28, phi: 1.32` — about 16 degrees of azimuth and 14 degrees above the equator. That projects the whole object onto essentially one face: you look straight down its square tunnels and get a mottled flat rectangle with no third face and no cubic silhouette. Changing **only** the camera to the isometric corner view makes the cube appear; changing only the lighting does not. So the override goes and it uses the shared default, like the Sierpinski tetrahedron, which always read fine.

The isometric view has a second benefit that is specific to this renderer. The accumulator has no occlusion — every sample along a ray adds to the same pixel — so a face seen edge-on integrates far more samples per pixel and blows out to featureless white. A frontal camera showed exactly that on the receding face. Isometric keeps all three visible faces at the same angle, so exposure is even.

## Tone, for this flame only

The sponge has Hausdorff dimension log(20)/log(3) = 2.73, so it is nearly solid and lands far lower on the shared tone curve than the other classics. At `exposure: 0.2` with `gamma: 2.8` the render measured a mean luminance of 0.043 with over 80 percent of the frame at pure black — the whole image lived in the bottom 12 of 256 code values, which is also why the falloff banded.

`createClassic3D` gained an optional `tone` override so this can be fixed without touching the others: exposure 2 (verified not to clip — no flat white regions), gamma 2.2, lightPower 2.5 (the shared 0.1 is effectively no directional light at all), depthColorPower 1.2. A test pins the tetrahedron on the shared defaults so this stays a one-flame change.

## Measured

Eight variants in round one and five in round two and three, rendered through the real poster-capture page on a GPU and compared:

| | before | after |
| --- | --- | --- |
| peak brightness | 92/255 | 237/255 |
| hole-to-surround contrast | 0.11 | 0.33 |
| object area dark enough to read as void | 0.11% | 0.55% |

Renders are in `~/agent-out/chaos-master/2026-09-03/menger*/`.

## What this does not fix

The holes still do not read as *holes*: nothing is see-through and no interior wall is ever visible. That is inherent to the accumulator, not to this flame — `colorGrading.ts` stores a summed z per pixel and uses only `tex.z / tex.count`, a mean depth, and `lightPower` is a screen-space emboss of the density image rather than surface shading. There is no depth sort and no visibility test anywhere, so a hole is a slightly shorter integration path rather than a void, and material behind it fills it back in. Real see-through would need front-to-back opacity compositing. Sample count is exhausted: raising the capture's convergence target 36x dropped Monte Carlo noise the expected 6x, and the residual texture is converged sub-pixel fractal detail, not speckle.

Two renderer artefacts turned up alongside and are **not** addressed here, since they affect every 3D flame: a smooth 8-15px bright colour band hugging the silhouette that carries no fractal detail (21-24% of boundary pixels are 1.5x brighter than the interior, unchanged by sample count — it looks like the density-estimation kernel widening in the low-density edge region), and grazing-face blowout from the missing occlusion.

## Gallery

The published `classic-menger-sponge` row holds its own copy of the flame, so this change does not reach the gallery until the row is re-staged and its poster re-captured.

## Verification

`pnpm typecheck`, `prettier --check` clean; 154 files, 1925 tests passed.