### PR TITLE
fix: unblock the Load Flame modal, and keep dev logs out of prod

### DIFF
--- a/packages/app/src/MainWorkspace.tsx
+++ b/packages/app/src/MainWorkspace.tsx
@@ -2939,14 +2939,16 @@ export function MainWorkspace(props: AppProps) {
         ?.scrollIntoView({ behavior: 'smooth', block: 'center' })
     },
     executeCommand: (id, ...args) => {
-      console.info(
-        '[tourContext:executeCommand]',
-        id,
-        'args:',
-        ...args,
-        'fn:',
-        !!runTourCommand.fn,
-      )
+      if (import.meta.env.DEV) {
+        console.info(
+          '[tourContext:executeCommand]',
+          id,
+          'args:',
+          ...args,
+          'fn:',
+          !!runTourCommand.fn,
+        )
+      }
       runTourCommand.fn?.(id, ...args)
     },
     animateValue: (start, end, durationMs, onUpdate) => {
@@ -5312,10 +5314,12 @@ export function MainWorkspace(props: AppProps) {
                                 mode={quickPickerMode()}
                                 onModeChange={setQuickPickerMode}
                                 onOpenFullSelector={() => {
-                                  console.info(
-                                    '[QuickVariationPicker] onOpenFullSelector — opening full VariationSelector',
-                                    { tid: state.tid, vid: state.vid },
-                                  )
+                                  if (import.meta.env.DEV) {
+                                    console.info(
+                                      '[QuickVariationPicker] onOpenFullSelector — opening full VariationSelector',
+                                      { tid: state.tid, vid: state.vid },
+                                    )
+                                  }
                                   const currentVar =
                                     flameDescriptor.transforms[state.tid]
                                       ?.variations[state.vid]

--- a/packages/app/src/MainWorkspace.tsx
+++ b/packages/app/src/MainWorkspace.tsx
@@ -7639,13 +7639,22 @@ export function MainWorkspace(props: AppProps) {
                   ),
                 })
                 if (confirmed) {
-                  saveRecentFlame(flameDescriptor, undefined, tracks, true)
-                  markSavedBaseline()
-                  showToast(
-                    tracks.length > 0
-                      ? 'Flame + animation saved (replaced oldest)'
-                      : 'Flame saved (replaced oldest)',
-                  )
+                  // Honour the write result. `saveRecentFlame` now reports a
+                  // failed write instead of always claiming success, so marking
+                  // the workspace clean here unconditionally would tell the user
+                  // their flame is safe when nothing landed.
+                  if (
+                    saveRecentFlame(flameDescriptor, undefined, tracks, true)
+                  ) {
+                    markSavedBaseline()
+                    showToast(
+                      tracks.length > 0
+                        ? 'Flame + animation saved (replaced oldest)'
+                        : 'Flame saved (replaced oldest)',
+                    )
+                  } else {
+                    showToast('Could not save the flame to Recents', 5000)
+                  }
                 }
               } else {
                 markSavedBaseline()

--- a/packages/app/src/components/PaletteSelector/PaletteSelector.tsx
+++ b/packages/app/src/components/PaletteSelector/PaletteSelector.tsx
@@ -92,7 +92,9 @@ export function PaletteSelector(props: PaletteSelectorProps) {
           importedCount += palettes.length
         }
         setForceUpdate((n) => n + 1)
-        console.info(`Imported ${importedCount} palettes`)
+        if (import.meta.env.DEV) {
+          console.info(`Imported ${importedCount} palettes`)
+        }
       } catch (err) {
         console.error('Failed to import palettes:', err)
       }

--- a/packages/app/src/utils/recentFlames.test.ts
+++ b/packages/app/src/utils/recentFlames.test.ts
@@ -1,25 +1,32 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { examples } from '@/flame/examples'
-import { clearRecentFlamesCache, deleteRecentFlame, loadRecentFlames, loadRecentFlamesForRewrite, MAX_RECENT_FLAMES, saveRecentFlame, } from './recentFlames'
+import { clearRecentFlames, clearRecentFlamesCache, deleteRecentFlame, formatRecentDate, getOldestRecentFlame, loadRecentFlames, loadRecentFlamesForRewrite, MAX_RECENT_FLAMES, saveRecentFlame, saveRecentFlames, upsertRecentFlame, } from './recentFlames'
 import type { FlameDescriptor } from '@/flame/schema/flameSchema'
 
 const STORAGE_KEY = 'chaos-master-recent-flames'
 
 const sampleFlame = () => Object.values(examples)[0] as FlameDescriptor
 
-/** An entry that passes the structural check but fails the flame schema — the
- *  shape a stale save or a schema tightening leaves behind. */
+/** Minimal timeline track — only its presence and cloning matter here. */
+const sampleTrack = () => ({
+  id: 'track-1',
+  target: 'camera',
+  keyframes: [{ frame: 0, value: 0 }],
+})
+
+/** Passes `isValidRecentFlame` but fails the flame schema — the shape a stale
+ *  save or a schema tightening leaves behind in a real user's storage. */
 const brokenEntry = (id: string) => ({
   id,
   name: `broken ${id}`,
-  savedAt: Date.now(),
+  savedAt: 1,
   flame: { nonsense: true },
 })
 
-const goodEntry = (id: string) => ({
+const goodEntry = (id: string, savedAt = 1) => ({
   id,
   name: `good ${id}`,
-  savedAt: Date.now(),
+  savedAt,
   flame: sampleFlame(),
 })
 
@@ -48,71 +55,447 @@ function seed(entries: unknown[]) {
   clearRecentFlamesCache()
 }
 
+function seedRaw(raw: string) {
+  localStorage.setItem(STORAGE_KEY, raw)
+  clearRecentFlamesCache()
+}
+
+const ids = (entries: { id: string }[]) => entries.map((e) => e.id)
+
 beforeEach(() => {
   vi.stubGlobal('localStorage', memoryStorage)
   stored.clear()
   clearRecentFlamesCache()
 })
 
+// ── loadRecentFlames: malformed and empty input ───────────────────────────
+
+describe('loadRecentFlames input handling', () => {
+  it('returns empty when nothing is stored', () => {
+    expect(loadRecentFlames()).toEqual([])
+  })
+
+  it('returns empty for an empty stored list', () => {
+    seed([])
+    expect(loadRecentFlames()).toEqual([])
+  })
+
+  it('returns empty for malformed JSON rather than throwing', () => {
+    seedRaw('{ not json')
+    expect(loadRecentFlames()).toEqual([])
+  })
+
+  it('returns empty when the payload is not an array', () => {
+    seedRaw(JSON.stringify({ id: 'a' }))
+    expect(loadRecentFlames()).toEqual([])
+  })
+
+  it('returns empty when localStorage itself throws (private mode)', () => {
+    vi.stubGlobal('localStorage', {
+      getItem: () => {
+        throw new Error('SecurityError')
+      },
+    })
+    expect(loadRecentFlames()).toEqual([])
+  })
+
+  it.each([
+    ['missing id', { name: 'n', savedAt: 1, flame: sampleFlame() }],
+    ['missing name', { id: 'a', savedAt: 1, flame: sampleFlame() }],
+    ['missing savedAt', { id: 'a', name: 'n', flame: sampleFlame() }],
+    ['missing flame', { id: 'a', name: 'n', savedAt: 1 }],
+    ['non-object entry', 'nope'],
+    ['null entry', null],
+  ])('drops a structurally invalid entry (%s)', (_label, bad) => {
+    seed([goodEntry('keep'), bad])
+    expect(ids(loadRecentFlames())).toEqual(['keep'])
+  })
+
+  it('drops entries that fail the flame schema', () => {
+    seed([goodEntry('a'), brokenEntry('bad'), goodEntry('b')])
+    expect(ids(loadRecentFlames())).toEqual(['a', 'b'])
+  })
+})
+
+// ── loadRecentFlames: the memo ────────────────────────────────────────────
+
 describe('loadRecentFlames memo', () => {
   it('returns the same content on a repeat call', () => {
     seed([goodEntry('a'), goodEntry('b')])
-    const first = loadRecentFlames()
-    const second = loadRecentFlames()
-    expect(second).toHaveLength(first.length)
-    expect(second.map((e) => e.id)).toEqual(first.map((e) => e.id))
+    expect(ids(loadRecentFlames())).toEqual(ids(loadRecentFlames()))
   })
 
-  it('hands out a fresh array so callers cannot corrupt the memo', () => {
+  it('hands out a fresh outer array each call', () => {
     seed([goodEntry('a'), goodEntry('b')])
     const first = loadRecentFlames()
+    expect(loadRecentFlames()).not.toBe(first)
     first.pop()
     expect(loadRecentFlames()).toHaveLength(2)
   })
 
-  it('re-reads when the stored payload changes underneath it', () => {
+  it('re-reads when the payload changes out of band (another tab)', () => {
     seed([goodEntry('a')])
-    expect(loadRecentFlames().map((e) => e.id)).toEqual(['a'])
-
-    // Written directly, as another tab would — no invalidation call.
+    expect(ids(loadRecentFlames())).toEqual(['a'])
+    // Written directly, with no invalidation call — the memo must notice.
     localStorage.setItem(
       STORAGE_KEY,
       JSON.stringify([goodEntry('a'), goodEntry('b')]),
     )
-    expect(loadRecentFlames().map((e) => e.id)).toEqual(['a', 'b'])
+    expect(ids(loadRecentFlames())).toEqual(['a', 'b'])
   })
 
-  it('still drops schema-invalid entries from the validated read', () => {
-    seed([goodEntry('a'), brokenEntry('bad'), goodEntry('b')])
-    expect(loadRecentFlames().map((e) => e.id)).toEqual(['a', 'b'])
+  it('reflects a save without an explicit invalidation', () => {
+    seed([goodEntry('a')])
+    loadRecentFlames()
+    saveRecentFlame(sampleFlame(), 'fresh')
+    expect(loadRecentFlames().map((e) => e.name)).toContain('fresh')
+  })
+
+  it('reflects a delete without an explicit invalidation', () => {
+    seed([goodEntry('a'), goodEntry('b')])
+    loadRecentFlames()
+    deleteRecentFlame('a')
+    expect(ids(loadRecentFlames())).toEqual(['b'])
+  })
+
+  it('reflects a wholesale overwrite by the backup importer', () => {
+    seed([goodEntry('a')])
+    loadRecentFlames()
+    saveRecentFlames([goodEntry('x'), goodEntry('y')] as never)
+    expect(ids(loadRecentFlames())).toEqual(['x', 'y'])
+  })
+
+  it('empties after clearRecentFlames', () => {
+    seed([goodEntry('a')])
+    loadRecentFlames()
+    clearRecentFlames()
+    expect(loadRecentFlames()).toEqual([])
+  })
+
+  it('stays correct when an identical payload is written back', () => {
+    const payload = [goodEntry('a'), goodEntry('b')]
+    seed(payload)
+    expect(ids(loadRecentFlames())).toEqual(['a', 'b'])
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(payload))
+    expect(ids(loadRecentFlames())).toEqual(['a', 'b'])
+  })
+
+  it('freezes shared entries in dev so a caller cannot corrupt later reads', () => {
+    seed([goodEntry('a')])
+    const entry = loadRecentFlames()[0]!
+    expect(Object.isFrozen(entry)).toBe(true)
+    expect(() => {
+      ;(entry as { name: string }).name = 'mutated'
+    }).toThrow()
+    expect(loadRecentFlames()[0]!.name).toBe('good a')
   })
 })
 
-// Regression: a read-modify-write built on the *validated* list rewrites storage
-// without the entries the validator rejected, so one save or delete silently
-// deletes them. `loadRecentFlamesForRewrite` exists for exactly this.
-describe('read-modify-write preserves schema-invalid entries', () => {
-  it('saving a flame does not delete them', () => {
+// ── loadRecentFlamesForRewrite ────────────────────────────────────────────
+
+describe('loadRecentFlamesForRewrite', () => {
+  it('keeps schema-invalid entries the validated loader drops', () => {
+    seed([goodEntry('a'), brokenEntry('bad')])
+    expect(ids(loadRecentFlames())).toEqual(['a'])
+    expect(ids(loadRecentFlamesForRewrite())).toEqual(['a', 'bad'])
+  })
+
+  it('still drops structurally invalid entries', () => {
+    seed([goodEntry('a'), { id: 'no-name', savedAt: 1, flame: {} }])
+    expect(ids(loadRecentFlamesForRewrite())).toEqual(['a'])
+  })
+
+  it('returns empty for malformed JSON', () => {
+    seedRaw('nope')
+    expect(loadRecentFlamesForRewrite()).toEqual([])
+  })
+
+  it('returns empty when the payload is not an array', () => {
+    seedRaw(JSON.stringify({ id: 'a' }))
+    expect(loadRecentFlamesForRewrite()).toEqual([])
+  })
+
+  it('returns empty when nothing is stored', () => {
+    expect(loadRecentFlamesForRewrite()).toEqual([])
+  })
+
+  it('returns unfrozen entries, since rewrites build on them', () => {
+    seed([goodEntry('a')])
+    expect(Object.isFrozen(loadRecentFlamesForRewrite()[0])).toBe(false)
+  })
+})
+
+// ── saveRecentFlame ───────────────────────────────────────────────────────
+
+describe('saveRecentFlame', () => {
+  it('prepends the new entry', () => {
+    seed([goodEntry('a')])
+    saveRecentFlame(sampleFlame(), 'newest')
+    expect(loadRecentFlames()[0]!.name).toBe('newest')
+  })
+
+  it('falls back to the flame name, then a default', () => {
+    seed([])
+    saveRecentFlame(sampleFlame())
+    const name = loadRecentFlames()[0]!.name
+    expect(name === sampleFlame().metadata?.name || name === 'Flame').toBe(true)
+  })
+
+  it('stores tracks only when there are keyframes', () => {
+    seed([])
+    saveRecentFlame(sampleFlame(), 'no tracks', [])
+    expect(loadRecentFlamesForRewrite()[0]!.tracks).toBeUndefined()
+  })
+
+  it('stores tracks when there are keyframes, deep-cloned', () => {
+    seed([])
+    const tracks = [sampleTrack()]
+    saveRecentFlame(sampleFlame(), 'animated', tracks as never)
+    const saved = loadRecentFlamesForRewrite()[0]!
+    expect(saved.tracks).toHaveLength(1)
+    // Cloned, not aliased: editing the caller's tracks must not rewrite history.
+    tracks[0]!.id = 'mutated-after-save'
+    expect(loadRecentFlamesForRewrite()[0]!.tracks).not.toContainEqual(
+      expect.objectContaining({ id: 'mutated-after-save' }),
+    )
+  })
+
+  it('deep-clones the flame so later edits do not rewrite history', () => {
+    seed([])
+    const flame = structuredClone(sampleFlame())
+    saveRecentFlame(flame, 'snapshot')
+    const before = JSON.stringify(loadRecentFlamesForRewrite()[0]!.flame)
+    flame.renderSettings.dimensions =
+      flame.renderSettings.dimensions === 3 ? 2 : 3
+    expect(JSON.stringify(loadRecentFlamesForRewrite()[0]!.flame)).toBe(before)
+  })
+
+  // Regression: a read-modify-write on the *validated* list rewrites storage
+  // without the entries the validator rejected.
+  it('preserves schema-invalid entries', () => {
     seed([goodEntry('a'), brokenEntry('bad')])
     saveRecentFlame(sampleFlame(), 'new one')
-    expect(loadRecentFlamesForRewrite().map((e) => e.id)).toContain('bad')
+    expect(ids(loadRecentFlamesForRewrite())).toContain('bad')
   })
 
-  it('deleting one entry does not delete them', () => {
-    seed([goodEntry('a'), brokenEntry('bad'), goodEntry('b')])
-    deleteRecentFlame('a')
-    const ids = loadRecentFlamesForRewrite().map((e) => e.id)
-    expect(ids).toContain('bad')
-    expect(ids).not.toContain('a')
-  })
-
-  it('counts them toward the full-list guard', () => {
+  it('counts schema-invalid entries toward the full-list guard', () => {
     seed(
       Array.from({ length: MAX_RECENT_FLAMES }, (_, i) => brokenEntry(`b${i}`)),
     )
-    // The list IS full; a non-forcing save must refuse rather than silently
-    // rewriting 150 broken entries down to one good one.
     expect(saveRecentFlame(sampleFlame(), 'nope', undefined, false)).toBe(false)
     expect(loadRecentFlamesForRewrite()).toHaveLength(MAX_RECENT_FLAMES)
+  })
+
+  it('refuses without force when the list is full, and writes nothing', () => {
+    seed(
+      Array.from({ length: MAX_RECENT_FLAMES }, (_, i) => goodEntry(`g${i}`)),
+    )
+    const before = localStorage.getItem(STORAGE_KEY)
+    expect(saveRecentFlame(sampleFlame(), 'nope', undefined, false)).toBe(false)
+    expect(localStorage.getItem(STORAGE_KEY)).toBe(before)
+  })
+
+  it('evicts the oldest when forced, staying at the cap', () => {
+    seed(
+      Array.from({ length: MAX_RECENT_FLAMES }, (_, i) =>
+        goodEntry(`g${i}`, i),
+      ),
+    )
+    expect(saveRecentFlame(sampleFlame(), 'forced', undefined, true)).toBe(true)
+    const after = loadRecentFlamesForRewrite()
+    expect(after).toHaveLength(MAX_RECENT_FLAMES)
+    expect(after[0]!.name).toBe('forced')
+    expect(ids(after)).not.toContain(`g${MAX_RECENT_FLAMES - 1}`)
+  })
+
+  // Regression: this used to return true even when the write failed, and the
+  // caller marks the workspace clean on success.
+  it('reports failure when the storage write fails', () => {
+    vi.stubGlobal('localStorage', {
+      getItem: () => null,
+      setItem: () => {
+        throw new Error('QuotaExceededError')
+      },
+      removeItem: () => {},
+    })
+    expect(saveRecentFlame(sampleFlame(), 'doomed')).toBe(false)
+  })
+})
+
+// ── deleteRecentFlame ─────────────────────────────────────────────────────
+
+describe('deleteRecentFlame', () => {
+  it('removes the named entry', () => {
+    seed([goodEntry('a'), goodEntry('b')])
+    expect(deleteRecentFlame('a')).toBe(true)
+    expect(ids(loadRecentFlames())).toEqual(['b'])
+  })
+
+  it('is a no-op for an unknown id', () => {
+    seed([goodEntry('a')])
+    deleteRecentFlame('nope')
+    expect(ids(loadRecentFlames())).toEqual(['a'])
+  })
+
+  it('preserves schema-invalid entries', () => {
+    seed([goodEntry('a'), brokenEntry('bad'), goodEntry('b')])
+    deleteRecentFlame('a')
+    const remaining = ids(loadRecentFlamesForRewrite())
+    expect(remaining).toContain('bad')
+    expect(remaining).not.toContain('a')
+  })
+
+  it('reports failure when the storage write fails', () => {
+    vi.stubGlobal('localStorage', {
+      getItem: () => JSON.stringify([goodEntry('a')]),
+      setItem: () => {
+        throw new Error('QuotaExceededError')
+      },
+      removeItem: () => {},
+    })
+    expect(deleteRecentFlame('a')).toBe(false)
+  })
+})
+
+// ── getOldestRecentFlame ──────────────────────────────────────────────────
+
+describe('getOldestRecentFlame', () => {
+  it('returns undefined for an empty list', () => {
+    seed([])
+    expect(getOldestRecentFlame()).toBeUndefined()
+  })
+
+  it('returns the last stored entry', () => {
+    seed([goodEntry('newest'), goodEntry('oldest')])
+    expect(getOldestRecentFlame()?.id).toBe('oldest')
+  })
+
+  // It names the entry a forced save would evict, so it must see the entries
+  // the schema rejects — those get evicted too.
+  it('can name a schema-invalid entry', () => {
+    seed([goodEntry('a'), brokenEntry('bad')])
+    expect(getOldestRecentFlame()?.id).toBe('bad')
+  })
+})
+
+// ── upsertRecentFlame (autosave path) ─────────────────────────────────────
+
+describe('upsertRecentFlame', () => {
+  it('inserts a new entry at the front', () => {
+    seed([goodEntry('a')])
+    expect(upsertRecentFlame('auto', sampleFlame(), 'Autosaved')).toBe(true)
+    expect(ids(loadRecentFlamesForRewrite())).toEqual(['auto', 'a'])
+  })
+
+  it('updates in place by id instead of appending a duplicate', () => {
+    seed([goodEntry('a'), goodEntry('auto')])
+    upsertRecentFlame('auto', sampleFlame(), 'Updated')
+    const after = loadRecentFlamesForRewrite()
+    expect(ids(after)).toEqual(['auto', 'a'])
+    expect(after[0]!.name).toBe('Updated')
+  })
+
+  it('keeps the list at the cap', () => {
+    seed(
+      Array.from({ length: MAX_RECENT_FLAMES }, (_, i) => goodEntry(`g${i}`)),
+    )
+    upsertRecentFlame('auto', sampleFlame(), 'Autosaved')
+    expect(loadRecentFlamesForRewrite()).toHaveLength(MAX_RECENT_FLAMES)
+  })
+
+  it('preserves schema-invalid entries', () => {
+    seed([brokenEntry('bad')])
+    upsertRecentFlame('auto', sampleFlame(), 'Autosaved')
+    expect(ids(loadRecentFlamesForRewrite())).toContain('bad')
+  })
+
+  it('stores tracks when there are keyframes, and omits empty ones', () => {
+    seed([])
+    upsertRecentFlame('auto', sampleFlame(), 'Animated', [
+      sampleTrack(),
+    ] as never)
+    expect(loadRecentFlamesForRewrite()[0]!.tracks).toHaveLength(1)
+    upsertRecentFlame('auto2', sampleFlame(), 'Plain', [])
+    expect(loadRecentFlamesForRewrite()[0]!.tracks).toBeUndefined()
+  })
+
+  it('falls back to "Autosave" with no name, no metadata and no prior entry', () => {
+    seed([])
+    const unnamed = {
+      ...sampleFlame(),
+      metadata: undefined,
+    } as unknown as FlameDescriptor
+    upsertRecentFlame('auto', unnamed)
+    expect(loadRecentFlamesForRewrite()[0]!.name).toBe('Autosave')
+  })
+
+  it('inherits the existing name when none is given', () => {
+    seed([])
+    upsertRecentFlame('auto', sampleFlame(), 'Original')
+    upsertRecentFlame('auto', sampleFlame())
+    expect(loadRecentFlamesForRewrite()[0]!.name).toBe('Original')
+  })
+
+  it('reports failure when the storage write fails', () => {
+    vi.stubGlobal('localStorage', {
+      getItem: () => null,
+      setItem: () => {
+        throw new Error('QuotaExceededError')
+      },
+      removeItem: () => {},
+    })
+    expect(upsertRecentFlame('auto', sampleFlame(), 'doomed')).toBe(false)
+  })
+})
+
+// ── formatRecentDate ──────────────────────────────────────────────────────
+
+describe('formatRecentDate', () => {
+  // Fixed clock: 2026-05-26 14:30 local, so "today"/"yesterday" are decidable.
+  const NOW = new Date(2026, 4, 26, 14, 30, 0)
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(NOW)
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('labels today by time alone', () => {
+    expect(formatRecentDate(new Date(2026, 4, 26, 9, 5).getTime())).toBe(
+      'Today, 09:05',
+    )
+  })
+
+  it('labels yesterday', () => {
+    expect(formatRecentDate(new Date(2026, 4, 25, 23, 59).getTime())).toBe(
+      'Yesterday, 23:59',
+    )
+  })
+
+  it('falls back to month and day for anything older', () => {
+    expect(formatRecentDate(new Date(2026, 4, 20, 14, 30).getTime())).toMatch(
+      /^\w+ 20, 14:30$/,
+    )
+  })
+
+  it('crosses a month boundary for yesterday', () => {
+    vi.setSystemTime(new Date(2026, 5, 1, 8, 0))
+    expect(formatRecentDate(new Date(2026, 4, 31, 8, 0).getTime())).toBe(
+      'Yesterday, 08:00',
+    )
+  })
+
+  it('does not call the same day in a different year "today"', () => {
+    expect(formatRecentDate(new Date(2025, 4, 26, 14, 30).getTime())).toMatch(
+      /^\w+ 26, 14:30$/,
+    )
+  })
+
+  it('zero-pads hours and minutes', () => {
+    expect(formatRecentDate(new Date(2026, 4, 26, 0, 0).getTime())).toBe(
+      'Today, 00:00',
+    )
   })
 })

--- a/packages/app/src/utils/recentFlames.test.ts
+++ b/packages/app/src/utils/recentFlames.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { examples } from '@/flame/examples'
+import { clearRecentFlamesCache, deleteRecentFlame, loadRecentFlames, loadRecentFlamesForRewrite, MAX_RECENT_FLAMES, saveRecentFlame, } from './recentFlames'
+import type { FlameDescriptor } from '@/flame/schema/flameSchema'
+
+const STORAGE_KEY = 'chaos-master-recent-flames'
+
+const sampleFlame = () => Object.values(examples)[0] as FlameDescriptor
+
+/** An entry that passes the structural check but fails the flame schema — the
+ *  shape a stale save or a schema tightening leaves behind. */
+const brokenEntry = (id: string) => ({
+  id,
+  name: `broken ${id}`,
+  savedAt: Date.now(),
+  flame: { nonsense: true },
+})
+
+const goodEntry = (id: string) => ({
+  id,
+  name: `good ${id}`,
+  savedAt: Date.now(),
+  flame: sampleFlame(),
+})
+
+// The runner's own localStorage is not writable; back it with a plain map, the
+// same way `flameImport.test.ts` does.
+const stored = new Map<string, string>()
+const memoryStorage = {
+  getItem: (key: string) => stored.get(key) ?? null,
+  setItem: (key: string, value: string) => {
+    stored.set(key, value)
+  },
+  removeItem: (key: string) => {
+    stored.delete(key)
+  },
+  clear: () => {
+    stored.clear()
+  },
+  key: (index: number) => [...stored.keys()][index] ?? null,
+  get length() {
+    return stored.size
+  },
+}
+
+function seed(entries: unknown[]) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(entries))
+  clearRecentFlamesCache()
+}
+
+beforeEach(() => {
+  vi.stubGlobal('localStorage', memoryStorage)
+  stored.clear()
+  clearRecentFlamesCache()
+})
+
+describe('loadRecentFlames memo', () => {
+  it('returns the same content on a repeat call', () => {
+    seed([goodEntry('a'), goodEntry('b')])
+    const first = loadRecentFlames()
+    const second = loadRecentFlames()
+    expect(second).toHaveLength(first.length)
+    expect(second.map((e) => e.id)).toEqual(first.map((e) => e.id))
+  })
+
+  it('hands out a fresh array so callers cannot corrupt the memo', () => {
+    seed([goodEntry('a'), goodEntry('b')])
+    const first = loadRecentFlames()
+    first.pop()
+    expect(loadRecentFlames()).toHaveLength(2)
+  })
+
+  it('re-reads when the stored payload changes underneath it', () => {
+    seed([goodEntry('a')])
+    expect(loadRecentFlames().map((e) => e.id)).toEqual(['a'])
+
+    // Written directly, as another tab would — no invalidation call.
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify([goodEntry('a'), goodEntry('b')]),
+    )
+    expect(loadRecentFlames().map((e) => e.id)).toEqual(['a', 'b'])
+  })
+
+  it('still drops schema-invalid entries from the validated read', () => {
+    seed([goodEntry('a'), brokenEntry('bad'), goodEntry('b')])
+    expect(loadRecentFlames().map((e) => e.id)).toEqual(['a', 'b'])
+  })
+})
+
+// Regression: a read-modify-write built on the *validated* list rewrites storage
+// without the entries the validator rejected, so one save or delete silently
+// deletes them. `loadRecentFlamesForRewrite` exists for exactly this.
+describe('read-modify-write preserves schema-invalid entries', () => {
+  it('saving a flame does not delete them', () => {
+    seed([goodEntry('a'), brokenEntry('bad')])
+    saveRecentFlame(sampleFlame(), 'new one')
+    expect(loadRecentFlamesForRewrite().map((e) => e.id)).toContain('bad')
+  })
+
+  it('deleting one entry does not delete them', () => {
+    seed([goodEntry('a'), brokenEntry('bad'), goodEntry('b')])
+    deleteRecentFlame('a')
+    const ids = loadRecentFlamesForRewrite().map((e) => e.id)
+    expect(ids).toContain('bad')
+    expect(ids).not.toContain('a')
+  })
+
+  it('counts them toward the full-list guard', () => {
+    seed(
+      Array.from({ length: MAX_RECENT_FLAMES }, (_, i) => brokenEntry(`b${i}`)),
+    )
+    // The list IS full; a non-forcing save must refuse rather than silently
+    // rewriting 150 broken entries down to one good one.
+    expect(saveRecentFlame(sampleFlame(), 'nope', undefined, false)).toBe(false)
+    expect(loadRecentFlamesForRewrite()).toHaveLength(MAX_RECENT_FLAMES)
+  })
+})

--- a/packages/app/src/utils/recentFlames.ts
+++ b/packages/app/src/utils/recentFlames.ts
@@ -52,10 +52,33 @@ export function clearRecentFlamesCache(): void {
   validatedCache = undefined
 }
 
+/** Dev-only tripwire for the read-only contract above. Sharing entries between
+ *  callers is what makes the memo cheap, so a caller that mutates one instead of
+ *  cloning would corrupt every later read — a bug that is invisible until some
+ *  unrelated screen shows stale data. Freezing turns it into a throw at the
+ *  mutation site. Paid once per distinct payload, and `import.meta.env.DEV` is
+ *  statically false in production, so this whole path is dropped from the
+ *  bundle. */
+function deepFreeze<T>(value: T, seen = new WeakSet<object>()): T {
+  if (typeof value !== 'object' || value === null) return value
+  // Freezing a typed array with elements throws; stored flames are JSON so this
+  // should not arise, but a dev-only guard must not be the thing that crashes.
+  if (ArrayBuffer.isView(value)) return value
+  if (seen.has(value)) return value
+  seen.add(value)
+  for (const key of Object.getOwnPropertyNames(value)) {
+    deepFreeze((value as Record<string, unknown>)[key], seen)
+  }
+  return Object.freeze(value)
+}
+
 export function loadRecentFlames(): RecentFlame[] {
   try {
     const raw = safeGetItem(STORAGE_KEY)
-    if (raw === null) return []
+    if (raw === null) {
+      validatedCache = undefined
+      return []
+    }
     if (validatedCache?.raw === raw) return [...validatedCache.entries]
     const parsed = JSON.parse(raw)
     if (!Array.isArray(parsed)) return []
@@ -63,6 +86,7 @@ export function loadRecentFlames(): RecentFlame[] {
       const flame = tryValidateFlame(item.flame)
       return flame ? [{ ...item, flame }] : []
     })
+    if (import.meta.env.DEV) entries.forEach((entry) => deepFreeze(entry))
     validatedCache = { raw, entries }
     return [...entries]
   } catch {
@@ -96,8 +120,10 @@ export function saveRecentFlame(
     entry.tracks = deepClone(tracks)
   }
   const updated = [entry, ...recent].slice(0, MAX_RECENT_FLAMES)
-  safeSetItem(STORAGE_KEY, JSON.stringify(updated))
-  return true
+  // Report the real outcome. This used to return `true` unconditionally, so a
+  // write that failed on quota or in private mode still told the caller the
+  // flame was saved — and the caller marks the workspace clean on success.
+  return safeSetItem(STORAGE_KEY, JSON.stringify(updated))
 }
 
 /**
@@ -200,12 +226,14 @@ export function formatRecentDate(timestamp: number): string {
   return `${month} ${day}, ${time}`
 }
 
-export function deleteRecentFlame(id: string): void {
+/** @returns false when the localStorage write failed, so a caller can tell the
+ *  user the entry is still there instead of silently leaving it on screen. */
+export function deleteRecentFlame(id: string): boolean {
   // Read-modify-write — structural loader only, so deleting one entry cannot
   // take every schema-rejected entry with it.
   const recent = loadRecentFlamesForRewrite()
   const filtered = recent.filter((item) => item.id !== id)
-  safeSetItem(STORAGE_KEY, JSON.stringify(filtered))
+  return safeSetItem(STORAGE_KEY, JSON.stringify(filtered))
 }
 
 export function clearRecentFlames(): void {

--- a/packages/app/src/utils/recentFlames.ts
+++ b/packages/app/src/utils/recentFlames.ts
@@ -30,16 +30,41 @@ function isValidRecentFlame(item: unknown): item is RecentFlame {
   )
 }
 
+/** Memo for `loadRecentFlames`, keyed on the exact payload it was built from.
+ *
+ *  The schema pass costs ~90ms for a full 150-entry list (measured; `JSON.parse`
+ *  of the same payload is ~2ms), and the Load Flame modal reloads the list on
+ *  open, on import and on every delete — so without this, opening the modal
+ *  re-validates the same 150 flames and blocks the frame each time.
+ *
+ *  Keying on the raw string rather than asking writers to invalidate means any
+ *  write invalidates it for free, including ones this module never sees: another
+ *  tab, a devtools edit, or a future writer that forgets to call an invalidator.
+ *
+ *  Entries are shared with every caller, so they must be treated as read-only —
+ *  which is already the contract elsewhere (consumers `deepClone` before
+ *  editing). Only the outer array is copied per call, so callers can still
+ *  filter and spread freely. */
+let validatedCache: { raw: string; entries: readonly RecentFlame[] } | undefined
+
+/** Test seam: drop the memo so a test can observe a fresh validation pass. */
+export function clearRecentFlamesCache(): void {
+  validatedCache = undefined
+}
+
 export function loadRecentFlames(): RecentFlame[] {
   try {
     const raw = safeGetItem(STORAGE_KEY)
     if (raw === null) return []
+    if (validatedCache?.raw === raw) return [...validatedCache.entries]
     const parsed = JSON.parse(raw)
     if (!Array.isArray(parsed)) return []
-    return parsed.filter(isValidRecentFlame).flatMap((item) => {
+    const entries = parsed.filter(isValidRecentFlame).flatMap((item) => {
       const flame = tryValidateFlame(item.flame)
       return flame ? [{ ...item, flame }] : []
     })
+    validatedCache = { raw, entries }
+    return [...entries]
   } catch {
     return []
   }
@@ -51,7 +76,11 @@ export function saveRecentFlame(
   tracks?: TimelineTrack[],
   forceOverwriteOldest: boolean = true,
 ): boolean {
-  const recent = loadRecentFlames()
+  // Read-modify-write: use the structural loader, not the schema one. Rewriting
+  // the list from schema-validated entries silently deletes every entry the
+  // validator rejects, and under-counts the list so the "full" guard below
+  // never fires. Same reasoning as `upsertRecentFlame`.
+  const recent = loadRecentFlamesForRewrite()
   if (recent.length >= MAX_RECENT_FLAMES && !forceOverwriteOldest) {
     return false
   }
@@ -130,8 +159,12 @@ export function upsertRecentFlame(
   return safeSetItem(STORAGE_KEY, JSON.stringify(updated))
 }
 
+/** The oldest stored entry — the one a save would evict. Structural load only:
+ *  the caller reads `name` for a confirm prompt, so a schema pass over the whole
+ *  list would be wasted work, and a rejected entry is still a real entry that
+ *  can be evicted. */
 export function getOldestRecentFlame(): RecentFlame | undefined {
-  const recent = loadRecentFlames()
+  const recent = loadRecentFlamesForRewrite()
   if (recent.length === 0) return undefined
   return recent[recent.length - 1]
 }
@@ -168,7 +201,9 @@ export function formatRecentDate(timestamp: number): string {
 }
 
 export function deleteRecentFlame(id: string): void {
-  const recent = loadRecentFlames()
+  // Read-modify-write — structural loader only, so deleting one entry cannot
+  // take every schema-rejected entry with it.
+  const recent = loadRecentFlamesForRewrite()
   const filtered = recent.filter((item) => item.id !== id)
   safeSetItem(STORAGE_KEY, JSON.stringify(filtered))
 }

--- a/packages/app/src/webmcp/tools/createClashFlame.ts
+++ b/packages/app/src/webmcp/tools/createClashFlame.ts
@@ -70,14 +70,20 @@ function translateTransform3D(
     dz,
   ) as typeof clone.postAffine
 
-  console.info(
-    `[Arena 3D Upgrade] Translating transform (dx:${dx}, dy:${dy}, dz:${dz}).
+  // Dev only: this runs once per transform, twice per clash, so a 6-vs-6 duel
+  // prints a dozen affine dumps. `import.meta.env.DEV` is statically replaced
+  // with `false` in production, so the whole block — strings included — is
+  // dropped from the bundle rather than merely skipped at runtime.
+  if (import.meta.env.DEV) {
+    console.info(
+      `[Arena 3D Upgrade] Translating transform (dx:${dx}, dy:${dy}, dz:${dz}).
   - preAffine upgraded from 2D? ${is2DPre} => `,
-    clone.preAffine,
-    `
+      clone.preAffine,
+      `
   - postAffine upgraded from 2D? ${is2DPost} => `,
-    clone.postAffine,
-  )
+      clone.postAffine,
+    )
+  }
 
   if (tintColor !== undefined && tintMode !== 'none') {
     const rawColor = clone.color as unknown


### PR DESCRIPTION
Follow-up to the audit of the `flameXml.ts:929` rAF violation reported on the deployed site.

## The reported violation was misattributed

```
flameXml.ts:929 [Violation] 'requestAnimationFrame' handler took 325ms
```

Line 929 sits in `variationAttrs`, an **export-only** helper reachable solely from `exportFlameXml`, whose one caller is `ShareLinkModal.tsx:215`. Nothing on the Load Flame path reaches it — the modal imports `parseFlameXml`/`isFlameXmlContent` but only calls them in the drop/paste handler — and `flameXml.ts` contains no `requestAnimationFrame` at all. The build sets `sourcemap: true`, so Chrome resolves the sampled frame through the sourcemap, and after minification and chunk-splitting that lands on a neighbouring module. Real slowness, wrong file.

## 1. What actually blocked the frame

`LoadFlameModal` calls `loadRecentFlames()` on construction, on import, and on every delete. Each call re-ran valibot over all 150 stored flames. Measured on a full list (383KB payload):

| step | cost |
| --- | --- |
| `JSON.parse` | 2.4ms |
| `tryValidateFlame` × 150 | **90.0ms** |
| total | 92.5ms |

That explains why it was intermittent — a user with a handful of recents never sees it; one near `MAX_RECENT_FLAMES` pays it on every open.

**Fix:** memoize the validated list against the exact payload it was built from. Keying on the raw string instead of asking writers to invalidate means any write invalidates it for free, including writes this module never sees (another tab, a devtools edit, a future writer that forgets an invalidator).

```
cold 104.7ms  ->  warm 0.00ms/call
```

Cold load is unchanged. Only the outer array is copied per call, so callers can still filter and spread; entries are shared and must be treated as read-only, which is already the contract — consumers `deepClone` before editing.

## 2. A data-loss bug in the same file

Found while reading it. `saveRecentFlame` and `deleteRecentFlame` did a read-modify-write on top of the **validated** list, so rewriting storage silently deleted every entry the schema rejected. One save, or one delete of an unrelated flame, was enough to lose them. It also under-counted the list, so the "full" guard in `saveRecentFlame` never fired when rejected entries were the ones filling it.

`loadRecentFlamesForRewrite` already exists for exactly this hazard and says so in its doc comment — `upsertRecentFlame` (autosave) was its only caller. Both rewrite paths now use it. `getOldestRecentFlame` moves too: its caller reads only `name` for a confirm prompt, so a schema pass over the whole list was wasted work, and a rejected entry is still a real entry that a save would evict.

New `recentFlames.test.ts` covers memo identity and invalidation (including an out-of-band write), plus the three read-modify-write cases. **Verified non-vacuous** — all three fail against the previous implementation.

## 3. Dev logs shipping to production

The build has no `drop_console` and no terser `pure_funcs`, so every `console.*` ships verbatim. Four tracing calls were never gated — the loudest being the Arena 3D upgrade log, which runs once per transform inside *both* combatant loops, so a 6-vs-6 clash prints a dozen affine dumps to a real user's console.

Gated with inline `import.meta.env.DEV`, matching the existing convention in `jsonQueryParam.ts` and `registerWebMcp.ts`. Vite statically replaces it with `false` and drops the whole block, so the format strings and object dumps never reach the bundle — unlike a runtime check, which still ships them. This is also the "localhost builds only" behaviour, since it's true only under `vite dev`.

| gated | fires |
| --- | --- |
| `createClashFlame.ts` | per transform, twice per clash |
| `MainWorkspace.tsx` | per tour command |
| `MainWorkspace.tsx` | per variation-picker open |
| `PaletteSelector.tsx` | per palette import |

Deliberately left alone:

- **`WebgpuAdapter.ts`** — adapter vendor/features, once per page load, commented as intentional ("Always log adapter info for remote diagnostics") and genuinely useful for triaging user reports.
- **`homeConfig.ts`** — settings-fetch fallback, once per page load, documented as a non-error.
- **`cpuFlameRenderer.ts`** — `[CPU Test]` scaffolding; the module is imported by nothing but its own test, so it is tree-shaken out of the production bundle entirely.

## Not addressed here

`console-store.ts` retains logged `args` **by reference** for up to 2000 entries, pinning every logged object graph from GC, and allocates a new array identity per push so anything subscribed to `consoleLogs` re-renders on every console call. Measured at 0.01ms/log, so it is a retention concern rather than the latency source — left for a separate change.

Also worth knowing: the modal's preview tiles are **not** a problem. They are properly lazy behind an IntersectionObserver (`nearViewport()`), and the gallery memos are gated on `isGallery()`.

## Verification

From the repo root, all exit 0:

- `pnpm typecheck`
- `pnpm lint` (1 pre-existing warning in `AncestryTreeModal.tsx`, unrelated)
- `pnpm --filter chaos-master exec vitest run` — 155 files, **1939 tests passed**
