### PR TITLE
fix(dropzone): give the Load Flame zone a real drop affordance, and stop the flicker

### DIFF
--- a/packages/app/src/components/Dropzone/Dropzone.tsx
+++ b/packages/app/src/components/Dropzone/Dropzone.tsx
@@ -1,5 +1,6 @@
-import { createEffect, createSignal, onCleanup } from 'solid-js'
+import { createEffect, onCleanup } from 'solid-js'
 import { filesFromDataTransfer } from '@/utils/dataTransferFiles'
+import { createFileDragState } from '@/utils/fileDragState'
 import ui from './Dropzone.module.css'
 import type { ParentProps } from 'solid-js'
 
@@ -21,17 +22,10 @@ type DropzoneProps = {
 }
 
 export function Dropzone(props: ParentProps<DropzoneProps>) {
-  const [dropping, setDropping] = createSignal(false)
-  // dragenter/dragleave fire for every element the pointer crosses and bubble
-  // up here, so a plain boolean flips off each time the pointer moves onto a
-  // child. Count the nesting instead; a drop, or a leave to somewhere outside
-  // the zone, resets it.
-  let depth = 0
-
-  const reset = () => {
-    depth = 0
-    setDropping(false)
-  }
+  // Shared with the Load Flame modal's own zone so the two cannot drift — they
+  // already had different enter/leave behaviour, and only one of them flickered.
+  const fileDrag = createFileDragState()
+  const dropping = fileDrag.active
 
   preventDraggingAnyElement()
 
@@ -42,33 +36,15 @@ export function Dropzone(props: ParentProps<DropzoneProps>) {
         [props.class ?? '']: true,
         [ui.dropping as string]: dropping(),
       }}
