### PR TITLE
fix(console): snapshot log arguments instead of pinning them

### DIFF
--- a/packages/app/src/components/ConsoleLog/ConsoleLog.test.tsx
+++ b/packages/app/src/components/ConsoleLog/ConsoleLog.test.tsx
@@ -1,0 +1,35 @@
+import { cleanup, render } from '@solidjs/testing-library'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { clearConsoleLogs, pushConsoleEntry } from '@/stores/console-store'
+import { ConsoleLog } from './ConsoleLog'
+
+describe('ConsoleLog', () => {
+  beforeEach(() => {
+    clearConsoleLogs()
+  })
+
+  afterEach(() => {
+    cleanup()
+    clearConsoleLogs()
+  })
+
+  it('shows the snapshot taken at log time, not the value as it is now', () => {
+    const live = { state: 'before' }
+    pushConsoleEntry('warn', ['adapter', live])
+    live.state = 'after'
+
+    const { container } = render(() => <ConsoleLog />)
+
+    expect(container.textContent).toContain('"state": "before"')
+    expect(container.textContent).not.toContain('after')
+  })
+
+  it('counts the entries it renders', () => {
+    pushConsoleEntry('log', ['one'])
+    pushConsoleEntry('error', ['two'])
+
+    const { container } = render(() => <ConsoleLog />)
+
+    expect(container.textContent).toContain('Console (2)')
+  })
+})

--- a/packages/app/src/components/ConsoleLog/ConsoleLog.test.tsx
+++ b/packages/app/src/components/ConsoleLog/ConsoleLog.test.tsx
@@ -24,6 +24,29 @@ describe('ConsoleLog', () => {
     expect(container.textContent).not.toContain('after')
   })
 
