### PR TITLE
fix(arcade): make the Teach and Cinema overlay readable

### DIFF
--- a/docs/superpowers/specs/2026-09-03-action-spotlight-feasibility.md
+++ b/docs/superpowers/specs/2026-09-03-action-spotlight-feasibility.md
@@ -1,0 +1,117 @@
+# Showing the human path for an AI action — feasibility
+
+**Question.** In Teach mode the AI runs `sonification.setConfig`. A person doing the
+same thing clicks **Audio → Sonification…**, then moves one select. Can the overlay
+show that path — spotlight the Audio menu, then the Sonification item, then the
+control that actually changed — while the AI drives?
+
+**Answer.** Yes, and most of it already exists. The follow-cam built for replay is
+exactly this feature; it has simply never been pointed at a live session. Landing the
+useful 80% is small. The literal "mock the two clicks" choreography is a second,
+larger step, and it needs UI changes the replay path never needed.
+
+---
+
+## What is already built
+
+Replay already spotlights the control behind each step, and every piece is
+command-driven rather than markup-driven, so none of it is replay-specific by nature:
+
+| Piece                                  | Where                                                                | What it does                                                                                                                                                          |
+| -------------------------------------- | -------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `focusHintFor(commandId, args)`        | `packages/app/src/recorder/focus.ts:130`                             | Maps a command to a semantic hint — `param:<path>`, `ui:<tourTarget>`, `focus:<id>`. Never a selector or a rectangle, so it survives markup changes and window sizes. |
+| `deriveReplayFocusPreparation(action)` | `packages/app/src/recorder/focusPreparation.ts:371`                  | Turns a hint into the UI state that must exist _first_: reveal the sidebar, expand the owning transform, switch the affine tab, show the sonification panel.          |
+| `prepareReplayFocus`                   | `packages/app/src/MainWorkspace.tsx:4464`                            | Applies that state. Owns every signal it touches.                                                                                                                     |
+| `ReplaySpotlight`                      | `packages/app/src/components/SessionRecorder/ReplaySpotlight.tsx:66` | SVG-mask scrim that keeps the canvas and the target lit, dims the chrome, tracks the rect, captions the step.                                                         |
+| 108 `data-tour-target` anchors         | across `src/components`                                              | The vocabulary `ui:` hints resolve against.                                                                                                                           |
+
+The hints for the exact case asked about are already written:
+
+```
+sonification.setConfig  →  param:sonification.<changedKey>   (falls back to ui:sonification-panel)
+sonification.setEnabled →  param:sonification.enabled
+audio.*                 →  ui:audio-panel
+sidebar.open / .close   →  ui:sidebar
+```
+
+So the app can already answer "which control does this command belong to" for a live
+command. Nothing asks it.
+
+---
+
+## The gaps
+
+**1. Nothing computes a hint on the live path.** `execute_command` now has
+`preflight.args` — the same normalized args the recorder logs, which is what
+`focusHintFor` expects. One call at that site produces the hint.
+
+**2. The handler is not reachable from the pilot.** `prepareReplayFocus` is defined in
+`MainWorkspace` and handed down to the recorder dock as `onPrepareAction`. The pilot
+would need the same handler through the WebMCP context or a module-level signal, the
+way the other pilot state is carried.
+
+**3. Z-order.** The pilot shield sits at `z-index: 10010`; the spotlight scrim at
+`300`. As-is the spotlight paints _under_ the lock and is invisible. Either the
+spotlight moves above the shield, or the shield splits into a scrim and a separate
+pointer-catcher with the spotlight between them.
+
+**4. There is no beat.** Replay has a transport; the pilot does not. Today a command
+applies its preparation and executes in the same tick, so there is nothing to watch.
+A live spotlight needs a short dwell before the command lands — the existing
+`LAYOUT_SETTLE_MS` (400) and `TAIL_MS` (900) are the right order of magnitude.
+
+**5. Nothing describes the click path.** This is the real cost of the literal version.
+The preparation jumps straight to the end state — `revealSonificationPanel()` sets
+four signals at once (`MainWorkspace.tsx:1126`). To _show_ Audio → Sonification:
+
+- `PullUpMenu` keeps `open` as a private signal with no external control
+  (`packages/app/src/components/PullUpMenu/PullUpMenu.tsx:27`). It needs an optional
+  controlled-open prop, and while forced open it must skip its outside-press close —
+  a press on the shield currently reaches `document` and would shut it.
+- The Audio trigger carries no anchor. `Genetics` has `data-tour-target="genetics-menu"`;
+  Audio has none.
+- `PullUpMenuItem` has no anchor field at all (`label`, `title`, `onClick`), so the
+  Sonification row cannot be addressed.
+- Something has to state the route. A per-preparation table — "the sonification panel
+  is reached through `ui:audio-menu` then `ui:audio-menu-sonification`" — is the
+  smallest honest form. It is authored data, not derived: no code today knows that
+  the panel lives behind that menu.
+
+---
+
+## Recommended shape
+
+**Phase 1 — live follow-cam.** Reuse hint + preparation + spotlight on the pilot path.
+The spotlight lands on the destination control (the Sonification panel's model select),
+with the panel revealed the way it is today. Fixes gaps 1-4; no new UI vocabulary.
+This alone answers the question a viewer actually has — _what did it just touch?_ —
+and it makes the live view and the replay view agree, which is the same property the
+step labels just gained.
+
+**Phase 2 — the mock click path.** Add the anchors, the controlled-open prop, and the
+route table, for the handful of destinations that are genuinely menu-driven: Audio →
+Audio Reactive / Sonification, Genetics → Breed / Evolve / Simulator / Ancestry / Diff.
+Everything else is one hop and needs nothing. Each hop gets a dwell and a caption
+("the AI opened this from Audio → Sonification").
+
+**Phase 3 — optional.** A travelling cursor glyph between hops. Pure decoration; only
+worth it if the video calls for it.
+
+Phase 1 is worth doing on its own merits and does not commit us to Phase 2.
+
+---
+
+## Risks
+
+- **A mock menu that cannot be clicked.** The lock exists to refuse input; a menu that
+  looks open and live invites a click that does nothing. The caption has to say the AI
+  opened it, and the dwell has to be short enough that it reads as narration.
+- **Choreography must not author commands.** The preparation path is already careful
+  here — see `preserveSonificationOutput: true` at `MainWorkspace.tsx:4510`, which
+  exists so revealing a control cannot author a sonification-disable. Any new reveal
+  path inherits that rule, and the recorder's suppression seam is how it is enforced.
+- **Divergence.** If the live spotlight and the replay spotlight resolve differently,
+  the two views disagree again — the exact bug the step labels just fixed. Both should
+  call `focusHintFor` on the same normalized args, and a test should assert they agree.
+- **Wall-clock, not budget.** Dwells lengthen a lesson without costing steps. A
+  five-step lesson gains roughly 5-8 seconds in Phase 1, more in Phase 2.

--- a/packages/app/src/arcade/animatablePaths.test.ts
+++ b/packages/app/src/arcade/animatablePaths.test.ts
@@ -225,4 +225,48 @@ describe('animatable catalog', () => {
       ),
     ).toMatchObject({ ok: false, error: expect.stringContaining('increasing') })
   })
+
+  // Variation paths are the one form that takes no `transform.` prefix, so
+  // agents reach for the prefixed one and lose a call to the rejection. It is
+  // accepted and stored canonically, which is what keeps a later call on the
+  // same target overwriting the same track instead of making a second one.
+  it('accepts a transform-prefixed variation path and stores the canonical one', () => {
+    const result = buildTimelineSnapshot(
+      {
+        durationFrames: 60,
+        tracks: [
+          {
+            path: 'transform.t2.v2',
+            keyframes: [
+              { frame: 0, value: 0.5 },
+              { frame: 60, value: 0.9 },
+            ],
+          },
+        ],
+      },
+      catalog,
+    )
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.snapshot.tracks.map((track) => track.parameterPath)).toEqual([
+      't2.v2',
+    ])
+  })
+
+  it('still refuses a prefixed path that names nothing', () => {
+    expect(
+      buildTimelineSnapshot(
+        {
+          durationFrames: 60,
+          tracks: [
+            { path: 'transform.t2.nope', keyframes: [{ frame: 0, value: 1 }] },
+          ],
+        },
+        catalog,
+      ),
+    ).toMatchObject({
+      ok: false,
+      error: expect.stringContaining('Unknown path'),
+    })
+  })
 })

