### PR TITLE
fix(worker): per-response script-src nonce for Cloudflare's injected bot-detection script

### DIFF
--- a/packages/app/dev.changelog.md
+++ b/packages/app/dev.changelog.md
@@ -268,6 +268,17 @@ implementations.
   panels, live modulation and the timeline first, so leftover exposure/vibrancy
   tracks stop modulating the new descriptor every frame ("too bright"), and no
   dialog stays open across the hand-off.
+- **CSP blocked Cloudflare's bot-detection script on every page load**
+  (`worker/index.ts`): the zone's JavaScript Detections injects an inline
+  `<script>` (`window.__CF$cv$params`, the loader for
+  `/cdn-cgi/challenge-platform/scripts/jsd/main.js`) into HTML responses, and
+  the Worker's `script-src` had no inline allowance, so every load logged a CSP
+  violation and the detection never ran. Its hash changes per request (it
+  embeds the ray id), so a hash allowlist cannot work. The Worker now appends a
+  fresh `'nonce-…'` to `script-src` on every response; Cloudflare copies the
+  nonce it finds in the CSP header onto the tag it injects (its documented
+  mechanism). `'unsafe-inline'` stays out and the app's own `<script src>`
+  tags remain allowed by `'self'`.
 
 ## [0.9.8] - 2026-07-24
 

--- a/packages/app/src/worker/index.test.ts
+++ b/packages/app/src/worker/index.test.ts
@@ -933,3 +933,37 @@ describe('worker frontend routing', () => {
     expect(assetFetch).toHaveBeenCalledWith(request)
   })
 })
+
+describe('worker — CSP script nonce', () => {
+  const cspOf = async () =>
+    (
+      await worker.fetch(
+        post('https://x.test/api/shorten', { payload: 'abc' }),
+        makeEnv(),
+        ctx,
+      )
+    ).headers.get('Content-Security-Policy') ?? ''
+  const scriptSrc = (csp: string) =>
+    csp
+      .split(';')
+      .map((d) => d.trim())
+      .find((d) => d.startsWith('script-src ')) ?? ''
+
+  it('carries a fresh script-src nonce on every response', async () => {
+    // Cloudflare's bot detection ("JavaScript Detections") injects an inline
+    // <script> into the HTML it serves for this zone and copies the nonce it
+    // finds in the CSP response header onto that tag. Without one the browser
+    // refuses the script on every page load; a hash cannot work because the
+    // injected script embeds the request's ray id.
+    const a = scriptSrc(await cspOf())
+    const b = scriptSrc(await cspOf())
+    const nonce = /'nonce-([A-Za-z0-9+/]{22}==)'/
+    expect(a).toMatch(nonce)
+    expect(b).toMatch(nonce)
+    expect(a.match(nonce)?.[1]).not.toBe(b.match(nonce)?.[1])
+    // The nonce is the only inline allowance: scripts still get no
+    // 'unsafe-inline', and the app's own <script src> tags stay on 'self'.
+    expect(a).not.toContain("'unsafe-inline'")
+    expect(a).toContain("'self'")
+  })
+})