-      onDragEnter={() => {
-        depth += 1
-        setDropping(true)
-      }}
-      onDragLeave={(ev) => {
-        const next = ev.relatedTarget
-        // Browsers that report where the pointer went (Chromium, Firefox) let
-        // a leave to outside the zone clear the highlight even if the count
-        // drifted; the others fall back to the counter.
-        if (next instanceof Node && !ev.currentTarget.contains(next)) {
-          reset()
-          return
-        }
-        depth = Math.max(0, depth - 1)
-        if (depth === 0) setDropping(false)
-      }}
-      onDragOver={(ev) => {
-        // needed for drop to work
-        ev.preventDefault()
-        if (ev.dataTransfer) ev.dataTransfer.dropEffect = 'copy'
-      }}
+      onDragEnter={fileDrag.onDragEnter}
+      onDragLeave={fileDrag.onDragLeave}
+      onDragOver={fileDrag.onDragOver}
       onDrop={(ev) => {
         // Take every drop, with or without a file. The browser's default for a
         // dropped URL is navigating away, and the highlight has to clear either
         // way: it used to stay on when the payload carried no File.
         ev.preventDefault()
-        reset()
+        fileDrag.reset()
         const [file] = filesFromDataTransfer(ev.dataTransfer)
         if (!file) {
           console.warn(

--- a/packages/app/src/components/LoadFlameModal/LoadFlameModal.module.css
+++ b/packages/app/src/components/LoadFlameModal/LoadFlameModal.module.css
@@ -276,6 +276,66 @@
   }
 }
 
+/* The drag-hover state. This class was referenced from the component but never
+   existed here, so `ui.uploadZoneDragging` was undefined and a drag changed the
+   copy while leaving the zone looking exactly as it did at rest — no border, no
+   fill, nothing to say the drop would be accepted. */
+.uploadZoneDragging {
+  border-style: solid;
+  border-width: 2px;
+  border-color: var(--accent-color, #6366f1);
+  background: rgba(99, 102, 241, 0.1);
+  /* Slightly larger than rest, and larger than :hover's 0.995, so the zone
+     visibly "opens up" to receive the file. */
+  transform: scale(1.01);
+
+  [data-theme='dark'] & {
+    border-color: var(--accent-color, #818cf8);
+    background: rgba(129, 140, 248, 0.14);
+  }
+
+  .uploadIcon {
+    color: var(--accent-color, #6366f1);
+    transform: translateY(-3px) scale(1.1);
+
+    [data-theme='dark'] & {
+      color: var(--accent-color, #818cf8);
+    }
+  }
+
+  .uploadTitle {
+    color: var(--accent-color, #6366f1);
+
+    [data-theme='dark'] & {
+      color: var(--accent-color, #818cf8);
+    }
+  }
+
+  /* The pointer is mid-drag over these; letting them take hit-testing only
+     produces more enter/leave churn for the counter to unwind. */
+  .uploadIcon,
+  .uploadTitle,
+  .uploadSubtitle {
+    pointer-events: none;
+  }
+
+  /* `:active` fires mid-drag in some browsers and would fight the scale above. */
+  &:active {
+    transform: scale(1.01);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .uploadZoneDragging,
+  .uploadZoneDragging:active {
+    transform: none;
+  }
+
+  .uploadZoneDragging .uploadIcon {
+    transform: none;
+  }
+}
+
 .uploadIcon {
   color: var(--neutral-400);
   transition: all 0.2s ease;

--- a/packages/app/src/components/LoadFlameModal/LoadFlameModal.tsx
+++ b/packages/app/src/components/LoadFlameModal/LoadFlameModal.tsx
@@ -17,6 +17,7 @@ import { Default3DPreviewCamera } from '@/lib/Camera3D'
 import { Root } from '@/lib/Root'
 import { deepClone } from '@/utils/clone'
 import { filesFromDataTransfer } from '@/utils/dataTransferFiles'
+import { createFileDragState } from '@/utils/fileDragState'
 import { applyFlameImport, parseFlameEnvelope, readFlameFiles, summarizeImport, } from '@/utils/flameImport'
 import { extractFlameFromPng } from '@/utils/flameInPng'
 import { useElementIsScrolling } from '@/utils/isScrolling'
@@ -607,7 +608,8 @@ export function LoadFlameModal(props: LoadFlameModalProps) {
   const galleryScrolling = useElementIsScrolling(scrollBodyElement)
   const showAlert = useAlert()
   const { showToast } = useToast()
-  const [isDragging, setIsDragging] = createSignal(false)
+  const fileDrag = createFileDragState()
+  const isDragging = fileDrag.active
   const [isImporting, setIsImporting] = createSignal(false)
   const isGallery = () => props.mode === 'gallery'
 
@@ -841,25 +843,19 @@ export function LoadFlameModal(props: LoadFlameModalProps) {
     await processImportFiles(await pickFlameFiles())
   }
 
-  function handleDragOver(e: DragEvent) {
-    e.preventDefault()
-  }
-
-  function handleDragEnter(e: DragEvent) {
-    e.preventDefault()
-    setIsDragging(true)
-  }
-
-  function handleDragLeave(e: DragEvent) {
-    e.preventDefault()
-    setIsDragging(false)
-  }
-
   async function handleDrop(e: DragEvent) {
     e.preventDefault()
-    setIsDragging(false)
+    // `drop` never emits a matching `dragleave`, so the state has to be reset
+    // here or the highlight sticks until the next drag.
+    fileDrag.reset()
     const files = filesFromDataTransfer(e.dataTransfer)
-    if (files.length === 0) return
+    if (files.length === 0) {
+      console.warn(
+        'LoadFlameModal: drop carried no file; types:',
+        Array.from(e.dataTransfer?.types ?? []),
+      )
+      return
+    }
     await processImportFiles(files)
   }
 
@@ -942,9 +938,9 @@ export function LoadFlameModal(props: LoadFlameModalProps) {
             class={ui.uploadZone}
             classList={{ [ui.uploadZoneDragging as string]: isDragging() }}
             onClick={loadFromFile}
-            onDragOver={handleDragOver}
-            onDragEnter={handleDragEnter}
-            onDragLeave={handleDragLeave}
+            onDragOver={fileDrag.onDragOver}
+            onDragEnter={fileDrag.onDragEnter}
+            onDragLeave={fileDrag.onDragLeave}
             onDrop={handleDrop}
           >
             <svg

--- a/packages/app/src/components/LoadFlameModal/dropzoneStyles.test.ts
+++ b/packages/app/src/components/LoadFlameModal/dropzoneStyles.test.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+// Read the stylesheet as text rather than importing the CSS module: under vitest
+// a CSS-module import resolves to a proxy that answers every key, so it can
+// never tell us a class is missing — which is exactly the bug this guards.
+const css = readFileSync(
+  join(import.meta.dirname, 'LoadFlameModal.module.css'),
+  'utf8',
+)
+
+describe('upload dropzone styles', () => {
+  // The component has always toggled `ui.uploadZoneDragging` on drag, but the
+  // class was never defined here. `ui.uploadZoneDragging` was `undefined`, so
+  // the element got a literal class named "undefined" and a drag changed only
+  // the wording — no border, no fill, nothing saying the drop was valid.
+  it('defines the drag-hover class the component toggles', () => {
+    expect(css).toMatch(/^\.uploadZoneDragging\s*\{/m)
+  })
+
+  it('gives the drag state a visible border and fill, not just a text swap', () => {
+    const block = css.slice(css.indexOf('.uploadZoneDragging {'))
+    expect(block).toMatch(/border-color:/)
+    expect(block).toMatch(/background:/)
+    // The resting zone is dashed; a solid border is the "now it will take it"
+    // signal, so it must not silently regress to dashed.
+    expect(block).toMatch(/border-style:\s*solid/)
+  })
+
+  it('honours reduced motion for the drag transform', () => {
+    expect(css).toMatch(/prefers-reduced-motion/)
+  })
+})

--- a/packages/app/src/utils/fileDragState.test.ts
+++ b/packages/app/src/utils/fileDragState.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from 'vitest'
+import { createFileDragState } from './fileDragState'
+
+/** A `dragleave` whose `relatedTarget` the browser did report. */
+function leave(zone: Node, next: Node | null) {
+  return { relatedTarget: next, currentTarget: zone } as unknown as DragEvent
+}
+
+function makeZone() {
+  const zone = document.createElement('div')
+  const child = document.createElement('span')
+  const grandchild = document.createElement('em')
+  child.appendChild(grandchild)
+  zone.appendChild(child)
+  document.body.appendChild(zone)
+  return { zone, child, grandchild }
+}
+
+describe('createFileDragState', () => {
+  it('starts inactive', () => {
+    expect(createFileDragState().active()).toBe(false)
+  })
+
+  it('activates on enter', () => {
+    const s = createFileDragState()
+    s.onDragEnter()
+    expect(s.active()).toBe(true)
+  })
+
+  // The reported bug: moving the pointer a little up or down inside the zone
+  // crosses a child, which fires leave-then-enter on the zone. A plain boolean
+  // flips off in between and the "release to load" copy reverts.
+  it('stays active while the pointer crosses a child', () => {
+    const { zone, child } = makeZone()
+    const s = createFileDragState()
+
+    s.onDragEnter() // into the zone
+    s.onDragEnter() // onto the child
+    s.onDragLeave(leave(zone, child)) // leaving the zone *for* the child
+    expect(s.active()).toBe(true)
+  })
+
+  it('stays active across a deeper nest', () => {
+    const { zone, child, grandchild } = makeZone()
+    const s = createFileDragState()
+
+    s.onDragEnter()
+    s.onDragEnter()
+    s.onDragEnter()
+    s.onDragLeave(leave(zone, grandchild))
+    s.onDragLeave(leave(zone, child))
+    expect(s.active()).toBe(true)
+  })
+
+  it('deactivates when the pointer actually leaves', () => {
+    const { zone, child } = makeZone()
+    const outside = document.createElement('div')
+    document.body.appendChild(outside)
+    const s = createFileDragState()
+
+    s.onDragEnter()
+    s.onDragEnter()
+    s.onDragLeave(leave(zone, child))
+    s.onDragLeave(leave(zone, outside))
+    expect(s.active()).toBe(false)
+  })
+
+  // relatedTarget is null when the pointer leaves the window entirely, and some
+  // browsers omit it — the counter has to carry those.
+  it('falls back to the counter when relatedTarget is null', () => {
+    const { zone } = makeZone()
+    const s = createFileDragState()
+
+    s.onDragEnter()
+    s.onDragEnter()
+    s.onDragLeave(leave(zone, null))
+    expect(s.active()).toBe(true)
+    s.onDragLeave(leave(zone, null))
+    expect(s.active()).toBe(false)
+  })
+
+  it('never drives the counter negative', () => {
+    const { zone } = makeZone()
+    const s = createFileDragState()
+
+    s.onDragLeave(leave(zone, null))
+    s.onDragLeave(leave(zone, null))
+    s.onDragEnter()
+    // One stray enter must light it up, however many leaves preceded it.
+    expect(s.active()).toBe(true)
+  })
+
+  it('reset clears a nested drag in one call, as drop needs', () => {
+    const s = createFileDragState()
+    s.onDragEnter()
+    s.onDragEnter()
+    s.onDragEnter()
+    s.reset()
+    expect(s.active()).toBe(false)
+    // And the next drag starts clean rather than needing 3 leaves first.
+    s.onDragEnter()
+    expect(s.active()).toBe(true)
+  })
+
+  it('an outside relatedTarget clears even if the count drifted high', () => {
+    const { zone } = makeZone()
+    const outside = document.createElement('div')
+    document.body.appendChild(outside)
+    const s = createFileDragState()
+
+    s.onDragEnter()
+    s.onDragEnter()
+    s.onDragEnter()
+    s.onDragLeave(leave(zone, outside))
+    expect(s.active()).toBe(false)
+  })
+
+  describe('onDragOver', () => {
+    it('prevents default so drop can fire at all', () => {
+      let prevented = false
+      createFileDragState().onDragOver({
+        preventDefault: () => {
+          prevented = true
+        },
+        dataTransfer: null,
+      } as unknown as DragEvent)
+      expect(prevented).toBe(true)
+    })
+
+    it('marks the drop as a copy, which is what shows the accept cursor', () => {
+      const dataTransfer = { dropEffect: 'none' }
+      createFileDragState().onDragOver({
+        preventDefault: () => {},
+        dataTransfer,
+      } as unknown as DragEvent)
+      expect(dataTransfer.dropEffect).toBe('copy')
+    })
+
+    it('tolerates a missing dataTransfer', () => {
+      expect(() => {
+        createFileDragState().onDragOver({
+          preventDefault: () => {},
+          dataTransfer: null,
+        } as unknown as DragEvent)
+      }).not.toThrow()
+    })
+  })
+})

--- a/packages/app/src/utils/fileDragState.ts
+++ b/packages/app/src/utils/fileDragState.ts
@@ -1,0 +1,64 @@
+import { createSignal } from 'solid-js'
+
+/**
+ * Drag-hover state for a file drop target.
+ *
+ * `dragenter` and `dragleave` fire for *every* element the pointer crosses and
+ * bubble up to the zone, so a plain `setActive(false)` on leave flips off the
+ * moment the pointer moves onto a child — an icon, a line of text. The user
+ * sees the highlight and the "release to load" copy flicker away while the
+ * pointer is still inside the zone, which reads as "this drop is not valid".
+ *
+ * Count the nesting instead, and treat a leave whose `relatedTarget` lies
+ * outside the zone as a real exit regardless of the count, so a missed enter
+ * (the pointer entering through a shadow boundary, a drag that starts inside)
+ * cannot strand the highlight on.
+ *
+ * `onDragOver` also sets `dropEffect = 'copy'`: `preventDefault` alone is what
+ * makes `drop` fire, but the copy cursor is what tells the user at the OS level
+ * that the drop will be accepted.
+ */
+export function createFileDragState() {
+  const [active, setActive] = createSignal(false)
+  let depth = 0
+
+  const reset = () => {
+    depth = 0
+    setActive(false)
+  }
+
+  return {
+    /** True while a drag is over the zone or any of its descendants. */
+    active,
+    /** Force the state off — call after `drop`, which never emits `dragleave`. */
+    reset,
+
+    onDragEnter: () => {
+      depth += 1
+      setActive(true)
+    },
+
+    onDragLeave: (ev: DragEvent) => {
+      const next = ev.relatedTarget
+      const zone = ev.currentTarget
+      // Browsers that report where the pointer went (Chromium, Firefox) let a
+      // leave to outside the zone clear the highlight even if the count drifted;
+      // the rest fall back to the counter.
+      if (
+        zone instanceof Node &&
+        next instanceof Node &&
+        !zone.contains(next)
+      ) {
+        reset()
+        return
+      }
+      depth = Math.max(0, depth - 1)
+      if (depth === 0) setActive(false)
+    },
+
+    onDragOver: (ev: DragEvent) => {
+      ev.preventDefault()
+      if (ev.dataTransfer) ev.dataTransfer.dropEffect = 'copy'
+    },
+  }
+}


### PR DESCRIPTION
Follow-up to #147, from testing on the dev domain. Two separate faults in the Load Flame modal's upload zone.

## 1. The drag state had no styling at all

The component has always toggled `ui.uploadZoneDragging`:

```tsx
classList={{ [ui.uploadZoneDragging as string]: isDragging() }}
```

That class **was never defined** in `LoadFlameModal.module.css`. So `ui.uploadZoneDragging` was `undefined`, and `classList={{ [undefined]: true }}` put a literal class named `"undefined"` on the element. Dragging a file over the zone changed the wording and nothing else — same dashed border, same background, no cursor change. Hence "there is no real visual border or something indicating the drop is valid".

Adds the rule: solid accent border, accent fill, lifted icon, slight scale, both themes, with a `prefers-reduced-motion` opt-out.

## 2. The flicker

`handleDragLeave` cleared the state on **every** `dragleave`:

```tsx
function handleDragLeave(e: DragEvent) {
  e.preventDefault()
  setIsDragging(false)
}
```

`dragenter`/`dragleave` fire for each element the pointer crosses and bubble to the zone, so moving over the icon or either line of text cleared the state while the pointer was still inside — the highlight and the "release to load" copy snapped back mid-drag.

#147 fixed precisely this in `Dropzone` with a depth counter, but it only reached the modal's `handleDrop`; the modal's enter/leave was untouched.

## Why a shared helper rather than a second copy

The two zones had already drifted into different behaviour once — that is how this bug survived #147. So the counter logic moves into `createFileDragState()` and both use it. The modal also picks up `dropEffect = 'copy'` from it, which is what makes the OS show the accept cursor; it previously called only `preventDefault()`.

`handleDrop` now warns with the transfer types when a drop carries no file, matching `Dropzone`, so a fileless drop is diagnosable rather than silent. (Dragging from Chrome's downloads popup is one of the cases #147's `filesFromDataTransfer` covers — Chromium delivers those with an empty `files` list and the entries only in `items`.)

## Tests

**12 cases** for the drag state: child and deep-nest transitions keep it active, a genuine exit clears it, a null `relatedTarget` falls back to the counter, the counter never goes negative, `reset` clears a nested drag in one call, `dropEffect` is set, a missing `dataTransfer` is tolerated.

**Verified non-vacuous** — reverting `createFileDragState` to the old plain boolean fails exactly the three flicker cases:

```
× stays active while the pointer crosses a child
× stays active across a deeper nest
× falls back to the counter when relatedTarget is null
```

**3 assertions** that the drag class exists and carries a border, a fill and a reduced-motion guard. These read the stylesheet as text on purpose: a CSS-module import under vitest resolves to a proxy that answers every key, so it can never catch a missing class — which is the bug being guarded.

## Verification

`pnpm typecheck`, `pnpm lint`, `pnpm --filter chaos-master exec vitest run` — all exit 0. **159 files, 2013 tests passing.**

I could not get a live render to confirm the border visually: the dev server runs HTTPS with a self-signed certificate and the sandboxed browser refuses to load it over either scheme. The behaviour is covered by the unit tests and the stylesheet assertions above, but the visual itself is worth an eyeball on localhost.

## Found while here, not fixed

`uploadZoneDragging` was not alone. This component references about **fifteen** more classes that exist in no stylesheet — `itemName`, `filterPill`, `sectionHeader`, `itemMeta`, `dimBadge` and others — each resolving to `undefined` and emitting an `"undefined"` class. They look inert rather than harmful (the visuals come from structural selectors), but they are dead references and a repo-wide sweep would likely find more. Deliberately out of scope here.