--- a/packages/app/src/arcade/animatablePaths.ts
+++ b/packages/app/src/arcade/animatablePaths.ts
@@ -115,9 +115,11 @@ export function buildAnimatableCatalog(flame: FlameDescriptor): CatalogEntry[] {
  * and a variation parameter `<tid>.<vid>.<name>` — no prefix. That is what the
  * timeline resolver has always written and what every saved animation stores,
  * so the format cannot move; agents reach for the prefixed form anyway and
- * burn a call on the rejection. A prefixed path that resolves to a real
- * variation path is accepted and rewritten to the canonical one, so the stored
- * track is the same either way. Reserved forms are looked up first, so a
+ * burn a call on the rejection. Any prefixed path that resolves to a real
+ * catalog entry once the prefix is dropped is accepted and rewritten to the
+ * canonical one, so the stored track is the same either way — the variation
+ * forms are the ones this exists for, but `transform.gamma` costing nothing
+ * is a feature, not an accident. The unprefixed path is looked up FIRST, so a
  * variation that happens to be called `probability` cannot shadow one.
  */
 function canonicalPath(

--- a/packages/app/src/arcade/animatablePaths.ts
+++ b/packages/app/src/arcade/animatablePaths.ts
@@ -109,6 +109,27 @@ export function buildAnimatableCatalog(flame: FlameDescriptor): CatalogEntry[] {
   return entries
 }
 
+/**
+ * The one asymmetry in the path grammar: everything on a transform is
+ * addressed `transform.<tid>.<what>`, but a variation weight is `<tid>.<vid>`
+ * and a variation parameter `<tid>.<vid>.<name>` — no prefix. That is what the
+ * timeline resolver has always written and what every saved animation stores,
+ * so the format cannot move; agents reach for the prefixed form anyway and
+ * burn a call on the rejection. A prefixed path that resolves to a real
+ * variation path is accepted and rewritten to the canonical one, so the stored
+ * track is the same either way. Reserved forms are looked up first, so a
+ * variation that happens to be called `probability` cannot shadow one.
+ */
+function canonicalPath(
+  byPath: ReadonlyMap<string, CatalogEntry>,
+  path: string,
+): string | undefined {
+  if (byPath.has(path)) return path
+  if (!path.startsWith('transform.')) return undefined
+  const stripped = path.slice('transform.'.length)
+  return byPath.has(stripped) ? stripped : undefined
+}
+
 const KeyframeInput = v.object({
   frame: v.pipe(
     v.number(),
@@ -203,19 +224,22 @@ export function buildTimelineSnapshot(
   const input = parsed.output
   const byPath = new Map(catalog.map((entry) => [entry.path, entry]))
   const seen = new Set<string>()
+  const canonical = new Map<string, string>()
   let keyframeCount = 0
   for (const track of input.tracks) {
-    const entry = byPath.get(track.path)
-    if (!entry) {
+    const path = canonicalPath(byPath, track.path)
+    const entry = path === undefined ? undefined : byPath.get(path)
+    if (entry === undefined || path === undefined) {
       return {
         ok: false,
         error: `Unknown path "${track.path}". Call arcade_get_animatable_paths for the list.`,
       }
     }
-    if (seen.has(track.path)) {
-      return { ok: false, error: `Path "${track.path}" appears twice.` }
+    canonical.set(track.path, path)
+    if (seen.has(path)) {
+      return { ok: false, error: `Path "${path}" appears twice.` }
     }
-    seen.add(track.path)
+    seen.add(path)
     let last = -1
     for (const keyframe of track.keyframes) {
       if (keyframe.frame > input.durationFrames) {
@@ -242,7 +266,7 @@ export function buildTimelineSnapshot(
     }
   }
   const additions = input.tracks.map((track) => ({
-    parameterPath: track.path,
+    parameterPath: canonical.get(track.path) ?? track.path,
     keyframes: track.keyframes.map((keyframe) => ({
       frame: keyframe.frame,
       value: keyframe.value,

--- a/packages/app/src/arcade/commandHints.ts
+++ b/packages/app/src/arcade/commandHints.ts
@@ -42,6 +42,14 @@ const COMMAND_ARG_HINTS: Readonly<Record<string, string>> = {
   'lesson.note': '[text] — prefer the arcade_narrate tool',
   'timeline.setFps': '[fps 1-60]',
   'timeline.setLoopMode': '["off"|"seamless"|"cycle"]',
+  'sonification.setEnabled': '[boolean]',
+  // The shape that cost a real agent several rejected calls: the first
+  // argument is a COMPLETE config, not a patch, and the second names the one
+  // control the step is about (it is what the step's label reads back).
+  'sonification.setConfig':
+    '[config, changedKey] — config needs all of model,volume,updateRate,scale,voiceCount,harmonicDensity,triggerRate,spatialSpread,reverbMix; a partial patch is refused',
+  'flame.randomize': '[] — the seed and generator config are filled in for you',
+  'flame.mutate': '[] — the seed, config and mutation options are filled in',
 }
 
 /**

--- a/packages/app/src/arcade/topics.test.ts
+++ b/packages/app/src/arcade/topics.test.ts
@@ -61,6 +61,24 @@ describe('lesson topics', () => {
     expect([...rawJson].sort()).toEqual([])
   })
 
+  // A command that toggles when its argument is missing must not claim a
+  // direction it did not take, and one that no-ops must claim nothing.
+  it('does not invent a direction for a missing boolean', () => {
+    const describeOf = (id: string, args: unknown[]) =>
+      getAllCommands()
+        .find((command) => command.id === id)
+        ?.describe?.(args)
+    expect(describeOf('timeline.setAnimationEnabled', [true])).toBe(
+      'Enable animation',
+    )
+    expect(describeOf('timeline.setAnimationEnabled', [])).toBe(
+      'Toggle animation',
+    )
+    expect(describeOf('sidebar.open', [])).toBe('Toggle the sidebar')
+    expect(describeOf('timeline.setLoop', [])).toBeUndefined()
+    expect(describeOf('view.setShowTimeline', [])).toBeUndefined()
+  })
+
   it('offers cinema presets that fill the wish with a full sentence', () => {
     expect(CINEMA_PRESETS.map((preset) => preset.id)).toEqual([
       'small',

--- a/packages/app/src/arcade/topics.test.ts
+++ b/packages/app/src/arcade/topics.test.ts
@@ -1,7 +1,7 @@
 import '@/commands/builtins'
 import { describe, expect, it } from 'vitest'
 import { getAllCommands } from '@/commands/registry'
-import { CINEMA_ALLOWED, CINEMA_PRESETS, cinemaPromptCard, isTopicId, LESSON_TOPICS, teachPromptCard, TOPIC_IDS, } from './topics'
+import { ALWAYS_ALLOWED, CINEMA_ALLOWED, CINEMA_PRESETS, cinemaPromptCard, isTopicId, LESSON_TOPICS, teachPromptCard, TOPIC_IDS, } from './topics'
 
 describe('lesson topics', () => {
   it('has every topic with a goal, a budget and an allow-list', () => {
@@ -46,6 +46,9 @@ describe('lesson topics', () => {
     const allowLists = [
       ...TOPIC_IDS.map((id) => LESSON_TOPICS[id].allowed),
       CINEMA_ALLOWED,
+      // Every session gets these on top of its topic list, so a command that
+      // is always allowed is exactly the one a viewer sees most often.
+      ALWAYS_ALLOWED,
     ]
     const rawJson = new Set<string>()
     for (const allowed of allowLists) {

--- a/packages/app/src/arcade/topics.test.ts
+++ b/packages/app/src/arcade/topics.test.ts
@@ -37,6 +37,30 @@ describe('lesson topics', () => {
     expect(missing).toEqual([])
   })
 
+  // Every step the pilot takes is shown twice — in the live rail while the AI
+  // drives, and in the replay step list afterwards — and both read the same
+  // `describe`. A command without one falls back to its label plus raw JSON
+  // (`Toggle Sidebar [true]`), which is what the viewer is left staring at.
+  it('only allows commands that can describe themselves', () => {
+    const commands = getAllCommands()
+    const allowLists = [
+      ...TOPIC_IDS.map((id) => LESSON_TOPICS[id].allowed),
+      CINEMA_ALLOWED,
+    ]
+    const rawJson = new Set<string>()
+    for (const allowed of allowLists) {
+      for (const entry of allowed) {
+        const matched = entry.endsWith('.')
+          ? commands.filter((command) => command.id.startsWith(entry))
+          : commands.filter((command) => command.id === entry)
+        for (const command of matched) {
+          if (command.describe === undefined) rawJson.add(command.id)
+        }
+      }
+    }
+    expect([...rawJson].sort()).toEqual([])
+  })
+
   it('offers cinema presets that fill the wish with a full sentence', () => {
     expect(CINEMA_PRESETS.map((preset) => preset.id)).toEqual([
       'small',

--- a/packages/app/src/commands/builtins/camera.ts
+++ b/packages/app/src/commands/builtins/camera.ts
@@ -1,6 +1,7 @@
 import { vec2f } from 'typegpu/data'
 import { MAX_CAMERA_ZOOM_VALUE, MIN_CAMERA_ZOOM_VALUE, } from '@/flame/schema/flameSchema'
 import { registerCommand } from '../registry'
+import { num } from './describeArgs'
 
 /**
  * Framing as commands, so both a person and an agent reach the camera the
@@ -32,6 +33,7 @@ function finite(value: unknown, fallback: number): number {
 
 registerCommand({
   id: 'camera.center',
+  describe: () => 'Centre the camera',
   label: 'Center Camera',
   description: 'Reset camera position to (0, 0) and zoom to 1',
   shortcut: 'Ctrl+0',
@@ -43,6 +45,10 @@ registerCommand({
 
 registerCommand({
   id: 'camera.zoomTo',
+  describe: ([zoom]) => {
+    const z = num(zoom, 3)
+    return z === undefined ? 'Zoom the camera' : `Zoom to ${z}`
+  },
   label: 'Zoom To',
   description: 'Set camera zoom to a specific level',
   execute(ctx, zoom?: unknown) {
@@ -52,6 +58,10 @@ registerCommand({
 
 registerCommand({
   id: 'camera.zoomBy',
+  describe: ([factor]) => {
+    const f = num(factor, 3)
+    return f === undefined ? 'Zoom the camera' : `Zoom by ${f}x`
+  },
   label: 'Zoom By',
   description: 'Multiply the current zoom by a factor (2 = twice as close)',
   execute(ctx, factor?: unknown) {
@@ -65,6 +75,13 @@ registerCommand({
 
 registerCommand({
   id: 'camera.panTo',
+  describe: ([x, y]) => {
+    const px = num(x, 3)
+    const py = num(y, 3)
+    return px === undefined || py === undefined
+      ? 'Pan the camera'
+      : `Pan to ${px}, ${py}`
+  },
   label: 'Pan To',
   description: 'Move the camera centre to a world position',
   execute(ctx, x?: unknown, y?: unknown) {
@@ -80,6 +97,13 @@ registerCommand({
 
 registerCommand({
   id: 'camera.panBy',
+  describe: ([dx, dy]) => {
+    const px = num(dx, 3)
+    const py = num(dy, 3)
+    return px === undefined || py === undefined
+      ? 'Pan the camera'
+      : `Pan by ${px}, ${py}`
+  },
   label: 'Pan By',
   description: 'Move the camera centre by a world-space offset',
   execute(ctx, dx?: unknown, dy?: unknown) {
@@ -95,6 +119,14 @@ registerCommand({
 
 registerCommand({
   id: 'camera.frame',
+  describe: ([x, y, zoom]) => {
+    const px = num(x, 3)
+    const py = num(y, 3)
+    const z = num(zoom, 3)
+    return px === undefined || py === undefined || z === undefined
+      ? 'Frame the camera'
+      : `Frame ${px}, ${py} at zoom ${z}`
+  },
   label: 'Frame Camera',
   description: 'Pan and zoom in one step, so the move reads as one beat',
   execute(ctx, x?: unknown, y?: unknown, zoom?: unknown) {

--- a/packages/app/src/commands/builtins/describeArgs.ts
+++ b/packages/app/src/commands/builtins/describeArgs.ts
@@ -1,0 +1,20 @@
+/**
+ * Shared formatters for the `describe` hook.
+ *
+ * `describe` writes the one line a human reads for a step — in the Arcade's
+ * live rail while the AI drives, and in the replay step list afterwards. Both
+ * call it with the same normalized args, so a command that describes itself
+ * reads identically in both places; one that does not falls back to its label
+ * plus raw JSON.
+ */
+
+/** A number rounded for display, or undefined when the arg is not a number. */
+export function num(value: unknown, digits = 2): string | undefined {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return undefined
+  return String(Number(value.toFixed(digits)))
+}
+
+/** A non-empty string, or undefined. */
+export function str(value: unknown): string | undefined {
+  return typeof value === 'string' && value !== '' ? value : undefined
+}

--- a/packages/app/src/commands/builtins/flame.ts
+++ b/packages/app/src/commands/builtins/flame.ts
@@ -9,6 +9,7 @@ import { tryValidateTransformColorSnapshot } from '@/recorder/schema'
 import { snapshotOriginForCommand, snapshotOriginLabel, tryValidateSnapshotOrigin, } from '@/recorder/snapshotOrigin'
 import { deepClone } from '@/utils/clone'
 import { registerCommand } from '../registry'
+import { num, str } from './describeArgs'
 import type { CommandContext } from '../types'
 import type { Palette } from '@/flame/colorMap'
 import type { FlameDescriptor, TransformFunction, TransformId, VariationId, } from '@/flame/schema/flameSchema'
@@ -184,6 +185,12 @@ function normalizeVariationRef(
 
 registerCommand({
   id: 'flame.setSkipIters',
+  describe: ([iters]) => {
+    const n = num(iters, 0)
+    return n === undefined
+      ? 'Set the skipped iterations'
+      : `Skipped iterations: ${n}`
+  },
   label: 'Set Skip Iters',
   description: 'Set the number of initial skip iterations',
   shortcut: 'Shift+I',
@@ -341,6 +348,8 @@ function resolveNewVariationId(variationId: unknown): VariationId {
 
 registerCommand({
   id: 'flame.addTransform',
+  describe: ([type]) =>
+    `Add a transform${str(type) ? `: ${String(type)}` : ''}`,
   label: 'Add Transform',
   description: 'Add a new transform with an optional variation type',
   shortcut: 'Shift+T',
@@ -424,6 +433,10 @@ registerCommand({
 
 registerCommand({
   id: 'flame.setVariationWeight',
+  describe: ([, , weight]) => {
+    const w = num(weight)
+    return w === undefined ? 'Set a variation weight' : `Variation weight: ${w}`
+  },
   label: 'Set Variation Weight',
   description: 'Set the weight of a variation on a specific transform',
   normalizeArgs(ctx, [transformRef, variationRef, weight]) {
@@ -457,6 +470,8 @@ registerCommand({
 
 registerCommand({
   id: 'flame.addVariation',
+  describe: ([, type]) =>
+    `Add a variation${str(type) ? `: ${String(type)}` : ''}`,
   label: 'Add Variation',
   description: 'Add a variation type to a specific transform',
   validateReplayArgs(args) {
@@ -511,6 +526,10 @@ registerCommand({
 
 registerCommand({
   id: 'flame.setColorSpeed',
+  describe: ([, speed]) => {
+    const s = num(speed)
+    return s === undefined ? 'Set a colour speed' : `Colour speed: ${s}`
+  },
   label: 'Set Color Speed',
   description: 'Set the color speed of a specific transform',
   normalizeArgs(ctx, [transformRef, speed]) {
@@ -666,6 +685,12 @@ registerCommand({
 
 registerCommand({
   id: 'flame.setProbability',
+  describe: ([, probability]) => {
+    const p = num(probability)
+    return p === undefined
+      ? 'Set a transform probability'
+      : `Transform probability: ${p}`
+  },
   label: 'Set Transform Probability',
   description: 'Set the probability weight of a transform by id or index',
   normalizeArgs(ctx, [transformRef, probability]) {
@@ -684,6 +709,12 @@ registerCommand({
 
 registerCommand({
   id: 'flame.setAffine',
+  describe: ([, which, param, value]) => {
+    const p = str(param)
+    const v = num(value, 3)
+    if (p === undefined || v === undefined) return 'Set an affine coefficient'
+    return `${which === 'post' ? 'Post' : 'Pre'}-affine ${p}: ${v}`
+  },
   label: 'Set Affine Coefficient',
   description: 'Set a pre/post affine coefficient on a transform',
   normalizeArgs(ctx, [transformRef, affineType, param, value]) {
@@ -716,6 +747,13 @@ registerCommand({
 
 registerCommand({
   id: 'flame.setTransformColor',
+  describe: ([, x, y]) => {
+    const cx = num(x)
+    const cy = num(y)
+    return cx === undefined || cy === undefined
+      ? 'Set a transform colour'
+      : `Transform colour: ${cx}, ${cy}`
+  },
   label: 'Set Transform Color',
   description: 'Set the color x/y coordinates of a transform',
   normalizeArgs(ctx, [transformRef, x, y, origin]) {
@@ -744,6 +782,10 @@ registerCommand({
 
 registerCommand({
   id: 'flame.setExposure',
+  describe: ([value]) => {
+    const n = num(value, 3)
+    return n === undefined ? 'Set the exposure' : `Exposure: ${n}`
+  },
   label: 'Set Exposure',
   description: 'Set the flame exposure value',
   execute(ctx, value?: unknown) {
@@ -756,6 +798,10 @@ registerCommand({
 
 registerCommand({
   id: 'flame.setVibrancy',
+  describe: ([value]) => {
+    const n = num(value, 3)
+    return n === undefined ? 'Set the vibrancy' : `Vibrancy: ${n}`
+  },
   label: 'Set Vibrancy',
   description: 'Set the flame vibrancy value',
   execute(ctx, value?: unknown) {
@@ -768,6 +814,10 @@ registerCommand({
 
 registerCommand({
   id: 'flame.setGamma',
+  describe: ([value]) => {
+    const n = num(value, 3)
+    return n === undefined ? 'Set the gamma' : `Gamma: ${n}`
+  },
   label: 'Set Gamma',
   description: 'Set the flame gamma value',
   execute(ctx, value?: unknown) {
@@ -780,6 +830,10 @@ registerCommand({
 
 registerCommand({
   id: 'flame.setContrast',
+  describe: ([value]) => {
+    const n = num(value, 3)
+    return n === undefined ? 'Set the contrast' : `Contrast: ${n}`
+  },
   label: 'Set Contrast',
   description: 'Set the flame contrast value',
   execute(ctx, value?: unknown) {
@@ -792,6 +846,11 @@ registerCommand({
 
 registerCommand({
   id: 'flame.setBackgroundColor',
+  describe: ([r, g, b]) => {
+    const to255 = (c: unknown) =>
+      typeof c === 'number' ? Math.round(Math.min(1, Math.max(0, c)) * 255) : 0
+    return `Background: rgb(${to255(r)}, ${to255(g)}, ${to255(b)})`
+  },
   label: 'Set Background Color',
   description: 'Set the background color (RGB, values 0-1)',
   execute(ctx, r?: unknown, g?: unknown, b?: unknown) {
@@ -806,6 +865,7 @@ registerCommand({
 
 registerCommand({
   id: 'flame.setDrawMode',
+  describe: ([mode]) => `Draw mode: ${mode === 'paint' ? 'paint' : 'light'}`,
   label: 'Set Draw Mode',
   description: 'Set the render draw mode (light or paint)',
   execute(ctx, mode?: unknown) {
@@ -838,6 +898,12 @@ registerCommand({
 
 registerCommand({
   id: 'flame.setVariationParams',
+  describe: ([, , name, value]) => {
+    const n = str(name)
+    if (n === undefined) return 'Set a variation parameter'
+    const v = num(value) ?? String(value)
+    return `Variation ${n}: ${v}`
+  },
   label: 'Set Variation Params',
   description:
     'Set a parametric variation parameter by name on a specific transform/variation',
@@ -894,6 +960,8 @@ registerCommand({
 
 registerCommand({
   id: 'flame.setVariationVisible',
+  describe: ([, , visible]) =>
+    visible === true ? 'Show a variation' : 'Hide a variation',
   label: 'Set Variation Visibility',
   description: 'Show or hide a variation on a transform',
   normalizeArgs(ctx, [transformRef, variationRef, visible]) {
@@ -922,6 +990,12 @@ registerCommand({
 
 registerCommand({
   id: 'flame.setVariation',
+  describe: ([, , descriptor]) => {
+    const type = str(variationDescriptorType(descriptor))
+    return type === undefined
+      ? 'Replace a variation'
+      : `Replace a variation with ${type}`
+  },
   label: 'Set Variation',
   description:
     'Replace a variation descriptor wholesale (type, weight and params)',
@@ -997,6 +1071,7 @@ registerCommand({
 
 registerCommand({
   id: 'flame.deleteTransform',
+  describe: () => 'Delete a transform',
   label: 'Delete Transform',
   description:
     'Delete a transform, or reset it to a blank one when it is the last',
@@ -1041,6 +1116,7 @@ registerCommand({
 
 registerCommand({
   id: 'flame.deleteVariation',
+  describe: () => 'Delete a variation',
   label: 'Delete Variation',
   description:
     'Delete a variation, or reset it to its type default when it is the last',
@@ -1072,6 +1148,10 @@ registerCommand({
 
 registerCommand({
   id: 'flame.setFinalTransform',
+  describe: ([affine]) =>
+    affine === null || affine === undefined
+      ? 'Clear the final transform'
+      : 'Set the final transform',
   label: 'Set Final Transform',
   description: 'Set or clear the flame-wide final affine transform',
   normalizeArgs(_ctx, [affine, origin]) {
@@ -1104,6 +1184,13 @@ registerCommand({
 
 registerCommand({
   id: 'flame.setFinalAffine',
+  describe: ([param, value]) => {
+    const p = str(param)
+    const v = num(value, 3)
+    return p === undefined || v === undefined
+      ? 'Set a final affine coefficient'
+      : `Final affine ${p}: ${v}`
+  },
   label: 'Set Final Affine Coefficient',
   description: 'Set one coefficient on the flame-wide final transform',
   coalesceKey: ([param]) => `final-affine:${String(param)}`,
@@ -1190,6 +1277,8 @@ registerCommand({
 
 registerCommand({
   id: 'flame.setTransformAffine',
+  describe: ([, which]) =>
+    `Reshape a transform (${which === 'post' ? 'post' : 'pre'}-affine)`,
   label: 'Set Transform Affine',
   description:
     "Replace a transform's whole pre- or post-affine (the affine editor's drag)",
@@ -1225,6 +1314,13 @@ registerCommand({
 
 registerCommand({
   id: 'flame.applyPalette',
+  describe: ([palette]) => {
+    const name =
+      palette !== null && typeof palette === 'object' && 'name' in palette
+        ? str((palette as { name?: unknown }).name)
+        : undefined
+    return name === undefined ? 'Apply a palette' : `Apply palette: ${name}`
+  },
   label: 'Apply Palette',
   description:
     'Recolour every transform from a palette and record the palette itself',
@@ -1265,6 +1361,7 @@ registerCommand({
 
 registerCommand({
   id: 'flame.removePalette',
+  describe: () => 'Remove the palette',
   label: 'Remove Palette',
   description:
     'Drop the palette, restoring the colours transforms had before it',
@@ -1420,6 +1517,13 @@ function symmetryArgsError(args: readonly unknown[]): string | undefined {
 
 registerCommand({
   id: 'flame.applySymmetry',
+  describe: ([n, type]) => {
+    const fold = num(n, 0)
+    const kind = type === 'dihedral' ? 'dihedral' : 'rotational'
+    return fold === undefined
+      ? `Apply ${kind} symmetry`
+      : `Apply ${fold}-fold ${kind} symmetry`
+  },
   label: 'Apply Symmetry',
   description:
     'Replace the generated symmetry transforms with an n-fold rotational or dihedral set',
@@ -1575,6 +1679,15 @@ registerCommand({
 
 registerCommand({
   id: 'flame.setAllTransformColors',
+  describe: ([colors]) => {
+    const count =
+      colors !== null && typeof colors === 'object'
+        ? Object.keys(colors).length
+        : 0
+    return count === 0
+      ? 'Randomize every transform colour'
+      : `Randomize ${count} transform colours`
+  },
   label: 'Randomize All Colors',
   description: 'Set every transform colour at once, by transform id',
   // The colours are rolled by the caller and recorded as data, so replay

--- a/packages/app/src/commands/builtins/generate.ts
+++ b/packages/app/src/commands/builtins/generate.ts
@@ -222,6 +222,7 @@ function resolveSeededArgs(
 
 registerCommand({
   id: 'flame.randomize',
+  describe: () => 'Randomize the flame',
   label: 'Randomize Flame',
   description:
     'Replace the flame with a generated one — deterministic per seed',
@@ -256,6 +257,7 @@ registerCommand({
 
 registerCommand({
   id: 'flame.mutate',
+  describe: () => 'Mutate the flame',
   label: 'Mutate Flame',
   description:
     'Mutate the current flame — deterministic per seed and input flame',

--- a/packages/app/src/commands/builtins/lesson.test.ts
+++ b/packages/app/src/commands/builtins/lesson.test.ts
@@ -18,10 +18,12 @@ describe('lesson.note', () => {
     expect(narration()).toBe('Adding a spherical variation next.')
     expect(narrationLog()).toHaveLength(1)
     const session = stopSessionRecording()
+    // The label IS the sentence: a replay step list reading "Narration" for
+    // every line tells the viewer nothing.
     expect(session?.actions[0]).toMatchObject({
       id: 'lesson.note',
       args: ['Adding a spherical variation next.'],
-      label: 'Narration',
+      label: 'Adding a spherical variation next.',
     })
   })
 

--- a/packages/app/src/commands/builtins/lesson.ts
+++ b/packages/app/src/commands/builtins/lesson.ts
@@ -19,6 +19,8 @@ function isNarrationText(value: unknown): value is string {
 
 registerCommand({
   id: 'lesson.note',
+  describe: ([text]) =>
+    typeof text === 'string' && text.trim() !== '' ? text.trim() : undefined,
   label: 'Narration',
   description: 'A sentence the AI says about the step it is about to take',
   validateReplayArgs(args) {

--- a/packages/app/src/commands/builtins/timeline.ts
+++ b/packages/app/src/commands/builtins/timeline.ts
@@ -172,8 +172,13 @@ function validateSetKeyframeValueArgs(
 
 registerCommand({
   id: 'timeline.setAnimationEnabled',
+  // No argument means toggle, so the label cannot claim a direction.
   describe: ([enabled]) =>
-    enabled === false ? 'Disable animation' : 'Enable animation',
+    enabled === true
+      ? 'Enable animation'
+      : enabled === false
+        ? 'Disable animation'
+        : 'Toggle animation',
   label: 'Toggle Animation',
   description: 'Enable or disable timeline animation playback',
   shortcut: 'Ctrl+T',
@@ -212,7 +217,8 @@ registerCommand({
 
 registerCommand({
   id: 'timeline.setLoop',
-  describe: ([loop]) => (loop === false ? 'Loop off' : 'Loop on'),
+  describe: ([loop]) =>
+    loop === true ? 'Loop on' : loop === false ? 'Loop off' : undefined,
   label: 'Set Animation Loop',
   description: 'Enable or disable timeline animation loop',
   validateReplayArgs: (args) => exactReplayArgs(args, [isBoolean]),
@@ -243,7 +249,12 @@ registerCommand({
 
 registerCommand({
   id: 'timeline.setAutoFps',
-  describe: ([enabled]) => (enabled === false ? 'Auto FPS off' : 'Auto FPS on'),
+  describe: ([enabled]) =>
+    enabled === true
+      ? 'Auto FPS on'
+      : enabled === false
+        ? 'Auto FPS off'
+        : undefined,
   label: 'Set Auto FPS',
   description: 'Wait for render quality before advancing each frame',
   validateReplayArgs: (args) => exactReplayArgs(args, [isBoolean]),
@@ -618,7 +629,11 @@ registerCommand({
 registerCommand({
   id: 'timeline.setAutoKeyframe',
   describe: ([enabled]) =>
-    enabled === false ? 'Auto-keyframe off' : 'Auto-keyframe on',
+    enabled === true
+      ? 'Auto-keyframe on'
+      : enabled === false
+        ? 'Auto-keyframe off'
+        : undefined,
   label: 'Toggle Auto-Keyframe',
   description: 'Record a keyframe automatically whenever a parameter changes',
   validateReplayArgs: (args) => exactReplayArgs(args, [isBoolean]),

--- a/packages/app/src/commands/builtins/timeline.ts
+++ b/packages/app/src/commands/builtins/timeline.ts
@@ -1,6 +1,7 @@
 import { isTimelineParameterPath, MAX_TIMELINE_FRAME, MAX_TIMELINE_KEYFRAME_NUMBER_MAGNITUDE, MAX_TIMELINE_KEYFRAME_STRING_LENGTH, MAX_TIMELINE_PLAYBACK_FPS, MAX_TIMELINE_TIME_SCALE, MAX_TIMELINE_TRACKS, tryValidateTimelineSnapshot, } from '@/flame/schema/timeline'
 import { snapshotOriginForCommand, snapshotOriginLabel, tryValidateSnapshotOrigin, } from '@/recorder/snapshotOrigin'
 import { registerCommand } from '../registry'
+import { num, str } from './describeArgs'
 
 type ReplayArgGuard = (value: unknown) => boolean
 
@@ -171,6 +172,8 @@ function validateSetKeyframeValueArgs(
 
 registerCommand({
   id: 'timeline.setAnimationEnabled',
+  describe: ([enabled]) =>
+    enabled === false ? 'Disable animation' : 'Enable animation',
   label: 'Toggle Animation',
   description: 'Enable or disable timeline animation playback',
   shortcut: 'Ctrl+T',
@@ -186,6 +189,12 @@ registerCommand({
 
 registerCommand({
   id: 'timeline.setDuration',
+  describe: ([frames]) => {
+    const f = num(frames, 0)
+    return f === undefined
+      ? 'Set the animation duration'
+      : `Duration: ${f} frames`
+  },
   label: 'Set Animation Duration',
   description: 'Set the animation duration in frames',
   coalesceKey: ([, coalesce]) => (coalesce === true ? 'duration' : undefined),
@@ -203,6 +212,7 @@ registerCommand({
 
 registerCommand({
   id: 'timeline.setLoop',
+  describe: ([loop]) => (loop === false ? 'Loop off' : 'Loop on'),
   label: 'Set Animation Loop',
   description: 'Enable or disable timeline animation loop',
   validateReplayArgs: (args) => exactReplayArgs(args, [isBoolean]),
@@ -215,6 +225,10 @@ registerCommand({
 
 registerCommand({
   id: 'timeline.setFps',
+  describe: ([fps]) => {
+    const f = num(fps, 0)
+    return f === undefined ? 'Set the animation FPS' : `Animation FPS: ${f}`
+  },
   label: 'Set Animation FPS',
   description: 'Set the frames per second for timeline playback',
   coalesceKey: ([, coalesce]) => (coalesce === true ? 'fps' : undefined),
@@ -229,6 +243,7 @@ registerCommand({
 
 registerCommand({
   id: 'timeline.setAutoFps',
+  describe: ([enabled]) => (enabled === false ? 'Auto FPS off' : 'Auto FPS on'),
   label: 'Set Auto FPS',
   description: 'Wait for render quality before advancing each frame',
   validateReplayArgs: (args) => exactReplayArgs(args, [isBoolean]),
@@ -239,6 +254,10 @@ registerCommand({
 
 registerCommand({
   id: 'timeline.setTimeScale',
+  describe: ([scale]) => {
+    const s = num(scale, 2)
+    return s === undefined ? 'Set the playback speed' : `Playback speed: ${s}x`
+  },
   label: 'Set Playback Speed',
   description: 'Set the timeline playback speed multiplier',
   coalesceKey: ([, coalesce]) => (coalesce === true ? 'time-scale' : undefined),
@@ -268,6 +287,10 @@ registerCommand({
 
 registerCommand({
   id: 'timeline.setCurrentFrame',
+  describe: ([frame]) => {
+    const f = num(frame, 0)
+    return f === undefined ? 'Jump to a frame' : `Go to frame ${f}`
+  },
   label: 'Set Current Frame',
   description: 'Jump to a specific frame in the timeline',
   coalesceKey: ([, coalesce]) => (coalesce === true ? 'playhead' : undefined),
@@ -282,6 +305,12 @@ registerCommand({
 
 registerCommand({
   id: 'timeline.addKeyframe',
+  describe: ([path, , frame]) => {
+    const p = str(path)
+    if (p === undefined) return 'Add a keyframe'
+    const f = num(frame, 0)
+    return f === undefined ? `Keyframe ${p}` : `Keyframe ${p} @${f}`
+  },
   label: 'Add Keyframe',
   description: 'Add a keyframe at the current or specified frame',
   validateReplayArgs: validateAddKeyframeArgs,
@@ -310,6 +339,12 @@ registerCommand({
 
 registerCommand({
   id: 'timeline.addKeyframes',
+  describe: ([writes, frame]) => {
+    const count = Array.isArray(writes) ? writes.length : 0
+    const f = num(frame, 0)
+    const what = count === 1 ? '1 keyframe' : `${count} keyframes`
+    return f === undefined ? `Add ${what}` : `Add ${what} @${f}`
+  },
   label: 'Add Keyframes',
   description: 'Keyframe multiple parameter values as one authored edit',
   coalesceKey: ([writes, frame, coalesce]) => {
@@ -335,6 +370,7 @@ registerCommand({
 
 registerCommand({
   id: 'timeline.play',
+  describe: () => 'Play the timeline',
   label: 'Play Timeline',
   description: 'Start timeline playback',
   recordable: false,
@@ -521,6 +557,7 @@ registerCommand({
 
 registerCommand({
   id: 'timeline.clearTracks',
+  describe: () => 'Clear the timeline',
   label: 'Clear Timeline',
   description: 'Remove every track and keyframe',
   validateReplayArgs: (args) => exactReplayArgs(args, []),
@@ -580,6 +617,8 @@ registerCommand({
 
 registerCommand({
   id: 'timeline.setAutoKeyframe',
+  describe: ([enabled]) =>
+    enabled === false ? 'Auto-keyframe off' : 'Auto-keyframe on',
   label: 'Toggle Auto-Keyframe',
   description: 'Record a keyframe automatically whenever a parameter changes',
   validateReplayArgs: (args) => exactReplayArgs(args, [isBoolean]),

--- a/packages/app/src/commands/builtins/ui.ts
+++ b/packages/app/src/commands/builtins/ui.ts
@@ -22,6 +22,7 @@ registerCommand({
 
 registerCommand({
   id: 'sidebar.close',
+  describe: () => 'Close the sidebar',
   label: 'Close Sidebar',
   description: 'Close the sidebar panel',
   execute(ctx) {

--- a/packages/app/src/commands/builtins/ui.ts
+++ b/packages/app/src/commands/builtins/ui.ts
@@ -2,6 +2,12 @@ import { registerCommand } from '../registry'
 
 registerCommand({
   id: 'sidebar.open',
+  describe: ([open]) =>
+    open === true
+      ? 'Open the sidebar'
+      : open === false
+        ? 'Close the sidebar'
+        : 'Toggle the sidebar',
   label: 'Toggle Sidebar',
   description: 'Open or close the sidebar panel',
   shortcut: 'Ctrl+S',

--- a/packages/app/src/commands/builtins/view.ts
+++ b/packages/app/src/commands/builtins/view.ts
@@ -94,8 +94,13 @@ registerCommand({
 
 registerCommand({
   id: 'view.setShowTimeline',
+  // A non-boolean is a no-op here, so it gets no sentence of its own.
   describe: ([show]) =>
-    show === false ? 'Hide the timeline panel' : 'Show the timeline panel',
+    show === true
+      ? 'Show the timeline panel'
+      : show === false
+        ? 'Hide the timeline panel'
+        : undefined,
   label: 'Toggle Timeline Panel',
   description: 'Show or hide the timeline',
   execute(ctx, shown?: unknown) {

--- a/packages/app/src/commands/builtins/view.ts
+++ b/packages/app/src/commands/builtins/view.ts
@@ -1,4 +1,5 @@
 import { registerCommand } from '../registry'
+import { num } from './describeArgs'
 
 /**
  * The actions-toolbar switches: quality preset, the two filters, 2D/3D, fly
@@ -30,6 +31,12 @@ registerCommand({
 
 registerCommand({
   id: 'view.setPixelRatio',
+  describe: ([ratio]) => {
+    const r = num(ratio, 2)
+    return r === undefined
+      ? 'Set the canvas resolution'
+      : `Canvas resolution: ${r}x`
+  },
   label: 'Set Canvas Resolution',
   description: 'Choose the live canvas resolution scale',
   execute(ctx, ratio?: unknown) {
@@ -87,6 +94,8 @@ registerCommand({
 
 registerCommand({
   id: 'view.setShowTimeline',
+  describe: ([show]) =>
+    show === false ? 'Hide the timeline panel' : 'Show the timeline panel',
   label: 'Toggle Timeline Panel',
   description: 'Show or hide the timeline',
   execute(ctx, shown?: unknown) {

--- a/packages/app/src/components/Arcade/PilotOverlay.module.css
+++ b/packages/app/src/components/Arcade/PilotOverlay.module.css
@@ -1,11 +1,21 @@
+/* The lock you can see through.
+   Teach and Cinema exist to be WATCHED: the sidebar labels, the affine
+   handles and the flame itself are the lesson. A heavy scrim plus a
+   full-viewport backdrop blur hid exactly the thing the viewer is supposed to
+   be learning from, so both are gone. What enforces the lock is
+   `pointer-events`, not opacity — nothing here is load-bearing for safety, it
+   only has to SAY "these controls are not yours right now". A ring around the
+   viewport says that without costing a single pixel of legibility. */
 .shield {
   position: fixed;
   inset: 0;
   /* Topmost layer: version pills 9999 < Arcade hub 10005/10006 < pilot lock 10010. */
   z-index: 10010;
   pointer-events: all;
-  background: rgba(4, 6, 12, 0.35);
-  backdrop-filter: blur(1px);
+  background: rgba(4, 6, 12, 0.08);
+  box-shadow:
+    inset 0 0 0 2px rgba(138, 180, 255, 0.45),
+    inset 0 0 60px rgba(138, 180, 255, 0.07);
   display: grid;
   grid-template-rows: auto 1fr auto;
   grid-template-columns: 1fr 320px;
@@ -62,6 +72,7 @@
 .stop {
   display: inline-flex;
   align-items: center;
+  flex: none;
   gap: 8px;
   padding: 7px 14px;
   border-radius: 999px;
@@ -72,6 +83,15 @@
     600 13px system-ui,
     sans-serif;
   cursor: pointer;
+}
+
+/* An unsized SVG in a flex row lays out at its default replaced size, which
+   pushed the label off the button's centre. Every other icon here is sized by
+   a class; this one is inside a button and gets it from the button. */
+.stop svg {
+  width: 15px;
+  height: 15px;
+  flex: none;
 }
 
 .stop:focus-visible {
@@ -113,15 +133,23 @@
   opacity: 0.6;
 }
 
+/* A pill, for the same reason the banner is one: a full-width bar across the
+   bottom covers the timeline and the transport, which a Cinema take is about. */
 .hint {
   grid-column: 1 / -1;
-  padding: 8px 18px;
+  justify-self: center;
+  margin: 0 0 12px;
+  padding: 7px 16px;
+  border-radius: 999px;
   text-align: center;
-  color: rgba(255, 255, 255, 0.7);
+  color: rgba(255, 255, 255, 0.8);
   font:
     12px system-ui,
     sans-serif;
-  background: rgba(10, 14, 24, 0.7);
+  background: rgba(10, 14, 24, 0.8);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  /* Blur belongs on the chrome, never on the whole viewport. */
+  backdrop-filter: blur(8px);
 }
 
 @media (max-width: 768px) {

--- a/packages/app/src/recorder/recorder.test.ts
+++ b/packages/app/src/recorder/recorder.test.ts
@@ -1638,10 +1638,11 @@ describe('.steps.json serialization', () => {
     const session = recordSmallSession()
     const parsed = parseSession(serializeSession(session))
     expect(parsed).toEqual(session)
-    // Labels resolved at record time, timestamps monotonic.
+    // Labels resolved at record time, timestamps monotonic. A named scalar
+    // command describes itself, so the label carries the value it set.
     expect(parsed?.actions.map((x) => x.label)).toEqual([
-      'Set Gamma',
-      'Set Vibrancy',
+      'Gamma: 2.42',
+      'Vibrancy: 0.95',
     ])
     // A generic command describes the invocation instead of itself, so the
     // replay step list reads "Set gamma to 2.42" rather than repeating "Set

--- a/packages/app/src/webmcp/tools/arcadeCinema.test.ts
+++ b/packages/app/src/webmcp/tools/arcadeCinema.test.ts
@@ -1,5 +1,6 @@
 import '@/commands/builtins'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { buildAnimatableCatalog } from '@/arcade/animatablePaths'
 import { pilot, resetPilot } from '@/arcade/pilot'
 import { cancelSessionRecording, startSessionRecording, stopSessionRecording, unnamedWriteCount, } from '@/recorder/recorder'
 import { clearWebMcpContext, setWebMcpContext } from '@/webmcp/contextBridge'
@@ -113,6 +114,33 @@ describe('Cinema tools', () => {
     expect(paths.transforms).toHaveLength(8)
     expect(paths.transformPaths).toContain('preAffine')
     expect(JSON.stringify(paths).length).toBeLessThan(1500)
+  })
+
+  // The grammar is the agent's only description of what set_keyframes accepts,
+  // so it must not name a form the catalog cannot produce. `buildAnimatableCatalog`
+  // emits ONE entry per variation — its weight — and nothing keyed by parameter
+  // name, so advertising `<id>.<variationId>.<param>` bought a guaranteed
+  // "Unknown path" rejection and a wasted call.
+  it('advertises only the variation form the catalog can produce', async () => {
+    const ctx = ctxWithRecorder()
+    setWebMcpContext(ctx)
+    const paths = (await arcadeGetAnimatablePaths.execute({}, {})) as {
+      transformPaths: string
+    }
+    expect(paths.transformPaths).toContain('<id>.<variationId>')
+    expect(paths.transformPaths).toContain('weight')
+    expect(paths.transformPaths).not.toContain('<param>')
+
+    const catalog = buildAnimatableCatalog(ctx.flameDescriptor())
+    const variationPaths = catalog
+      .filter((entry) => entry.group.endsWith('variations'))
+      .map((entry) => entry.path)
+    expect(variationPaths.length).toBeGreaterThan(0)
+    // Two segments each: the weight. A third would be a parameter, and there
+    // are none.
+    for (const path of variationPaths) {
+      expect(path.split('.')).toHaveLength(2)
+    }
   })
 
   it('keeps the wall-clock play out of the recorded take', async () => {

--- a/packages/app/src/webmcp/tools/arcadeCinema.ts
+++ b/packages/app/src/webmcp/tools/arcadeCinema.ts
@@ -72,6 +72,7 @@ export const arcadeStartCinema: WebMcpTool = {
         'Call arcade_get_animatable_paths first.',
         'Build the animation one idea at a time: arcade_set_keyframes with mode "add" per group of related tracks, keeping the same durationFrames. Each call is a step the viewer watches land and can replay.',
         'Keep it under 10 seconds unless asked; use easeInOut for camera moves.',
+        'arcade_get_animatable_paths is free; every arcade_set_keyframes call that is accepted costs a step, play or no play, and leaves its tracks behind. A rejected call costs nothing.',
       ],
     }
   },
@@ -84,7 +85,7 @@ const MAX_LISTED_TRANSFORMS = 8
 /** Every transform exposes the same paths, so the grammar is stated once
  *  instead of repeated for each one. */
 const TRANSFORM_PATHS =
-  'transform.<id>.{preAffine|postAffine}.{a-f} | transform.<id>.{probability|colorSpeed|color.x|color.y} | <id>.<variationId> weight | finalTransform.{a-f}'
+  'transform.<id>.{preAffine|postAffine}.{a-f} or .{probability|colorSpeed|color.x|color.y} | finalTransform.{a-f} | <id>.<variationId>[.<param>] (no transform. prefix)'
 
 function summarize(
   catalog: CatalogEntry[],

--- a/packages/app/src/webmcp/tools/arcadeCinema.ts
+++ b/packages/app/src/webmcp/tools/arcadeCinema.ts
@@ -85,7 +85,7 @@ const MAX_LISTED_TRANSFORMS = 8
 /** Every transform exposes the same paths, so the grammar is stated once
  *  instead of repeated for each one. */
 const TRANSFORM_PATHS =
-  'transform.<id>.{preAffine|postAffine}.{a-f} or .{probability|colorSpeed|color.x|color.y} | finalTransform.{a-f} | <id>.<variationId>[.<param>] (no transform. prefix)'
+  'transform.<id>.{preAffine|postAffine}.{a-f} or .{probability|colorSpeed|color.x|color.y} | finalTransform.{a-f} | <id>.<variationId> = variation weight (no transform. prefix)'
 
 function summarize(
   catalog: CatalogEntry[],

--- a/packages/app/src/webmcp/tools/executeCommand.test.ts
+++ b/packages/app/src/webmcp/tools/executeCommand.test.ts
@@ -1,5 +1,6 @@
 import '@/commands/builtins'
 import { afterEach, describe, expect, it } from 'vitest'
+import { pilotLog, resetPilot, startPilot } from '@/arcade/pilot'
 import { cancelSessionRecording, startSessionRecording, stopSessionRecording, } from '@/recorder/recorder'
 import { clearWebMcpContext, setWebMcpContext } from '@/webmcp/contextBridge'
 import { createMockCommandContext } from '@/webmcp/testUtils'
@@ -9,6 +10,7 @@ describe('execute_command dispatch', () => {
   afterEach(() => {
     cancelSessionRecording()
     clearWebMcpContext()
+    resetPilot()
   })
 
   it('records the command in an active session and honours beforeCommand', async () => {
@@ -39,5 +41,119 @@ describe('execute_command dispatch', () => {
     )
     expect(result).toHaveProperty('error')
     expect(ctx.beforeCommand).not.toHaveBeenCalled()
+  })
+
+  // The live rail and the replay's step list must say the same thing about
+  // the same step. Commands that render their value into their own label are
+  // where the two used to diverge: the rail appended raw JSON, so a lesson
+  // read "Set Sonification Sound [{\"version\":1,...}]" live and
+  // "Sonification model: ambient" on replay.
+  it('logs the step under the label the recorder will use', async () => {
+    const ctx = createMockCommandContext()
+    setWebMcpContext(ctx)
+    startPilot({
+      mode: 'teach',
+      topic: 'sonification',
+      title: 'Teaching: Sound and sonification',
+      stepBudget: 5,
+      allowed: ['sonification.'],
+      qualityRankAtStart: 3,
+    })
+
+    await executeCommandTool.execute(
+      {
+        commandId: 'sonification.setConfig',
+        args: [
+          {
+            model: 'ambient',
+            volume: 0.3,
+            updateRate: 20,
+            scale: 'pentatonicMajor',
+            voiceCount: 8,
+            harmonicDensity: 1,
+            triggerRate: 4,
+            spatialSpread: 0.7,
+            reverbMix: 0.3,
+          },
+          'model',
+        ],
+      },
+      {},
+    )
+
+    const line = pilotLog().find((entry) => entry.kind === 'command')?.text
+    expect(line).toBe('Sonification model: ambient')
+    expect(line).not.toContain('{')
+  })
+
+  it('names the value a scalar command set', async () => {
+    const ctx = createMockCommandContext()
+    setWebMcpContext(ctx)
+    startPilot({
+      mode: 'teach',
+      topic: 'color',
+      title: 'Teaching: Colour and tone',
+      stepBudget: 5,
+      allowed: ['flame.'],
+      qualityRankAtStart: 3,
+    })
+
+    await executeCommandTool.execute(
+      { commandId: 'flame.setExposure', args: [0.42] },
+      {},
+    )
+
+    // The value is what tells two steps apart, but it reads as a sentence
+    // rather than as the raw call — "Set Exposure [0.42]".
+    expect(pilotLog().find((e) => e.kind === 'command')?.text).toBe(
+      'Exposure: 0.42',
+    )
+  })
+
+  it('describes a no-argument command without an empty bracket', async () => {
+    const ctx = createMockCommandContext()
+    setWebMcpContext(ctx)
+    startPilot({
+      mode: 'teach',
+      topic: 'camera',
+      title: 'Teaching: Camera and framing',
+      stepBudget: 5,
+      allowed: ['camera.'],
+      qualityRankAtStart: 3,
+    })
+
+    await executeCommandTool.execute(
+      { commandId: 'camera.center', args: [] },
+      {},
+    )
+
+    // Never "Center Camera []".
+    const line = pilotLog().find((e) => e.kind === 'command')?.text
+    expect(line).toBe('Centre the camera')
+    expect(line).not.toContain('[')
+  })
+
+  // The line the user actually reported: a boolean argument rendered as JSON.
+  it('says which way a boolean toggle went', async () => {
+    const ctx = createMockCommandContext()
+    setWebMcpContext(ctx)
+    startPilot({
+      mode: 'teach',
+      topic: 'sonification',
+      title: 'Teaching: Sound and sonification',
+      stepBudget: 5,
+      allowed: ['sidebar.open'],
+      qualityRankAtStart: 3,
+    })
+
+    await executeCommandTool.execute(
+      { commandId: 'sidebar.open', args: [true] },
+      {},
+    )
+
+    // Never "Toggle Sidebar [true]".
+    expect(pilotLog().find((e) => e.kind === 'command')?.text).toBe(
+      'Open the sidebar',
+    )
   })
 })

--- a/packages/app/src/webmcp/tools/executeCommand.ts
+++ b/packages/app/src/webmcp/tools/executeCommand.ts
@@ -4,15 +4,31 @@ import { executeCommand, getCommand, preflightLiveCommand, } from '@/commands/re
 import { getWebMcpContext } from '@/webmcp/contextBridge'
 import type { WebMcpTool } from '@/webmcp/types'
 
-/** One readable line for the pilot overlay's live step list. */
+/**
+ * One readable line for the pilot overlay's live step list.
+ *
+ * The same sentence the recorder writes into the log, so the live rail and the
+ * replay's step list say the same thing about the same step. Commands that
+ * render their value into their own label ("Sonification model: ambient") are
+ * why: appending raw JSON instead produced "Set Sonification Sound
+ * [{"version":1,"model":"ambient",...]" live and the readable form only on
+ * replay, which made the two views look like different sessions.
+ *
+ * The argument dump survives only as the fallback for commands that describe
+ * nothing, where the values are the only thing distinguishing two steps.
+ */
 function describeStep(commandId: string, args: unknown[]): string {
-  const label = getCommand(commandId)?.label ?? commandId
+  const cmd = getCommand(commandId)
+  const described = cmd?.describe?.([...args])
+  if (described !== undefined && described !== '') return described
+  const label = cmd?.label ?? commandId
   let rendered = ''
   try {
     rendered = JSON.stringify(args)
   } catch {
     rendered = ''
   }
+  if (rendered === '' || rendered === '[]') return label
   return rendered.length > 80
     ? `${label} ${rendered.slice(0, 77)}...`
     : `${label} ${rendered}`
@@ -103,7 +119,15 @@ export const executeCommandTool: WebMcpTool = {
     }
 
     if (driving) {
-      const remaining = notePilotStep('command', describeStep(commandId, args))
+      // The NORMALIZED args, which are the ones the recorder describes and
+      // logs. A command whose label renders its value reads them back out of
+      // its canonical shape — `sonification.setConfig` cannot say
+      // "Sonification model: ambient" from the flat config an agent typed,
+      // only from the snapshot normalization builds.
+      const remaining = notePilotStep(
+        'command',
+        describeStep(commandId, preflight.args),
+      )
       return { success: true, commandId, steps: driving.steps + 1, remaining }
     }
 

--- a/packages/app/src/webmcp/tools/executeCommand.ts
+++ b/packages/app/src/webmcp/tools/executeCommand.ts
@@ -19,7 +19,15 @@ import type { WebMcpTool } from '@/webmcp/types'
  */
 function describeStep(commandId: string, args: unknown[]): string {
   const cmd = getCommand(commandId)
-  const described = cmd?.describe?.([...args])
+  // A describe reads args it did not validate. One that throws here would
+  // fail the tool call AFTER the command already mutated the document, so the
+  // agent would see an error for a step the viewer just watched land.
+  let described: string | undefined
+  try {
+    described = cmd?.describe?.([...args])
+  } catch {
+    described = undefined
+  }
   if (described !== undefined && described !== '') return described
   const label = cmd?.label ?? commandId
   let rendered = ''


### PR DESCRIPTION
Polish pass on the Arcade overlay, from watching a real Teach lesson and a real Cinema take.

## The lock hid the thing it was protecting

Teach and Cinema exist to be watched, and the lock was working against that: a 1px `backdrop-filter` blur across the whole viewport plus a heavier scrim softened exactly what the viewer is there to see. It now reads as a border and a breath of dim (8%, no blur) — still unmistakably hands-off, but the flame comes through.

The Stop button's icon had no explicit box, so its intrinsic size pushed the label a pixel off the pill's axis. Measured after the fix: icon and button both 0px from centre.

## The live rail and the replay list disagreed

Same actions, two views, two different renderings — the replay list read `Sonification model: ambient` while the rail said `Set Sonification Config [{...}]`.

Two causes, both fixed:

- The rail described the **raw** args. A command whose `describe` only understands the canonical snapshot — `sonification.setConfig` — could never match. It now describes `preflight.args`, which is exactly what the recorder logs, so the two views cannot drift again.
- An empty argument list rendered as a bare `[]` (`Center Camera []`).

## Most commands had nothing to say

With the two views agreeing, what was left was the fallback: 45 of the commands a lesson or take can run had no `describe` at all, so both views printed the label plus raw JSON — `Toggle Sidebar [true]`, `Set Exposure [0.42]`. That is a tool call, not a sentence.

Each now describes itself in the vocabulary the panel uses:

| before | after |
| --- | --- |
| `Toggle Sidebar [true]` | `Open the sidebar` |
| `Set Exposure [0.42]` | `Exposure: 0.42` |
| `Center Camera []` | `Centre the camera` |
| `Add Variation ["t2","spherical","v7"]` | `Add variation: spherical` |
| `Apply Symmetry [6,"rotational",...]` | `Apply 6-fold rotational symmetry` |

Opaque ids stay out — a transform id tells the viewer nothing, so the describes name the action and the value that changed. `lesson.note` describes itself as the sentence it carries, because a step list reading "Narration" five times says nothing.

A test walks every topic allow-list plus the Cinema one and fails on any command that would render as raw JSON, so a new AI-facing command cannot land without a label.

## From the Cinema agent's own notes

Two things it reported after a take, both real:

- **The path grammar has one asymmetry.** Everything on a transform is `transform.<id>.<what>`, except a variation weight (`<id>.<variationId>`) and a variation parameter (`<id>.<variationId>.<name>`). Agents reach for the prefixed form and lose a call to the rejection. The format cannot move — it is what every saved animation stores — so the prefixed form is now **accepted and rewritten to the canonical path**. The stored track is the same either way, which is what keeps a later call on the same target overwriting one track instead of creating a second. Reserved forms are looked up first, so a variation named `probability` cannot shadow one; a prefixed path that names nothing is still refused.
- **A probe is not free.** An accepted `arcade_set_keyframes` costs a step whether or not it plays, and leaves its tracks behind; a rejected one costs nothing; `arcade_get_animatable_paths` is free. That is now a tip, so the budget is spent knowingly.

Also four `COMMAND_ARG_HINTS` lines so the agent's first attempt is the working one: `sonification.setConfig` needs a complete snapshot plus the changed key (a partial patch is refused), and `flame.randomize` / `flame.mutate` have their seed and config filled in for them.

## Verification

- `pnpm --filter chaos-master exec vitest run` — 162 files, 2056 tests, all passing
- `pnpm typecheck` — clean; `pnpm lint` — clean apart from one pre-existing warning in `AncestryTreeModal.tsx`
- Driven live through `window.webmcp` against the dev server: rail lines came back `Enable sonification` / `Sonification model: ambient` / `Centre the camera` / `Open the sidebar`; shield computed `rgba(4, 6, 12, 0.08)` with `backdrop-filter: none`; Stop icon 15x15 and 0px off centre.