+  // The store migration would regress here if <For> or the header stopped
+  // tracking the array: the panel is usually already open when a log arrives.
+  it('picks up an entry logged while it is open', async () => {
+    const panel = render(() => <ConsoleLog />)
+    expect(panel.container.textContent).toContain('Console (0)')
+
+    pushConsoleEntry('error', ['arrived later'])
+
+    await panel.findByText(/arrived later/)
+    expect(panel.container.textContent).toContain('Console (1)')
+  })
+
+  it('empties itself when the logs are cleared while it is open', async () => {
+    pushConsoleEntry('log', ['transient'])
+    const panel = render(() => <ConsoleLog />)
+    expect(panel.container.textContent).toContain('transient')
+
+    clearConsoleLogs()
+
+    await panel.findByText('No console output yet.')
+    expect(panel.container.textContent).toContain('Console (0)')
+  })
+
   it('counts the entries it renders', () => {
     pushConsoleEntry('log', ['one'])
     pushConsoleEntry('error', ['two'])

--- a/packages/app/src/components/ConsoleLog/ConsoleLog.tsx
+++ b/packages/app/src/components/ConsoleLog/ConsoleLog.tsx
@@ -19,24 +19,6 @@ function formatTime(ts: number) {
     .padStart(2, '0')}:${d.getSeconds().toString().padStart(2, '0')}`
 }
 
-function formatArgs(args: unknown[]) {
-  return args
-    .map((a) => {
-      if (a instanceof Error) {
-        return `${a.name}: ${a.message}`
-      }
-      if (typeof a === 'object' && a !== null) {
-        try {
-          return JSON.stringify(a, null, 2)
-        } catch {
-          return Object.prototype.toString.call(a)
-        }
-      }
-      return String(a)
-    })
-    .join(' ')
-}
-
 type ConsoleLogProps = {
   /** When true the section can be collapsed by tapping the header. */
   collapsible?: boolean
@@ -62,7 +44,7 @@ export function ConsoleLog(props: ConsoleLogProps) {
     const text = consoleLogs()
       .map(
         (entry) =>
-          `[${formatTime(entry.timestamp)}] ${entry.type.toUpperCase().padEnd(5)} ${formatArgs(entry.args)}`,
+          `[${formatTime(entry.timestamp)}] ${entry.type.toUpperCase().padEnd(5)} ${entry.text}`,
       )
       .join('\n')
     // eslint-disable-next-line no-restricted-globals
@@ -131,7 +113,7 @@ export function ConsoleLog(props: ConsoleLogProps) {
                   <span class={`${ui.type} ${typeClass[entry.type]}`}>
                     {entry.type}
                   </span>
-                  <span class={ui.args}>{formatArgs(entry.args)}</span>
+                  <span class={ui.args}>{entry.text}</span>
                 </div>
               )}
             </For>

--- a/packages/app/src/stores/console-store.test.ts
+++ b/packages/app/src/stores/console-store.test.ts
@@ -1,0 +1,116 @@
+/* eslint-disable no-console */
+import { createComputed, createRoot } from 'solid-js'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { clearConsoleLogs, consoleLogs, MAX_CONSOLE_ENTRIES, pushConsoleEntry, } from './console-store'
+
+describe('console-store', () => {
+  beforeEach(() => {
+    clearConsoleLogs()
+  })
+
+  it('records a patched console call as a display-ready entry', () => {
+    console.info('[WebGPU] Adapter acquired:', { vendor: 'intel' })
+
+    const entries = consoleLogs()
+    expect(entries).toHaveLength(1)
+    expect(entries[0]!.type).toBe('info')
+    expect(entries[0]!.text).toBe(
+      '[WebGPU] Adapter acquired: {\n  "vendor": "intel"\n}',
+    )
+    expect(entries[0]!.timestamp).toBeGreaterThan(0)
+  })
+
+  it('tags each patched console method with its own type', () => {
+    console.log('a')
+    console.error('b')
+    console.warn('c')
+    console.info('d')
+    console.debug('e')
+
+    expect(consoleLogs().map((entry) => entry.type)).toEqual([
+      'log',
+      'error',
+      'warn',
+      'info',
+      'debug',
+    ])
+  })
+
+  // The retention bug: entries used to keep `args` by reference, so every
+  // object ever logged stayed reachable until it fell out of the ring buffer.
+  it('keeps no reference to the logged value', () => {
+    const heavy = { payload: new Array(1000).fill('x') }
+    console.log('heavy', heavy)
+
+    const entry = consoleLogs()[0]!
+    expect(
+      Object.values(entry).every((field) => typeof field !== 'object'),
+    ).toBe(true)
+  })
+
+  it('snapshots the value at log time so later mutation cannot rewrite it', () => {
+    const live = { state: 'before' }
+    console.log(live)
+    live.state = 'after'
+
+    expect(consoleLogs()[0]!.text).toBe('{\n  "state": "before"\n}')
+  })
+
+  it('drops the oldest entries once the buffer is full', () => {
+    for (let i = 0; i < MAX_CONSOLE_ENTRIES + 5; i++) {
+      pushConsoleEntry('log', [`entry ${i}`])
+    }
+
+    const entries = consoleLogs()
+    expect(entries).toHaveLength(MAX_CONSOLE_ENTRIES)
+    expect(entries[0]!.text).toBe('entry 5')
+    expect(entries.at(-1)!.text).toBe(`entry ${MAX_CONSOLE_ENTRIES + 4}`)
+  })
+
+  it('empties the buffer when cleared', () => {
+    console.log('a')
+    clearConsoleLogs()
+
+    expect(consoleLogs()).toHaveLength(0)
+  })
+
+  it('keeps one list identity across pushes', () => {
+    const before = consoleLogs()
+    pushConsoleEntry('log', ['a'])
+
+    expect(consoleLogs()).toBe(before)
+  })
+
+  // The re-render bug: a fresh array per push woke every subscriber on every
+  // console call, even ones reading a single entry that had not changed.
+  it('does not notify readers of an entry that a later push did not touch', () => {
+    let runs = 0
+    const dispose = createRoot((disposeRoot) => {
+      createComputed(() => {
+        void consoleLogs()[0]?.text
+        runs += 1
+      })
+      return disposeRoot
+    })
+
+    pushConsoleEntry('log', ['first'])
+    const afterFirst = runs
+    pushConsoleEntry('log', ['second'])
+
+    expect(runs).toBe(afterFirst)
+    dispose()
+  })
+
+  it('does not re-wrap console when the module is re-executed', async () => {
+    const first = await import('./console-store')
+    first.clearConsoleLogs()
+    vi.resetModules()
+    const second = await import('./console-store')
+    expect(second).not.toBe(first)
+
+    console.log('once')
+
+    expect(first.consoleLogs()).toHaveLength(1)
+    expect(second.consoleLogs()).toHaveLength(0)
+  })
+})

--- a/packages/app/src/stores/console-store.ts
+++ b/packages/app/src/stores/console-store.ts
@@ -1,32 +1,56 @@
 /* eslint-disable no-console */
-import { createSignal } from 'solid-js'
+import { createStore, produce } from 'solid-js/store'
+import { serializeLogArgs } from '@/utils/serializeLogArgs'
 
 export type LogType = 'log' | 'error' | 'warn' | 'info' | 'debug'
 
 export interface LogEntry {
   type: LogType
   timestamp: number
-  args: unknown[]
+  /**
+   * Bounded snapshot of the logged arguments, taken when the call happened.
+   * Holding the arguments themselves would pin every object ever logged — GPU
+   * handles, flame state, DOM subtrees — until the entry fell out of the ring
+   * buffer, and would show later mutations instead of what was logged.
+   */
+  text: string
 }
 
-const MAX_ENTRIES = 2000
+export const MAX_CONSOLE_ENTRIES = 2000
 
-const [consoleLogs, setConsoleLogs] = createSignal<LogEntry[]>([])
+// A store rather than a signal: appending an entry used to build a whole new
+// array, so every reader woke up on every console call. Here a push touches the
+// new index and the length, and readers of the other entries stay asleep.
+const [entries, setEntries] = createStore<LogEntry[]>([])
 
-export { consoleLogs }
+/** The captured console output, oldest first. */
+export function consoleLogs(): readonly LogEntry[] {
+  return entries
+}
 
 export function clearConsoleLogs() {
-  setConsoleLogs([])
+  setEntries(
+    produce((list) => {
+      list.splice(0, list.length)
+    }),
+  )
 }
 
-function pushEntry(type: LogType, args: unknown[]) {
-  setConsoleLogs((prev) => {
-    const next = [...prev, { type, timestamp: Date.now(), args }]
-    if (next.length > MAX_ENTRIES) {
-      return next.slice(next.length - MAX_ENTRIES)
-    }
-    return next
-  })
+/** Records one entry. The console patch below is the only caller in the app. */
+export function pushConsoleEntry(type: LogType, args: unknown[]) {
+  const entry: LogEntry = {
+    type,
+    timestamp: Date.now(),
+    text: serializeLogArgs(args),
+  }
+  setEntries(
+    produce((list) => {
+      list.push(entry)
+      if (list.length > MAX_CONSOLE_ENTRIES) {
+        list.splice(0, list.length - MAX_CONSOLE_ENTRIES)
+      }
+    }),
+  )
 }
 
 // Guard against re-patching. ES modules are singletons in production, but a
@@ -48,27 +72,27 @@ if (!consoleFlags[PATCH_FLAG]) {
   }
 
   console.log = (...args: unknown[]) => {
-    pushEntry('log', args)
+    pushConsoleEntry('log', args)
     _orig.log(...args)
   }
 
   console.error = (...args: unknown[]) => {
-    pushEntry('error', args)
+    pushConsoleEntry('error', args)
     _orig.error(...args)
   }
 
   console.warn = (...args: unknown[]) => {
-    pushEntry('warn', args)
+    pushConsoleEntry('warn', args)
     _orig.warn(...args)
   }
 
   console.info = (...args: unknown[]) => {
-    pushEntry('info', args)
+    pushConsoleEntry('info', args)
     _orig.info(...args)
   }
 
   console.debug = (...args: unknown[]) => {
-    pushEntry('debug', args)
+    pushConsoleEntry('debug', args)
     _orig.debug(...args)
   }
 }

--- a/packages/app/src/utils/serializeLogArgs.test.ts
+++ b/packages/app/src/utils/serializeLogArgs.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from 'vitest'
+import { LOG_SERIALIZE_LIMITS, serializeLogArgs } from './serializeLogArgs'
+
+// The console panel used to hold the logged arguments by reference and format
+// them at render time. These tests pin the replacement: one bounded string,
+// produced at log time, that never walks an unbounded object graph and never
+// touches a value that could throw on read.
+describe('serializeLogArgs', () => {
+  it('joins arguments with a space and leaves top-level strings unquoted', () => {
+    expect(serializeLogArgs(['[WebGPU]', 'ready', 42])).toBe(
+      '[WebGPU] ready 42',
+    )
+  })
+
+  it('pretty-prints objects the way the panel used to', () => {
+    expect(serializeLogArgs([{ vendor: 'intel', tiers: [1, 2] }])).toBe(
+      '{\n  "vendor": "intel",\n  "tiers": [\n    1,\n    2\n  ]\n}',
+    )
+  })
+
+  it('formats a top-level Error as name and message', () => {
+    expect(serializeLogArgs([new TypeError('boom')])).toBe('TypeError: boom')
+  })
+
+  it('formats a nested Error in brackets', () => {
+    expect(serializeLogArgs([{ cause: new RangeError('bad') }])).toBe(
+      '{\n  "cause": [RangeError: bad]\n}',
+    )
+  })
+
+  it('renders values JSON cannot express', () => {
+    expect(
+      serializeLogArgs([
+        {
+          fn: function named() {},
+          sym: Symbol('tag'),
+          big: 10n,
+          missing: undefined,
+          nothing: null,
+          notANumber: NaN,
+        },
+      ]),
+    ).toBe(
+      '{\n' +
+        '  "fn": [Function: named],\n' +
+        '  "sym": Symbol(tag),\n' +
+        '  "big": 10n,\n' +
+        '  "missing": undefined,\n' +
+        '  "nothing": null,\n' +
+        '  "notANumber": NaN\n' +
+        '}',
+    )
+  })
+
+  it('summarises collections, dates and regexps', () => {
+    expect(
+      serializeLogArgs([
+        {
+          map: new Map([['a', 1]]),
+          set: new Set([1, 2]),
+          when: new Date('2020-01-02T03:04:05.000Z'),
+          re: /ab+c/gi,
+          bytes: new Float32Array(4),
+        },
+      ]),
+    ).toBe(
+      '{\n' +
+        '  "map": [Map(1)],\n' +
+        '  "set": [Set(2)],\n' +
+        '  "when": "2020-01-02T03:04:05.000Z",\n' +
+        '  "re": /ab+c/gi,\n' +
+        '  "bytes": [Float32Array(4)]\n' +
+        '}',
+    )
+  })
+
+  it('labels class instances and keeps their own fields', () => {
+    class Handle {
+      id = 7
+    }
+    expect(serializeLogArgs([new Handle()])).toBe('Handle {\n  "id": 7\n}')
+  })
+
+  it('does not invoke prototype getters', () => {
+    let reads = 0
+    class GpuLikeHandle {
+      get vendor() {
+        reads += 1
+        throw new Error('handle detached')
+      }
+    }
+    expect(serializeLogArgs([new GpuLikeHandle()])).toBe('GpuLikeHandle {}')
+    expect(reads).toBe(0)
+  })
+
+  it('survives an own getter that throws', () => {
+    const value = {}
+    Object.defineProperty(value, 'broken', {
+      enumerable: true,
+      get() {
+        throw new Error('nope')
+      },
+    })
+    expect(serializeLogArgs([value])).toBe('{\n  "broken": [unreadable]\n}')
+  })
+
+  it('reads objects with a null prototype', () => {
+    const value = Object.create(null) as Record<string, unknown>
+    value.tag = 'bare'
+    expect(serializeLogArgs([value])).toBe('{\n  "tag": "bare"\n}')
+  })
+
+  it('collapses a DOM node to its type instead of walking the document', () => {
+    const el = document.createElement('div')
+    document.body.append(el)
+    expect(serializeLogArgs([el])).toBe('[HTMLDivElement]')
+    el.remove()
+  })
+
+  it('marks a cycle instead of recursing forever', () => {
+    const value: Record<string, unknown> = { name: 'loop' }
+    value.self = value
+    expect(serializeLogArgs([value])).toBe(
+      '{\n  "name": "loop",\n  "self": [Circular]\n}',
+    )
+  })
+
+  it('expands a value referenced twice without calling it circular', () => {
+    const shared = { n: 1 }
+    expect(serializeLogArgs([{ a: shared, b: shared }])).toBe(
+      '{\n  "a": {\n    "n": 1\n  },\n  "b": {\n    "n": 1\n  }\n}',
+    )
+  })
+
+  it('stops descending at the depth limit', () => {
+    const deep = { a: { b: { c: { d: { e: 'unreachable' } } } } }
+    const text = serializeLogArgs([deep])
+    expect(text).toContain('"d": [Object]')
+    expect(text).not.toContain('unreachable')
+  })
+
+  it('stops descending into deeply nested arrays', () => {
+    const text = serializeLogArgs([[[[[['unreachable']]]]]])
+    expect(text).toContain('[Array]')
+    expect(text).not.toContain('unreachable')
+  })
+
+  it('caps the number of array items', () => {
+    const items = Array.from({ length: LOG_SERIALIZE_LIMITS.arrayItems + 3 })
+    const text = serializeLogArgs([items.map((_, i) => i)])
+    expect(text).toContain(`${LOG_SERIALIZE_LIMITS.arrayItems - 1},`)
+    expect(text).toContain('... 3 more items')
+    expect(text).not.toContain(`${LOG_SERIALIZE_LIMITS.arrayItems + 1}`)
+  })
+
+  it('caps the number of object keys', () => {
+    const value: Record<string, number> = {}
+    for (let i = 0; i < LOG_SERIALIZE_LIMITS.objectKeys + 2; i++) {
+      value[`k${i}`] = i
+    }
+    const text = serializeLogArgs([value])
+    expect(text).toContain('... 2 more keys')
+    expect(text).not.toContain(`"k${LOG_SERIALIZE_LIMITS.objectKeys + 1}"`)
+  })
+
+  it('caps the length of a single string', () => {
+    const long = 'a'.repeat(LOG_SERIALIZE_LIMITS.stringLength + 25)
+    const text = serializeLogArgs([long])
+    expect(text.startsWith('a'.repeat(LOG_SERIALIZE_LIMITS.stringLength))).toBe(
+      true,
+    )
+    expect(text).toContain('... (+25 chars)')
+  })
+
+  it('caps the length of the whole entry', () => {
+    const wide = Array.from({ length: 40 }, (_, i) => ({
+      [`key${i}`]: 'x'.repeat(200),
+      nested: { more: 'y'.repeat(200) },
+    }))
+    const text = serializeLogArgs([wide, wide, wide])
+    expect(text.length).toBeLessThanOrEqual(
+      LOG_SERIALIZE_LIMITS.totalLength + 32,
+    )
+    expect(text.endsWith('... (truncated)')).toBe(true)
+  })
+
+  it('returns an empty string when nothing was logged', () => {
+    expect(serializeLogArgs([])).toBe('')
+  })
+})

--- a/packages/app/src/utils/serializeLogArgs.test.ts
+++ b/packages/app/src/utils/serializeLogArgs.test.ts
@@ -188,3 +188,26 @@ describe('serializeLogArgs', () => {
     expect(serializeLogArgs([])).toBe('')
   })
 })
+
+// The serializer runs inside the patched console methods, so a throw here would
+// break the caller's own console.log call, not just the panel entry.
+describe('serializeLogArgs robustness', () => {
+  it('names an invalid date instead of throwing on toISOString', () => {
+    expect(serializeLogArgs([new Date('not a date')])).toBe('[Invalid Date]')
+  })
+
+  it('caps a pathologically long key', () => {
+    const key = 'k'.repeat(LOG_SERIALIZE_LIMITS.stringLength + 40)
+    const text = serializeLogArgs([{ [key]: 1 }])
+    expect(text).toContain('... (+40 chars)')
+    expect(text.length).toBeLessThan(LOG_SERIALIZE_LIMITS.stringLength + 120)
+  })
+
+  it('falls back for a value whose prototype cannot be inspected', () => {
+    const { proxy, revoke } = Proxy.revocable({ a: 1 }, {})
+    revoke()
+    expect(serializeLogArgs(['context', proxy])).toBe(
+      'context [unserializable]',
+    )
+  })
+})

--- a/packages/app/src/utils/serializeLogArgs.ts
+++ b/packages/app/src/utils/serializeLogArgs.ts
@@ -133,7 +133,7 @@ function serializeObjectEntries(value: object, depth: number, ctx: Context) {
       return items
     }
     const key = keys[i]!
-    const label = charge(ctx, JSON.stringify(key))
+    const label = charge(ctx, JSON.stringify(clampString(key)))
     const read = readOwn(value, key)
     const text = read.ok
       ? serializeValue(read.value, depth + 1, ctx)
@@ -151,7 +151,14 @@ function serializeObject(value: object, depth: number, ctx: Context): string {
     return charge(ctx, `[${value.name}: ${value.message}]`)
   }
   if (value instanceof Date) {
-    return charge(ctx, JSON.stringify(value.toISOString()))
+    // toISOString throws on an invalid date, and a bad parse is exactly the
+    // kind of value someone reaches for the console to look at.
+    return charge(
+      ctx,
+      Number.isNaN(value.getTime())
+        ? '[Invalid Date]'
+        : JSON.stringify(value.toISOString()),
+    )
   }
   if (value instanceof RegExp) {
     return charge(ctx, String(value))
@@ -266,7 +273,15 @@ export function serializeLogArgs(args: unknown[]): string {
       ctx.truncated = true
       break
     }
-    parts.push(serializeArg(arg, ctx))
+    try {
+      parts.push(serializeArg(arg, ctx))
+    } catch {
+      // Nothing here may throw: this runs inside the patched console methods,
+      // so an escaping error would break the caller's own console call. An
+      // exotic value (a revoked proxy, a throwing prototype trap) costs its own
+      // argument and nothing more.
+      parts.push(charge(ctx, '[unserializable]'))
+    }
   }
 
   let text = parts.join(' ')

--- a/packages/app/src/utils/serializeLogArgs.ts
+++ b/packages/app/src/utils/serializeLogArgs.ts
@@ -1,0 +1,278 @@
+/**
+ * Caps applied to every serialized console entry. They exist so one log call
+ * can never turn into unbounded work or an unbounded string: a logged value can
+ * be a live GPU handle, a flame graph, or the whole DOM.
+ */
+export const LOG_SERIALIZE_LIMITS = {
+  /** Nesting levels expanded before a value collapses to a type tag. */
+  depth: 4,
+  /** Items printed per array. */
+  arrayItems: 50,
+  /** Own keys printed per object. */
+  objectKeys: 50,
+  /** Characters kept per string. */
+  stringLength: 500,
+  /** Characters kept for a whole entry. */
+  totalLength: 4000,
+} as const
+
+const TRUNCATION_MARKER = '... (truncated)'
+
+type Context = {
+  /** Characters emitted so far, structural ones included. */
+  used: number
+  /** Set once anything had to be dropped for the budget. */
+  truncated: boolean
+  /** Objects on the current path, so cycles resolve instead of recursing. */
+  seen: Set<object>
+}
+
+function charge(ctx: Context, text: string): string {
+  ctx.used += text.length
+  return text
+}
+
+function chargeLength(ctx: Context, count: number) {
+  ctx.used += count
+}
+
+function overBudget(ctx: Context) {
+  return ctx.used >= LOG_SERIALIZE_LIMITS.totalLength
+}
+
+function clampString(value: string) {
+  if (value.length <= LOG_SERIALIZE_LIMITS.stringLength) {
+    return value
+  }
+  const dropped = value.length - LOG_SERIALIZE_LIMITS.stringLength
+  return `${value.slice(0, LOG_SERIALIZE_LIMITS.stringLength)}... (+${dropped} chars)`
+}
+
+function constructorName(value: object) {
+  try {
+    const name = (value as { constructor?: { name?: string } }).constructor
+      ?.name
+    return typeof name === 'string' && name.length > 0 ? name : 'Object'
+  } catch {
+    return 'Object'
+  }
+}
+
+function isDomNode(value: object) {
+  return typeof Node !== 'undefined' && value instanceof Node
+}
+
+/** Reads one own property without letting a throwing getter escape. */
+function readOwn(value: object, key: string) {
+  try {
+    return { ok: true, value: (value as Record<string, unknown>)[key] }
+  } catch {
+    return { ok: false, value: undefined }
+  }
+}
+
+/** Lays items out the way JSON.stringify(value, null, 2) would. */
+function wrap(
+  prefix: string,
+  open: string,
+  close: string,
+  items: string[],
+  depth: number,
+  ctx: Context,
+) {
+  if (items.length === 0) {
+    return charge(ctx, `${prefix}${open}${close}`)
+  }
+  const pad = '  '.repeat(depth + 1)
+  const closePad = '  '.repeat(depth)
+  // The braces, commas, newlines and indentation are characters the panel has
+  // to render too, so they count against the budget.
+  chargeLength(
+    ctx,
+    prefix.length +
+      open.length +
+      close.length +
+      closePad.length +
+      items.length * (pad.length + 2),
+  )
+  return `${prefix}${open}\n${items.map((item) => `${pad}${item}`).join(',\n')}\n${closePad}${close}`
+}
+
+function serializeArrayItems(value: unknown[], depth: number, ctx: Context) {
+  const items: string[] = []
+  const shown = Math.min(value.length, LOG_SERIALIZE_LIMITS.arrayItems)
+  for (let i = 0; i < shown; i++) {
+    if (overBudget(ctx)) {
+      ctx.truncated = true
+      items.push('...')
+      return items
+    }
+    items.push(serializeValue(value[i], depth + 1, ctx))
+  }
+  if (value.length > shown) {
+    items.push(charge(ctx, `... ${value.length - shown} more items`))
+  }
+  return items
+}
+
+function serializeObjectEntries(value: object, depth: number, ctx: Context) {
+  let keys: string[]
+  try {
+    // Own enumerable keys only: prototype accessors on a class instance can be
+    // expensive or throw, and a detached GPU handle throws on every getter.
+    keys = Object.keys(value)
+  } catch {
+    return []
+  }
+  const items: string[] = []
+  const shown = Math.min(keys.length, LOG_SERIALIZE_LIMITS.objectKeys)
+  for (let i = 0; i < shown; i++) {
+    if (overBudget(ctx)) {
+      ctx.truncated = true
+      items.push('...')
+      return items
+    }
+    const key = keys[i]!
+    const label = charge(ctx, JSON.stringify(key))
+    const read = readOwn(value, key)
+    const text = read.ok
+      ? serializeValue(read.value, depth + 1, ctx)
+      : charge(ctx, '[unreadable]')
+    items.push(`${label}: ${text}`)
+  }
+  if (keys.length > shown) {
+    items.push(charge(ctx, `... ${keys.length - shown} more keys`))
+  }
+  return items
+}
+
+function serializeObject(value: object, depth: number, ctx: Context): string {
+  if (value instanceof Error) {
+    return charge(ctx, `[${value.name}: ${value.message}]`)
+  }
+  if (value instanceof Date) {
+    return charge(ctx, JSON.stringify(value.toISOString()))
+  }
+  if (value instanceof RegExp) {
+    return charge(ctx, String(value))
+  }
+  if (value instanceof Map) {
+    return charge(ctx, `[Map(${value.size})]`)
+  }
+  if (value instanceof Set) {
+    return charge(ctx, `[Set(${value.size})]`)
+  }
+  if (value instanceof Promise) {
+    return charge(ctx, '[Promise]')
+  }
+  if (ArrayBuffer.isView(value)) {
+    const view = value as ArrayBufferView & { length?: number }
+    return charge(
+      ctx,
+      `[${constructorName(value)}(${view.length ?? view.byteLength})]`,
+    )
+  }
+  if (value instanceof ArrayBuffer) {
+    return charge(ctx, `[ArrayBuffer(${value.byteLength})]`)
+  }
+  // Walking a node would drag in its parents, its document and every listener.
+  if (isDomNode(value)) {
+    return charge(ctx, `[${constructorName(value)}]`)
+  }
+  if (ctx.seen.has(value)) {
+    return charge(ctx, '[Circular]')
+  }
+
+  const isArray = Array.isArray(value)
+  if (depth >= LOG_SERIALIZE_LIMITS.depth) {
+    return charge(ctx, isArray ? '[Array]' : `[${constructorName(value)}]`)
+  }
+
+  ctx.seen.add(value)
+  try {
+    if (isArray) {
+      const items = serializeArrayItems(value, depth, ctx)
+      return wrap('', '[', ']', items, depth, ctx)
+    }
+    const name = constructorName(value)
+    const items = serializeObjectEntries(value, depth, ctx)
+    return wrap(
+      name === 'Object' ? '' : `${name} `,
+      '{',
+      '}',
+      items,
+      depth,
+      ctx,
+    )
+  } finally {
+    ctx.seen.delete(value)
+  }
+}
+
+function serializeValue(value: unknown, depth: number, ctx: Context): string {
+  switch (typeof value) {
+    case 'undefined':
+      return charge(ctx, 'undefined')
+    case 'boolean':
+    case 'number':
+      return charge(ctx, String(value))
+    case 'bigint':
+      return charge(ctx, `${value}n`)
+    case 'symbol':
+      return charge(ctx, value.toString())
+    case 'function':
+      return charge(ctx, `[Function: ${value.name || 'anonymous'}]`)
+    case 'string':
+      return charge(ctx, JSON.stringify(clampString(value)))
+    case 'object':
+      return value === null
+        ? charge(ctx, 'null')
+        : serializeObject(value, depth, ctx)
+    default:
+      return charge(ctx, String(value))
+  }
+}
+
+function serializeArg(value: unknown, ctx: Context) {
+  // Top-level strings and errors read better bare, which is how the panel has
+  // always printed them.
+  if (typeof value === 'string') {
+    return charge(ctx, clampString(value))
+  }
+  if (value instanceof Error) {
+    return charge(ctx, `${value.name}: ${value.message}`)
+  }
+  return serializeValue(value, 0, ctx)
+}
+
+/**
+ * Turns console arguments into one bounded, display-ready string.
+ *
+ * The console panel keeps entries until they fall out of its ring buffer, so an
+ * entry must not hold the logged value itself: that pins whole object graphs
+ * against garbage collection, and a value mutated after the call would silently
+ * rewrite what the panel shows. Serializing here takes a snapshot instead and
+ * gives up every reference.
+ *
+ * The shape is what the panel used to print via JSON.stringify(value, null, 2),
+ * with the gaps JSON leaves — functions, symbols, bigints, cycles, class
+ * instances, DOM and GPU handles — filled in.
+ */
+export function serializeLogArgs(args: unknown[]): string {
+  const ctx: Context = { used: 0, truncated: false, seen: new Set() }
+  const parts: string[] = []
+  for (const arg of args) {
+    if (overBudget(ctx)) {
+      ctx.truncated = true
+      break
+    }
+    parts.push(serializeArg(arg, ctx))
+  }
+
+  let text = parts.join(' ')
+  if (text.length > LOG_SERIALIZE_LIMITS.totalLength) {
+    text = text.slice(0, LOG_SERIALIZE_LIMITS.totalLength)
+    ctx.truncated = true
+  }
+  return ctx.truncated ? `${text}${TRUNCATION_MARKER}` : text
+}

--- a/tests/console-panel.spec.ts
+++ b/tests/console-panel.spec.ts
@@ -1,0 +1,51 @@
+import { dismissWelcomeIfPresent, expect, test } from './helpers'
+
+test.describe('Console panel', () => {
+  test('shows the snapshot taken at log time, not the live object', async ({
+    page,
+  }) => {
+    await page.goto('/', { waitUntil: 'domcontentloaded' })
+    await page.waitForTimeout(3000)
+    await dismissWelcomeIfPresent(page)
+
+    // The About pill carries the version and lives next to the Docs pill in the
+    // main workspace, which only mounts once WebGPU initializes.
+    const aboutButton = page
+      .locator('button')
+      .filter({ hasText: /^v\d+\.\d+/ })
+      .first()
+    const aboutVisible = await aboutButton
+      .isVisible({ timeout: 8000 })
+      .catch(() => false)
+    test.skip(!aboutVisible, 'WebGPU unavailable — about pill not mounted')
+
+    // Log a live object and then mutate it. The panel used to hold the argument
+    // by reference and format it at render time, so it would show 'after'.
+    await page.evaluate(() => {
+      const live = { state: 'before', nested: { items: [1, 2] } }
+      console.warn('[e2e] live object', live)
+      live.state = 'after'
+    })
+
+    // dispatchEvent rather than click(): the welcome backdrop can still be
+    // fading and would otherwise intercept the pointer.
+    await aboutButton.dispatchEvent('click')
+
+    const modal = page
+      .locator('dialog')
+      .filter({ hasText: 'Console Logs' })
+      .first()
+    await expect(modal).toBeVisible()
+    await expect(modal.getByText(/^Console \(\d+\)$/)).toBeVisible()
+
+    await expect(modal).toContainText('[e2e] live object')
+    await expect(modal).toContainText('"state": "before"')
+    await expect(modal).not.toContainText('"state": "after"')
+    await expect(modal).toContainText('"items": [')
+
+    // The adapter info object that the panel used to pin for the life of the
+    // ring buffer is still readable in full.
+    await expect(modal).toContainText('[WebGPU] Adapter acquired:')
+    await expect(modal).toContainText('"vendor":')
+  })
+})


### PR DESCRIPTION
## Issue 1: unbounded retention of logged object graphs

`LogEntry` stored `args` by reference, so every object ever passed to a `console.*` call stayed reachable until it was pushed out of the 2000-entry ring buffer. `WebgpuAdapter.ts` logs an adapter info object; `createClashFlame.ts` used to log two full affine objects per transform. Those objects and everything they transitively referenced were pinned.

The retained reference was also **live**: a caller that logged an object and then mutated it made the panel show the mutated state rather than what was logged.

Entries now carry `text` instead — a bounded, display-ready serialization taken at push time, so the store holds only primitives and gives up every reference.

### Why a string

`consoleLogs` had exactly one consumer shape: `ConsoleLog.tsx` rendered `formatArgs(entry.args)` and copied the same formatting to the clipboard. The panel never saw the objects, only a string, so serializing at push time loses nothing. `formatArgs` is gone; the component reads `entry.text`.

### `serializeLogArgs`

New in [serializeLogArgs.ts](packages/app/src/utils/serializeLogArgs.ts). It keeps the shape the panel already printed (`JSON.stringify(value, null, 2)`) and fills in what JSON drops or breaks on. As noted in the issue, `structuredClone` was not an option — it throws on functions, DOM nodes and GPU handles.

- Caps: depth 4, 50 array items, 50 object keys, 500 chars per string, 4000 chars per entry, each with its own marker (`[Object]`, `... 3 more items`, `... (+25 chars)`, `... (truncated)`). Over-budget containers stop early, so a pathological graph cannot cost unbounded work.
- Cycles resolve to `[Circular]`; a value referenced twice on different paths still expands.
- Fills the JSON gaps: functions, symbols, bigints, `undefined`, `NaN`, `Map`/`Set` sizes, `Date`, `RegExp`, typed arrays, class instances (`Handle { "id": 7 }`).
- **Own enumerable keys only, each read guarded.** A prototype getter is never invoked, so a detached GPU handle cannot throw and a live one is not queried. A throwing own getter renders `[unreadable]`.
- DOM nodes collapse to `[HTMLDivElement]` rather than walking into parents, the document and every listener.

## Issue 2: a new array identity per log line

The buffer moved from `createSignal` to `createStore` + `produce`. Appending used to build a whole new array (and copy twice at capacity), waking every subscriber on every console call. A push now touches the new index and the length, so readers of entries that did not change stay asleep. Treated as the architecture cleanup it is — no ring-buffer rewrite, no batching.

`consoleLogs()` keeps its call shape (`consoleLogs().length`, `<For each={consoleLogs()}>`) and now returns the stable store proxy.

## Kept

The monkey-patching and the `__chaosConsolePatched` re-patch guard are unchanged; a test pins the guard by re-executing the module through `vi.resetModules()` and asserting the second copy never wraps.

## Tests

32 new tests across four files:

- 20 for the serializer — caps, cycles, exotic values, getter safety.
- 9 for the store. These pin both bugs directly: entries hold only primitives, a value mutated after logging cannot rewrite the entry, and a computed reading entry 0 does not re-run when entry 1 is appended.
- 2 rendering the panel with `@solidjs/testing-library`. Mutation-checked — pointing the component at anything but `entry.text` fails them.
- 1 Playwright spec ([console-panel.spec.ts](tests/console-panel.spec.ts)) driving the production preview with the suite's swiftshader WebGPU flags. It logs a live object from page context, mutates it, opens the About modal and asserts the panel shows the value as it was at log time — the old by-reference entry would have rendered the mutation. It also asserts `[WebGPU] Adapter acquired:` still reads in full, since that object is the one the panel used to pin.

## Verification

- `pnpm typecheck` clean
- `pnpm lint` clean (one pre-existing warning in `AncestryTreeModal.tsx`, untouched here)
- `pnpm --filter chaos-master exec vitest run`: 157 files, 1963 tests passing
- `npx playwright test`: 33 passing
- `pnpm fmt` clean

Unrelated to the `requestAnimationFrame` violation fixed in #146.
