### PR TITLE
fix(ci): pass --env dev when applying dev D1 migrations

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -97,6 +97,17 @@ jobs:
       # append-only D1 migrations before the Worker that reads them goes live,
       # both on main and on an explicitly requested manual dev deploy. Prod
       # remains a separate, deliberate release operation.
+      #
+      # `--env dev` is REQUIRED. The CONTENT_DB binding lives only inside
+      # `env.dev` in wrangler.jsonc, and wrangler does not inherit bindings up
+      # into the top-level config. Without the flag wrangler reads the
+      # binding-less top-level config and dies with "Couldn't find a D1 DB with
+      # the name or binding 'chaos-master-content-dev'", failing the whole job
+      # before the dev deploy step ever runs.
+      #
+      # Passing the database *name* instead of the binding is also deliberate:
+      # a mistaken `--env` then errors out rather than quietly migrating
+      # another environment's database.
       - name: Apply Dev Content Migrations
         if: >-
           env.DEPLOY_ENABLED == 'true' &&
@@ -106,7 +117,7 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: d1 migrations apply chaos-master-content-dev --remote
+          command: d1 migrations apply chaos-master-content-dev --remote --env dev
           packageManager: 'pnpm'
           workingDirectory: 'packages/app'
 


### PR DESCRIPTION
## What broke

The `Apply Dev Content Migrations` step introduced in #134 has failed on **every** push to `main` since it landed, and because it runs before `Deploy to Dev Environment`, the job aborts there and the dev deploy never executes. `dev.lumenapeiron.com` has been serving the 2026-09-02 build ever since.

```
✘ [ERROR] Couldn't find a D1 DB with the name or binding 'chaos-master-content-dev' in your wrangler.jsonc file.
```

## Root cause

The step ran:

```
wrangler d1 migrations apply chaos-master-content-dev --remote
```

with no `--env`, so wrangler resolved the **top-level** `packages/app/wrangler.jsonc` config. `CONTENT_DB` / `chaos-master-content-dev` is declared only inside `env.dev` (and `env.preview`), and wrangler does not inherit bindings up into the top-level config, so the lookup found nothing.

This is not a Cloudflare incident. The failure is deterministic config resolution, it reproduces locally with no network dependency, and no D1 or Workers incident overlapped the failure window. The one wrangler/D1 incident on the status page resolved 2026-09-01 12:05 UTC, well before #134 landed on 2026-09-03.

The `Node 20 is being deprecated` line in the log is an unrelated advisory about the actions' own runtime, not the failure.

## Fix

Add `--env dev` to the command. Passing the database *name* rather than the binding is kept deliberately: a mistaken `--env` then errors out instead of quietly migrating another environment's database.

## Verification

Reproduced and confirmed locally against the real remote dev database:

- Without `--env dev`: identical error to CI.
- With `--env dev`: wrangler resolves the database and reports `0005_gallery_provenance.sql` and `0006_gallery_community_submissions.sql` as pending.

The dev migration ledger is consistent with its real schema (`d1_migrations` records 0001-0004; `gallery_items` ends at the `sequence` column), so those two migrations apply cleanly with no hand-applied drift to reconcile.

## Follow-up, not included here

Production's migration ledger is out of sync with its schema and is a landmine for anyone who later automates prod migrations. On `chaos-master-content`, `d1_migrations` is **empty**, but the schema already has 0001, 0002 and 0003 applied by hand (`gallery_items` has `poster_frame`, and `home_config` exists). A naive `d1 migrations apply` against prod would therefore fail on 0002's `ALTER TABLE gallery_items ADD COLUMN poster_frame`, since that column already exists. Prod needs its ledger backfilled before any such step is added. This PR does not touch prod.

Prod is not currently broken by the missing provenance and community columns: the Worker detects `no such column` and falls back to a query that synthesizes `'curated'` defaults.
