### PR TITLE
fix(dropzone): take fileless drops and clear the stuck drop highlight

### DIFF
--- a/packages/app/dev.changelog.md
+++ b/packages/app/dev.changelog.md
@@ -164,6 +164,19 @@ implementations.
 
 ### Fixed
 
+- **Dropzone highlight stuck after a fileless drop** (`components/Dropzone/`,
+  `utils/dataTransferFiles.ts`, `LoadFlameModal.tsx`): a drop whose
+  `DataTransfer` carried no `File` (a URL dragged from another window, or a
+  Linux file-manager drop that Chromium delivers with an empty `files` list)
+  returned early, before `preventDefault` and before clearing the `dropping`
+  state, so the white drop overlay stayed on screen and the browser could run
+  its default action (navigating to a dropped URL). The drop is now always
+  taken and the highlight always cleared; files are read from `items` when
+  `files` is empty (shared with the Load Flame modal's own zone), and a
+  fileless drop logs the transfer types. dragenter/dragleave use a depth
+  counter (plus `relatedTarget` where the browser reports it) so the highlight
+  no longer flickers when the pointer crosses child elements.
+
 - **`wrangler dev` OOM-killed the workstation** (`packages/app/wrangler.jsonc`,
   `packages/app/package.json`): both envs declared `build.command`, and
   wrangler runs a custom build for `dev` as well as `deploy`, re-running it on

--- a/packages/app/src/components/Dropzone/Dropzone.test.tsx
+++ b/packages/app/src/components/Dropzone/Dropzone.test.tsx
@@ -1,0 +1,90 @@
+import { cleanup, render } from '@solidjs/testing-library'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { Dropzone } from './Dropzone'
+
+type FakeTransfer = {
+  files?: File[]
+  items?: { kind: string; getAsFile: () => File | null }[]
+  types?: string[]
+}
+
+/** A drag event carrying a hand-built DataTransfer (happy-dom has none). */
+function dragEvent(type: string, transfer: FakeTransfer = {}): Event {
+  const ev = new Event(type, { bubbles: true, cancelable: true })
+  const files = transfer.files ?? []
+  Object.defineProperty(ev, 'dataTransfer', {
+    value: {
+      files: { length: files.length, item: (i: number) => files[i] ?? null },
+      items: transfer.items ?? [],
+      types: transfer.types ?? [],
+      dropEffect: 'none',
+    },
+  })
+  return ev
+}
+
+function setup() {
+  const onDrop = vi.fn()
+  const { container } = render(() => (
+    <Dropzone onDrop={onDrop}>
+      <div data-testid="child">child</div>
+    </Dropzone>
+  ))
+  const zone = container.querySelector('.dropzone') as HTMLElement
+  const child = container.querySelector('[data-testid="child"]') as HTMLElement
+  return { zone, child, onDrop }
+}
+
+describe('Dropzone', () => {
+  afterEach(cleanup)
+
+  it('clears the highlight and takes the drop even when no file arrives', () => {
+    // A drop with no File (a URL dragged from another window, or a file
+    // manager drop that Chromium delivered without the File objects) used to
+    // leave the white border on screen and let the browser run its default,
+    // which for a dropped URL is navigating away.
+    const { zone, onDrop } = setup()
+    zone.dispatchEvent(dragEvent('dragenter'))
+    expect(zone.classList.contains('dropping')).toBe(true)
+
+    const drop = dragEvent('drop', { types: ['text/uri-list'] })
+    zone.dispatchEvent(drop)
+
+    expect(zone.classList.contains('dropping')).toBe(false)
+    expect(drop.defaultPrevented).toBe(true)
+    expect(onDrop).not.toHaveBeenCalled()
+  })
+
+  it('hands the first dropped file to onDrop and clears the highlight', () => {
+    const { zone, onDrop } = setup()
+    const file = new File(['x'], 'flame.png', { type: 'image/png' })
+    zone.dispatchEvent(dragEvent('dragenter'))
+    zone.dispatchEvent(dragEvent('drop', { files: [file] }))
+
+    expect(onDrop).toHaveBeenCalledWith(file)
+    expect(zone.classList.contains('dropping')).toBe(false)
+  })
+
+  it('falls back to DataTransfer.items when files is empty', () => {
+    const { zone, onDrop } = setup()
+    const file = new File(['x'], 'flame.png', { type: 'image/png' })
+    zone.dispatchEvent(
+      dragEvent('drop', { items: [{ kind: 'file', getAsFile: () => file }] }),
+    )
+    expect(onDrop).toHaveBeenCalledWith(file)
+  })
+
+  it('keeps the highlight while the pointer moves between children', () => {
+    const { zone, child } = setup()
+    zone.dispatchEvent(dragEvent('dragenter'))
+    // Moving onto a child fires dragenter on the child (it bubbles) and then
+    // dragleave on the zone itself; a plain boolean turns the highlight off here.
+    child.dispatchEvent(dragEvent('dragenter'))
+    zone.dispatchEvent(dragEvent('dragleave'))
+    expect(zone.classList.contains('dropping')).toBe(true)
+
+    // Leaving the zone from the child is the last dragleave out.
+    child.dispatchEvent(dragEvent('dragleave'))
+    expect(zone.classList.contains('dropping')).toBe(false)
+  })
+})

--- a/packages/app/src/components/Dropzone/Dropzone.tsx
+++ b/packages/app/src/components/Dropzone/Dropzone.tsx
@@ -1,4 +1,5 @@
 import { createEffect, createSignal, onCleanup } from 'solid-js'
+import { filesFromDataTransfer } from '@/utils/dataTransferFiles'
 import ui from './Dropzone.module.css'
 import type { ParentProps } from 'solid-js'
 
@@ -21,6 +22,16 @@ type DropzoneProps = {
 
 export function Dropzone(props: ParentProps<DropzoneProps>) {
   const [dropping, setDropping] = createSignal(false)
+  // dragenter/dragleave fire for every element the pointer crosses and bubble
+  // up here, so a plain boolean flips off each time the pointer moves onto a
+  // child. Count the nesting instead; a drop, or a leave to somewhere outside
+  // the zone, resets it.
+  let depth = 0
+
+  const reset = () => {
+    depth = 0
+    setDropping(false)
+  }
 
   preventDraggingAnyElement()
 
@@ -32,25 +43,49 @@ export function Dropzone(props: ParentProps<DropzoneProps>) {
         [ui.dropping as string]: dropping(),
       }}
       onDragEnter={() => {
+        depth += 1
         setDropping(true)
       }}
-      onDragLeave={() => {
-        setDropping(false)
+      onDragLeave={(ev) => {
+        const next = ev.relatedTarget
+        // Browsers that report where the pointer went (Chromium, Firefox) let
+        // a leave to outside the zone clear the highlight even if the count
+        // drifted; the others fall back to the counter.
+        if (next instanceof Node && !ev.currentTarget.contains(next)) {
+          reset()
+          return
+        }
+        depth = Math.max(0, depth - 1)
+        if (depth === 0) setDropping(false)
       }}
       onDragOver={(ev) => {
         // needed for drop to work
         ev.preventDefault()
+        if (ev.dataTransfer) ev.dataTransfer.dropEffect = 'copy'
       }}
       onDrop={(ev) => {
-        const file = ev.dataTransfer?.files.item(0)
-        if (file) {
-          ev.preventDefault()
+        // Take every drop, with or without a file. The browser's default for a
+        // dropped URL is navigating away, and the highlight has to clear either
+        // way: it used to stay on when the payload carried no File.
+        ev.preventDefault()
+        reset()
+        const [file] = filesFromDataTransfer(ev.dataTransfer)
+        if (!file) {
+          console.warn(
+            'Dropzone: drop carried no file; types:',
+            Array.from(ev.dataTransfer?.types ?? []),
+          )
+          return
+        }
+        const report = (err: unknown) => {
+          console.error('Dropzone onDrop handler failed:', err)
+        }
+        try {
           // onDrop may be async (e.g. it loads/parses the file) — surface
           // a rejection instead of letting it become an unhandled rejection.
-          Promise.resolve(props.onDrop(file)).catch((err: unknown) => {
-            console.error('Dropzone onDrop handler failed:', err)
-          })
-          setDropping(false)
+          Promise.resolve(props.onDrop(file)).catch(report)
+        } catch (err) {
+          report(err)
         }
       }}
     >

--- a/packages/app/src/components/LoadFlameModal/LoadFlameModal.tsx
+++ b/packages/app/src/components/LoadFlameModal/LoadFlameModal.tsx
@@ -16,6 +16,7 @@ import { Camera2D } from '@/lib/Camera2D'
 import { Default3DPreviewCamera } from '@/lib/Camera3D'
 import { Root } from '@/lib/Root'
 import { deepClone } from '@/utils/clone'
+import { filesFromDataTransfer } from '@/utils/dataTransferFiles'
 import { applyFlameImport, parseFlameEnvelope, readFlameFiles, summarizeImport, } from '@/utils/flameImport'
 import { extractFlameFromPng } from '@/utils/flameInPng'
 import { useElementIsScrolling } from '@/utils/isScrolling'
@@ -857,7 +858,7 @@ export function LoadFlameModal(props: LoadFlameModalProps) {
   async function handleDrop(e: DragEvent) {
     e.preventDefault()
     setIsDragging(false)
-    const files = [...(e.dataTransfer?.files ?? [])]
+    const files = filesFromDataTransfer(e.dataTransfer)
     if (files.length === 0) return
     await processImportFiles(files)
   }

--- a/packages/app/src/utils/dataTransferFiles.test.ts
+++ b/packages/app/src/utils/dataTransferFiles.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import { filesFromDataTransfer } from './dataTransferFiles'
+
+function fileList(files: File[]): FileList {
+  return {
+    length: files.length,
+    item: (i: number) => files[i] ?? null,
+  } as unknown as FileList
+}
+
+describe('filesFromDataTransfer', () => {
+  it('returns the files list when the browser filled it', () => {
+    const file = new File(['x'], 'a.png')
+    const dt = { files: fileList([file]), items: [] } as unknown as DataTransfer
+    expect(filesFromDataTransfer(dt)).toEqual([file])
+  })
+
+  it('falls back to file items when files is empty', () => {
+    // Some Chromium builds on Linux hand over a file-manager drop with an
+    // empty `files` list while `items` still carries the entries.
+    const file = new File(['x'], 'a.png')
+    const dt = {
+      files: fileList([]),
+      items: [
+        { kind: 'string', getAsFile: () => null },
+        { kind: 'file', getAsFile: () => file },
+      ],
+    } as unknown as DataTransfer
+    expect(filesFromDataTransfer(dt)).toEqual([file])
+  })
+
+  it('is empty for a missing transfer or a drop with no files at all', () => {
+    expect(filesFromDataTransfer(null)).toEqual([])
+    const dt = {
+      files: fileList([]),
+      items: [{ kind: 'string', getAsFile: () => null }],
+    } as unknown as DataTransfer
+    expect(filesFromDataTransfer(dt)).toEqual([])
+  })
+})

--- a/packages/app/src/utils/dataTransferFiles.ts
+++ b/packages/app/src/utils/dataTransferFiles.ts
@@ -1,0 +1,33 @@
+/**
+ * The files a drop carries, from `dataTransfer.files` first and the `items`
+ * list as a fallback.
+ *
+ * Some Chromium builds on Linux (Wayland and X11 file-manager drags) deliver a
+ * drop whose `files` list is empty while `items` still holds the entries; a URL
+ * or image dragged from another window carries no file at all. Callers get an
+ * empty array in that case instead of a crash or a silently ignored drop.
+ */
+export function filesFromDataTransfer(
+  dt: DataTransfer | null | undefined,
+): File[] {
+  if (!dt) return []
+  const out: File[] = []
+  const files = dt.files
+  if (files) {
+    for (let i = 0; i < files.length; i++) {
+      const file = files.item(i)
+      if (file) out.push(file)
+    }
+  }
+  if (out.length > 0) return out
+  const items = dt.items
+  if (!items) return out
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i]
+    if (item && item.kind === 'file') {
+      const file = item.getAsFile()
+      if (file) out.push(file)
+    }
+  }
+  return out
+}


### PR DESCRIPTION
## Problem

Dropping a flame PNG sometimes did nothing and left the white drop overlay stuck on the page until the next drag.

Root cause in `Dropzone.tsx`: both `ev.preventDefault()` and `setDropping(false)` sat inside `if (file)`. A `drop` whose `DataTransfer` carried no `File` returned early, so the `dropping` class (and its `::before` overlay) stayed on, and the browser was free to run its default action, which for a dropped URL is navigating away. `dragleave` never fires after `drop`, so nothing cleared it. Reproduced live on dev by dispatching a fileless `drop` on the workspace zone.

When does a drop carry no `File`? A URL or image dragged from another window (Chromium gives only `text/uri-list`), and Linux file-manager drags that Chromium delivers with an empty `files` list while `items` still holds the entries. The Load Flame modal's own zone reset its highlight but also ignored those drops silently, which matches "neither zone worked" until the next attempt.

## Fix

- `Dropzone`: always `preventDefault` and reset on `drop`; read files through the new `filesFromDataTransfer` helper (`files`, then `items[].getAsFile()`); log the transfer types when a drop still carries no file.
- `dragenter`/`dragleave`: depth counter, plus `relatedTarget` where the browser reports it, so the highlight no longer flickers off when the pointer crosses a child element.
- `LoadFlameModal.handleDrop` uses the same helper, so the modal's zone gets the `items` fallback too.
- `dev.changelog.md` entry under 0.9.9 / Fixed.

## Tests

`Dropzone.test.tsx` (fileless drop clears and prevents default; file drop reaches `onDrop`; `items` fallback; child transitions keep the highlight) and `dataTransferFiles.test.ts`. All three failing cases were red before the change.

```
pnpm --filter chaos-master exec vitest run src/components/Dropzone src/utils/dataTransferFiles src/utils/useAppDragAndDrop src/components/LoadFlameModal
```

## Manual check

Drag a PNG from the file manager onto the workspace: the overlay shows while hovering, the flame loads, the overlay clears. Drag a link from another browser window: the overlay clears, the page does not navigate, the console shows `Dropzone: drop carried no file; types: [...]`.