--- a/packages/app/src/worker/index.ts
+++ b/packages/app/src/worker/index.ts
@@ -1193,7 +1193,9 @@ const baseHandler = {
 // covers inline / CSS-in-JS styles. This is deliberately not a "strict" CSP,
 // but it still blocks inline <script> / event-handler injection (no
 // 'unsafe-inline' in script-src), cross-origin scripts / frames / connections,
-// clickjacking (frame-ancestors), and <base> injection.
+// clickjacking (frame-ancestors), and <base> injection. The CSP itself is
+// built per response by `contentSecurityPolicy` (see below) so `script-src`
+// can carry a fresh nonce.
 const SECURITY_HEADERS: Readonly<Record<string, string>> = {
   'X-Content-Type-Options': 'nosniff',
   'Referrer-Policy': 'strict-origin-when-cross-origin',
@@ -1215,30 +1217,55 @@ const SECURITY_HEADERS: Readonly<Record<string, string>> = {
     'accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(self), payment=(), usb=(), browsing-topics=()',
   // Disable legacy Adobe cross-domain policy files.
   'X-Permitted-Cross-Domain-Policies': 'none',
-  'Content-Security-Policy': [
-    "default-src 'self'",
-    // GA4 pixels: google-analytics.com is the no-JS/beacon fallback,
-    // googletagmanager.com serves /td and /a (verified blocked by Google's Tag
-    // Assistant before these were listed).
-    "img-src 'self' data: blob: https://*.google-analytics.com https://*.googletagmanager.com",
-    // 'unsafe-eval' is mandatory — TypeGPU uses new Function for shader codegen.
-    // googletagmanager.com serves gtag.js (see lib/telemetry.ts); without it
-    // the loader is refused and no analytics event is ever recorded.
-    "script-src 'self' 'unsafe-eval' 'wasm-unsafe-eval' https://challenges.cloudflare.com https://*.googletagmanager.com",
-    "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
-    "font-src 'self' https://fonts.gstatic.com",
-    // GA4 beacons go to google-analytics.com (regional endpoints on
-    // analytics.google.com); googletagmanager.com is needed for the container
-    // /td fetches. This is the allowlist Google documents for gtag.js at
-    // developers.google.com/tag-platform/security/guides/csp — kept explicit
-    // rather than widening to `https:`, which would defeat the point of an
-    // allowlist-based policy.
-    "connect-src 'self' https://challenges.cloudflare.com https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com",
-    'frame-src https://challenges.cloudflare.com',
-    "worker-src 'self' blob:",
-    "frame-ancestors 'none'",
-    "base-uri 'self'",
-  ].join('; '),
+}
+
+// Content-Security-Policy directives. `script-src` gets a per-response nonce
+// appended in `contentSecurityPolicy()`: Cloudflare's bot detection
+// ("JavaScript Detections", part of Bot Fight Mode) injects an inline <script>
+// into the HTML served for this zone and, per its docs, copies the nonce it
+// finds in the CSP response header onto that tag. Without a nonce the browser
+// blocks that script on every page load (a console error, and no detection
+// signal for real visitors). 'unsafe-inline' would also unblock it but would
+// re-open the inline injection this policy exists to close, and a hash cannot
+// work because the injected script embeds the request's ray id.
+const CSP_DIRECTIVES: readonly string[] = [
+  "default-src 'self'",
+  // GA4 pixels: google-analytics.com is the no-JS/beacon fallback,
+  // googletagmanager.com serves /td and /a (verified blocked by Google's Tag
+  // Assistant before these were listed).
+  "img-src 'self' data: blob: https://*.google-analytics.com https://*.googletagmanager.com",
+  // 'unsafe-eval' is mandatory — TypeGPU uses new Function for shader codegen.
+  // googletagmanager.com serves gtag.js (see lib/telemetry.ts); without it
+  // the loader is refused and no analytics event is ever recorded.
+  "script-src 'self' 'unsafe-eval' 'wasm-unsafe-eval' https://challenges.cloudflare.com https://*.googletagmanager.com",
+  "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+  "font-src 'self' https://fonts.gstatic.com",
+  // GA4 beacons go to google-analytics.com (regional endpoints on
+  // analytics.google.com); googletagmanager.com is needed for the container
+  // /td fetches. This is the allowlist Google documents for gtag.js at
+  // developers.google.com/tag-platform/security/guides/csp — kept explicit
+  // rather than widening to `https:`, which would defeat the point of an
+  // allowlist-based policy.
+  "connect-src 'self' https://challenges.cloudflare.com https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com",
+  'frame-src https://challenges.cloudflare.com',
+  "worker-src 'self' blob:",
+  "frame-ancestors 'none'",
+  "base-uri 'self'",
+]
+
+/** Sixteen random bytes as base64: a fresh CSP nonce for one response. */
+function scriptNonce(): string {
+  const bytes = new Uint8Array(16)
+  globalThis.crypto.getRandomValues(bytes)
+  return btoa(Array.from(bytes, (b) => String.fromCharCode(b)).join(''))
+}
+
+function contentSecurityPolicy(nonce: string): string {
+  return CSP_DIRECTIVES.map((directive) =>
+    directive.startsWith('script-src ')
+      ? `${directive} 'nonce-${nonce}'`
+      : directive,
+  ).join('; ')
 }
 
 /** Return a copy of `res` with the security headers applied. */
@@ -1247,6 +1274,7 @@ function withSecurityHeaders(res: Response): Response {
   for (const [name, value] of Object.entries(SECURITY_HEADERS)) {
     headers.set(name, value)
   }
+  headers.set('Content-Security-Policy', contentSecurityPolicy(scriptNonce()))
   return new Response(res.body, {
     status: res.status,
     statusText: res.statusText,


### PR DESCRIPTION
## Problem

Every page load on dev.lumenapeiron.com and lumenapeiron.com logs:

```
Executing inline script violates the following Content Security Policy directive 'script-src 'self' 'unsafe-eval' 'wasm-unsafe-eval' https://challenges.cloudflare.com https://*.googletagmanager.com'. Either the 'unsafe-inline' keyword, a hash ('sha256-…'), or a nonce ('nonce-…') is required to enable inline execution.
```

The blocked script is not ours. Cloudflare's bot detection ("JavaScript Detections", part of Bot Fight Mode on this zone) injects an inline `<script>` into HTML responses: `window.__CF$cv$params = {r: '<ray id>', …}` plus a loader for `/cdn-cgi/challenge-platform/scripts/jsd/main.js`. The Worker's `script-src` has no inline allowance, so the browser refuses it. The reported hash differs on every load (`p5oEHQ…`, `RAaELt…`, `W1gRTO…`) because the script embeds the request's ray id, so a hash allowlist cannot work. Verified in the DOM on both hosts (`document.querySelectorAll('script:not([src])')` shows exactly this one inline script).

Effect: a console error on every load, and the detection signal never set for real visitors.

## Fix

Cloudflare's JavaScript Detections docs: "If your CSP uses a nonce for script tags, Cloudflare will add these nonces to the scripts it injects by parsing your CSP response header", and "We highly discourage the use of `unsafe-inline` and instead recommend the use CSP nonces." (header-based nonces only, not `<meta>`).

The Worker now builds the CSP per response and appends `'nonce-<16 random bytes, base64>'` to `script-src`. Nothing else changes: `'self'` still allows the app's own `<script src>` tags (a nonce only disables `'unsafe-inline'`, which we never had), `'unsafe-eval'` stays for TypeGPU, all other directives are untouched. The directives moved from the `SECURITY_HEADERS` constant into `CSP_DIRECTIVES` plus `contentSecurityPolicy(nonce)`.

## Tests

New test: two responses carry a `script-src` nonce of the expected shape, the nonces differ, `'unsafe-inline'` is absent from `script-src`, `'self'` is present. Was red before the change; the whole worker suite (43) passes.

```
pnpm --filter chaos-master exec vitest run src/worker/index.test.ts
```

## Verification after merge

The injection only happens on the real zone, so the PR preview (`workers.dev`) cannot show it. After the dev deploy: open https://dev.lumenapeiron.com/ with DevTools open, the CSP error must be gone and `<script nonce="…">` must appear on the injected tag. If Cloudflare ever stops honouring the header nonce, the fallback is turning JavaScript Detections off in the dashboard (Security > Bots); the docs note that toggle is not available to Bot Fight Mode customers, which is why the nonce route is the one that always works.
