### PR TITLE
fix(replay): pay the pause to the step that earned it

### DIFF
--- a/docs/superpowers/plans/2026-09-04-teach-replay-pacing.md
+++ b/docs/superpowers/plans/2026-09-04-teach-replay-pacing.md
@@ -1,0 +1,200 @@
+# Teach replay pacing — investigation and plan
+
+## The finding
+
+A Teach replay does not show the lesson. It shows the edits, at machine speed,
+and hides every sentence that explains them.
+
+`gapBefore(index)` (`packages/app/src/recorder/player.ts:290`) is the delay
+_before applying_ `index`, so it is the **dwell on step `index - 1`**. The
+recorded gap is therefore charged to the step that comes _before_ the pause,
+not the one the pause produced. For an agent take that inverts everything: the
+agent thinks for fifteen seconds, then writes a sentence, then edits in a
+burst — so the fifteen seconds are spent holding the _previous burst's last
+edit_, and the sentence is replaced a millisecond later.
+
+Measured on the user's real lesson
+(`Lesson_Variations_Variations_Three_Families_From_Blank.steps.json`, 30
+actions, 7 min 06 s recorded, 7.32 s replayed at speed 1):
+
+| step                                                            | dwell      |
+| --------------------------------------------------------------- | ---------- |
+| `camera.zoomTo`                                                 | 1200 ms    |
+| **`lesson.note` "A variation is the nonlinear function…"**      | **3.2 ms** |
+| `flame.addTransform sphericalVar`                               | 18 ms      |
+| `flame.setVariationWeight 1`                                    | 1200 ms    |
+| **`lesson.note` "Spherical alone collapses to a point…"**       | **1.3 ms** |
+| …                                                               | …          |
+| **`lesson.note` "To close: three transforms, three families…"** | **0 ms**   |
+
+**Six narration sentences share 10.3 milliseconds of screen time.** All 7.3
+seconds of the replay is six editing steps sitting at the 1200 ms clamp. The
+whole teaching content of a teaching feature is invisible.
+
+The burst the user noticed — `pdjVar` plus four parameters plus a weight in
+25.8 ms — is the same disease seen from the other side. It is real (six
+separate recorded actions, not one command) and it matters, but it is the
+second problem, not the first.
+
+**Why stepping works.** `seek()` (`player.ts:349`) applies actions with no
+timer at all, so every step gets the viewer's own dwell, the spotlight's 400 ms
+settle completes, and each target is lit. The user's observation is exactly
+right and is the diagnostic: focus resolution is fine. Only the clock is wrong.
+
+**Why the spotlight misses during a burst.** `ReplaySpotlight` sets
+`settleUntil = now + LAYOUT_SETTLE_MS` (400 ms) and re-measures through
+`requestAnimationFrame`. With 1-17 ms gaps no frame ever renders between steps,
+so the ring is measured once from a layout that has not settled, and the
+browser paints at most once across the whole burst. A `lesson.note` carries no
+focus hint at all (`focus.ts` falls through to `default:`), so a narration step
+draws no ring — which would be fine if it were on screen long enough to read.
+
+## Constraints any fix must respect
+
+Verified, not assumed. Several sank the obvious first attempts.
+
+1. **Two schedulers duplicate the formula.** `player.ts:290-297` and
+   `createReplayVideoSchedule` (`replayVideo.ts:391-399`) implement it
+   independently. Worse, `replayInterfaceVideo.ts:324` pre-validates the
+   two-minute encoder budget from the _schedule_ and then screen-records the
+   _live player_, so if the two drift the capture overruns its own budget.
+   **Any change must land in one shared function.**
+2. **`holdMs` is authored data.** It wins over the recorded gap and is
+   deliberately unclamped (`player.ts:281-289`), it is editable per step in
+   `SessionReplayPanel`, and `MAX_ACTION_HOLD_MS` is 600 000. Machine-stamping
+   it destroys "clear the field to get recorded pacing back".
+3. **Companion commands share a timestamp on purpose**
+   (`replayVideo.ts:402-404`). A blanket floor pulls the two halves of one
+   atomic gesture apart.
+4. **`MAX_REPLAY_VIDEO_DURATION_MS` is 120 000.** Lengthening replays can make
+   a session unexportable, with an error that would blame the user for pacing
+   they did not author.
+5. **The floor must not be divided by playback speed.** It exists to clear
+   fixed wall-clock DOM constants — `LAYOUT_SETTLE_MS` 400 and the 420 ms ring
+   transition — and neither scales with speed. Worse, the ceiling is applied
+   _after_ the division, so a speed-scaled floor of 600 would equal the 1200 ms
+   ceiling at 0.5x and turn every step into a metronome.
+6. **Narration has two recording modes.** With `narrationAsStep` off there are
+   no `lesson.note` actions at all; the sentence rides as `note` on the next
+   step. A fix that only matches `lesson.note` silently misses that mode.
+
+## The plan
+
+### Step 1 — one owner for the cadence (pure refactor)
+
+Export `stepGapMs(previous, next, speed)` from `player.ts` holding the entire
+rule, call it from `gapBefore`, and replace the duplicated expression in
+`createReplayVideoSchedule`. **No numbers change.** Both suites must stay green
+with zero edited expectations — that is the proof the extraction is pure, and
+it is what makes steps 2 and 3 a one-line change in one place instead of a
+two-place change that can drift.
+
+### Step 2 — pay the pause to the step that earned it
+
+The narration fix, and the one that matters most. It slots into the existing
+`previous.holdMs` branch, because it is the same idea: pacing belongs to the
+step being held.
+
+In `stepGapMs`, when the previous step carries a sentence — either
+`previous.id === 'lesson.note'` or `previous.note !== undefined`, covering both
+recording modes — and no authored `holdMs` overrides it, return a reading time
+instead of the recorded delta:
+
+```
+clamp(NARRATION_MIN_HOLD_MS, words * MS_PER_WORD, NARRATION_MAX_HOLD_MS)
+```
+
+Suggested: 1200 / 250 (240 wpm) / **4000**. Full reading time for these
+sentences is 8.5-12 s each; six of those would eat 60 s of a 120 s video
+budget. 4000 ms shows the sentence, and the viewer can pause or step for the
+rest. Divide by speed, as the authored-hold branch already does.
+
+Effect on the real lesson: narration goes from 10.3 ms total to ~24 s.
+
+### Step 3 — a floor under the edit bursts
+
+`MIN_STEP_GAP_MS = 500`, **not** divided by speed (constraint 5), applied only
+when `previous` and `next` do not share an identical timestamp (constraint 3),
+and only from index 1 — flooring index 0 delays the first step after Play,
+reads as a hang, and causes most of the test churn for no benefit.
+
+500 ms clears `LAYOUT_SETTLE_MS` (400) with enough margin for one paint, so the
+spotlight's settle loop completes and every burst step gets a ring. Higher
+values squeeze against the 1200 ms ceiling and erase what rhythm the recording
+has.
+
+Effect: the 25.8 ms `pdjVar` burst becomes ~3 s; the whole lesson lands around
+35 s — inside the video budget with room to spare.
+
+**Add a guard**: when the resulting schedule exceeds
+`MAX_REPLAY_VIDEO_DURATION_MS`, the export error must name the pacing as the
+cause and point at the speed control, not read as the user's fault.
+
+### Step 4 — the hint pill (independent, small)
+
+The hint sits at the viewport bottom edge, where a host browser's own floating
+Stop control covers it.
+
+Note what the investigation turned up: **the timeline is hidden by default in a
+Teach lesson**, so the app's bottom chrome is just the ~50 px view-controls
+strip — the case a measured-height solution treats as an edge case is actually
+the reported one. That kills the elaborate route. Two candidates:
+
+- **Preferred, zero JS**: CSS anchor positioning. Give `.bottom-bar` an
+  `anchor-name` and anchor `.hint` above it inside `@supports`, with today's
+  rule as the fallback. The app is already Chrome-only (WebGPU), so support is
+  not the usual objection.
+- **Fallback**: a fixed offset that clears the strip and the `ProgressBar`
+  band. Simpler, slightly wrong when the timeline is dragged tall.
+
+Avoid the `ResizeObserver` + root-custom-property route: it needs an
+`agentDriving()` gate that **the in-flight seats branch has already changed**,
+and git would merge it cleanly and wrong.
+
+Check against: the Cinema end card, the 320 px step rail, the version pills,
+and the 3D orientation gizmo (80x80, bottom-right, in exactly the band the pill
+moves into — they collide below ~560 px wide).
+
+### Step 5 — what the driving agent asked for
+
+From the agent's own notes after this lesson, both real:
+
+- **It could not re-read its brief.** A second `arcade_start_lesson` returns
+  "already active". Fix: add `goal` to `arcade_status` (already free, zero-arg,
+  `readOnlyHint`). Measured cost: 178 → ~420 chars. Do **not** put
+  `allowedCommands` there — that is the 882-char half that caused the
+  truncation.
+- **The brief arrived truncated** at `flame.setVariationParams [transfo…`, so
+  it recovered the argument shape from the app bundle. The truncation happens
+  in the client, outside this repo, and the brief cannot be made to fit — so
+  the fix is a **recovery channel**, not a smaller brief: expose
+  `commandArgHint(id)` from `commandHints.ts` and return it from
+  `list_commands`, which is already free, read-only and prefix-filtered.
+  `list_commands {prefix: 'flame.setVariationParams'}` then re-serves exactly
+  the line that was lost.
+- Free and worth taking while there: `toMcpResult` pretty-prints every result
+  (`registerWebMcp.ts:39`). Dropping `null, 2` cuts the brief 10 % and makes
+  the in-repo budget assertions measure the string that actually goes over the
+  wire, which they do not today.
+- **Flagged, not solved**: a second truncation exists on the Cinema path.
+
+## Order and cost
+
+|     |                            |                            |
+| --- | -------------------------- | -------------------------- |
+| 1   | one owner for the cadence  | small, no behaviour change |
+| 2   | narration reading hold     | small, **highest value**   |
+| 3   | burst floor + budget guard | small                      |
+| 4   | hint pill                  | small                      |
+| 5   | agent brief recovery       | small                      |
+
+Steps 1-3 are one file and one test file. They are what stands between a Teach
+replay and something worth recording a video of.
+
+## Deferred
+
+The live action spotlight
+(`docs/superpowers/specs/2026-09-03-action-spotlight-feasibility.md`). Tonight's
+finding sharpens it: a live spotlight that retargets six times in 25 ms is a
+strobe, so **pacing is a prerequisite for that feature**, not an orthogonal
+nicety. Corrections to that document are listed in its own file.

--- a/docs/superpowers/specs/2026-09-03-action-spotlight-feasibility.md
+++ b/docs/superpowers/specs/2026-09-03-action-spotlight-feasibility.md
@@ -17,13 +17,13 @@ larger step, and it needs UI changes the replay path never needed.
 Replay already spotlights the control behind each step, and every piece is
 command-driven rather than markup-driven, so none of it is replay-specific by nature:
 
-| Piece                                  | Where                                                                | What it does                                                                                                                                                          |
-| -------------------------------------- | -------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `focusHintFor(commandId, args)`        | `packages/app/src/recorder/focus.ts:130`                             | Maps a command to a semantic hint — `param:<path>`, `ui:<tourTarget>`, `focus:<id>`. Never a selector or a rectangle, so it survives markup changes and window sizes. |
-| `deriveReplayFocusPreparation(action)` | `packages/app/src/recorder/focusPreparation.ts:371`                  | Turns a hint into the UI state that must exist _first_: reveal the sidebar, expand the owning transform, switch the affine tab, show the sonification panel.          |
-| `prepareReplayFocus`                   | `packages/app/src/MainWorkspace.tsx:4464`                            | Applies that state. Owns every signal it touches.                                                                                                                     |
-| `ReplaySpotlight`                      | `packages/app/src/components/SessionRecorder/ReplaySpotlight.tsx:66` | SVG-mask scrim that keeps the canvas and the target lit, dims the chrome, tracks the rect, captions the step.                                                         |
-| 108 `data-tour-target` anchors         | across `src/components`                                              | The vocabulary `ui:` hints resolve against.                                                                                                                           |
+| Piece                                  | Where                                                                | What it does                                                                                                                                                                                                                                                                                                                                                     |
+| -------------------------------------- | -------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `focusHintFor(commandId, args)`        | `packages/app/src/recorder/focus.ts:130`                             | Maps a command to a semantic hint — `param:<path>`, `ui:<tourTarget>`, `focus:<id>`. Never a selector or a rectangle, so it survives markup changes and window sizes.                                                                                                                                                                                            |
+| `deriveReplayFocusPreparation(action)` | `packages/app/src/recorder/focusPreparation.ts:371`                  | Turns a hint into the UI state that must exist _first_: reveal the sidebar, expand the owning transform, switch the affine tab, show the sonification panel.                                                                                                                                                                                                     |
+| `prepareReplayFocus`                   | `packages/app/src/MainWorkspace.tsx:4464`                            | Applies that state. Owns every signal it touches.                                                                                                                                                                                                                                                                                                                |
+| `ReplaySpotlight`                      | `packages/app/src/components/SessionRecorder/ReplaySpotlight.tsx:66` | SVG-mask scrim that keeps the canvas and the target lit, dims the chrome, tracks the rect, captions the step.                                                                                                                                                                                                                                                    |
+| ~87 `data-tour-target` anchors         | 21 files across `src`                                                | The vocabulary `ui:` hints resolve against. 87 distinct literal names, 52 of them under `src/components`; 33 live in `MainWorkspace.tsx` alone. Six components also forward the attribute as a pass-through prop (`Slider`, `ScrubInput`, `CollapsibleCard`, `ButtonGroup`, `PullUpMenu`, `AngleEditor`), so the real surface is larger than any grep can count. |
 
 The hints for the exact case asked about are already written:
 
@@ -41,19 +41,36 @@ command. Nothing asks it.
 
 ## The gaps
 
-**1. Nothing computes a hint on the live path.** `execute_command` now has
-`preflight.args` — the same normalized args the recorder logs, which is what
-`focusHintFor` expects. One call at that site produces the hint.
+**1. The hint already exists live — what is missing is a consumer.** This was
+wrong when first written. A Teach session records while the agent drives, and the
+recorder stamps a hint on every action as it happens: `focusFor`
+(`packages/app/src/recorder/recorder.ts:135`) is called at four sites during
+recording. The producer is already running; nothing reads it.
+
+That matters for the seam. `focusFor` is
+`cmd.focus?.(args) ?? focusHintFor(cmd.id, args)` — a command's own `focus()`
+override (`commands/types.ts:331`) wins over the central table. A live consumer
+hooked into `execute_command`'s `preflight.args` that called `focusHintFor`
+directly would silently lose that override and light the wrong control for
+exactly the commands that bothered to say where they live. Read the hint the
+recorder already produced, or call `focusFor` — never `focusHintFor` alone.
 
 **2. The handler is not reachable from the pilot.** `prepareReplayFocus` is defined in
 `MainWorkspace` and handed down to the recorder dock as `onPrepareAction`. The pilot
 would need the same handler through the WebMCP context or a module-level signal, the
 way the other pilot state is carried.
 
-**3. Z-order.** The pilot shield sits at `z-index: 10010`; the spotlight scrim at
-`300`. As-is the spotlight paints _under_ the lock and is invisible. Either the
-spotlight moves above the shield, or the shield splits into a scrim and a separate
-pointer-catcher with the spotlight between them.
+**3. Z-order — and it is three layers, not two.** The pilot shield sits at
+`z-index: 10010`, the spotlight scrim at `300`, and `ReplayAgentRail` at `310`,
+with a comment saying it is deliberately above the scrim so the rail stays
+readable. `PilotOverlay`'s `.endBackdrop` is a second element at 10010.
+
+As-is the spotlight paints _under_ the lock and is invisible. But simply raising
+it above 10010 has a consequence the first draft missed: `ReplaySpotlight` dims
+everything except elements carrying `data-replay-region`, so a raised scrim would
+dim the pilot's own banner, rail and hint — the chrome that explains what is
+happening. Either those get a region marker, or the shield splits into a scrim
+and a separate pointer-catcher with the spotlight between them.
 
 **4. There is no beat.** Replay has a transport; the pilot does not. Today a command
 applies its preparation and executes in the same tick, so there is nothing to watch.
@@ -80,6 +97,13 @@ four signals at once (`MainWorkspace.tsx:1126`). To _show_ Audio → Sonificatio
 ---
 
 ## Recommended shape
+
+**Phase 0 — give an agent's steps a beat.** Discovered after this document was
+written, from a real lesson: an agent's edits land in bursts of six steps inside
+26 milliseconds, and its narration gets 10.3 ms of screen time across six
+sentences. A live spotlight retargeting six times in 25 ms is a strobe, not a
+follow-cam. Pacing is a **prerequisite** for everything below, not an orthogonal
+nicety — see `docs/superpowers/plans/2026-09-04-teach-replay-pacing.md`.
 
 **Phase 1 — live follow-cam.** Reuse hint + preparation + spotlight on the pilot path.
 The spotlight lands on the destination control (the Sonification panel's model select),

--- a/packages/app/src/App.module.css
+++ b/packages/app/src/App.module.css
@@ -38,6 +38,12 @@
   left: 0;
   right: 0;
   z-index: 5;
+  /* So an overlay can sit exactly above the chrome without measuring it in
+     JS. Its height moves with the timeline (shown, hidden, dragged), and a
+     ResizeObserver writing a custom property would fire at frame rate while
+     the user drags. Dashed idents are not rewritten by CSS Modules, so the
+     name resolves from PilotOverlay.module.css. */
+  anchor-name: --app-bottom-chrome;
   display: flex;
   flex-direction: column;
 

--- a/packages/app/src/arcade/commandHints.ts
+++ b/packages/app/src/arcade/commandHints.ts
@@ -73,6 +73,19 @@ export const SAMPLE_VARIATION_TYPES = [
  * signature is not a single obvious value. One array instead of an id list
  * plus a parallel hint map, because the brief pays for every byte twice.
  */
+/**
+ * The argument shape for one command, for a caller that lost the brief.
+ *
+ * A lesson brief is sent once, at `arcade_start_lesson`, and a client that
+ * truncates it takes the argument shapes with it — a real agent lost the line
+ * for `flame.setVariationParams` mid-lesson and had to recover it by reading
+ * the app bundle. `list_commands` is free, read-only and filterable, so it can
+ * hand back one line without restarting anything.
+ */
+export function commandArgHint(id: string): string | undefined {
+  return COMMAND_ARG_HINTS[id]
+}
+
 export function describeAllowedCommands(allowed: readonly string[]): string[] {
   const ids: string[] = []
   for (const entry of allowed) {

--- a/packages/app/src/components/Arcade/PilotOverlay.module.css
+++ b/packages/app/src/components/Arcade/PilotOverlay.module.css
@@ -138,7 +138,11 @@
 .hint {
   grid-column: 1 / -1;
   justify-self: center;
-  margin: 0 0 12px;
+  /* Clear of the view-controls strip rather than flush with the viewport
+     edge: a host browser driving this session puts its own floating controls
+     down there, and they sit on top of ours. This is the floor for engines
+     without anchor positioning — with it, the rule below is exact. */
+  margin: 0 0 62px;
   padding: 7px 16px;
   border-radius: 999px;
   text-align: center;
@@ -150,6 +154,20 @@
   border: 1px solid rgba(255, 255, 255, 0.1);
   /* Blur belongs on the chrome, never on the whole viewport. */
   backdrop-filter: blur(8px);
+}
+
+/* Exactly above the app's own bottom chrome, whatever height it currently is —
+   the timeline can be hidden, shown, or dragged to 55vh. Chrome 125+; the
+   margin above stands in everywhere else, and this app already needs WebGPU. */
+@supports (anchor-name: --x) {
+  .hint {
+    position: fixed;
+    position-anchor: --app-bottom-chrome;
+    bottom: calc(anchor(top) + 12px);
+    left: 50%;
+    translate: -50% 0;
+    margin: 0;
+  }
 }
 
 @media (max-width: 768px) {

--- a/packages/app/src/components/Arcade/PilotOverlay.module.css
+++ b/packages/app/src/components/Arcade/PilotOverlay.module.css
@@ -167,6 +167,13 @@
     left: 50%;
     translate: -50% 0;
     margin: 0;
+    /* An auto-width fixed box with `left: 50%` and `right: auto` shrink-to-fits
+       against the INSET-MODIFIED containing block — half the viewport — so
+       without this the pill wrapped to three lines below ~673px wide, where as
+       a grid item it had the shield's full width. `translate` is paint-time and
+       does not size anything. */
+    width: max-content;
+    max-width: min(30rem, calc(100vw - 32px));
   }
 }
 

--- a/packages/app/src/components/Arcade/pilotOverlayCss.test.ts
+++ b/packages/app/src/components/Arcade/pilotOverlayCss.test.ts
@@ -1,0 +1,41 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * A centred box needs a width, and CSS will not say so.
+ *
+ * `left: 50%` with `right: auto` and no width makes an absolutely positioned
+ * box shrink-to-fit against the *inset-modified* containing block — half the
+ * viewport — so a one-line pill silently became a three-line block on a narrow
+ * window. Four other centred elements in this app already carry the guard
+ * (`width: max-content`, `white-space: nowrap`, or an explicit width); this
+ * keeps the pilot overlay from being the fifth that forgets.
+ */
+describe('PilotOverlay stylesheet', () => {
+  // Read as text, the way LoadFlameModal's dropzone styles are checked: a
+  // CSS-module import under vitest is a proxy that answers every key.
+  const css = readFileSync(
+    join(import.meta.dirname, 'PilotOverlay.module.css'),
+    'utf8',
+  )
+
+  it('gives every horizontally centred rule a width', () => {
+    // Comments first: this file's own prose mentions `right: auto`, which a
+    // naive scan would read as a declaration and skip the very rule it guards.
+    const declarations = css.replace(/\/\*[\s\S]*?\*\//g, '')
+    const bodies = declarations.match(/\{[^{}]*\}/g) ?? []
+    const centred = bodies.filter(
+      (body) => /left:\s*50%/.test(body) && !/\bright:/.test(body),
+    )
+    expect(centred.length).toBeGreaterThan(0)
+    for (const body of centred) {
+      // `max-width` does NOT count: the box still shrink-to-fits against half
+      // the containing block, and the cap only trims what is already too
+      // narrow. Only a real `width` (or nowrap) fixes the sizing.
+      const hasWidth = /(?:^|[;{\s])width:\s*(?!auto)[^;]+;/.test(body)
+      const hasNowrap = /white-space:\s*nowrap/.test(body)
+      expect(hasWidth || hasNowrap).toBe(true)
+    }
+  })
+})

--- a/packages/app/src/recorder/player.test.ts
+++ b/packages/app/src/recorder/player.test.ts
@@ -7,7 +7,7 @@ import { examples } from '@/flame/examples'
 import { deepClone } from '@/utils/clone'
 import { createStoreHistory } from '@/utils/createStoreHistory'
 import { createTimelineState } from '@/utils/timeline'
-import { createSessionPlayer, MAX_STEP_GAP_MS } from './player'
+import { createSessionPlayer, MAX_STEP_GAP_MS, MIN_STEP_GAP_MS, NARRATION_MAX_HOLD_MS, NARRATION_MIN_HOLD_MS, NARRATION_MS_PER_WORD, stepGapMs, } from './player'
 import { cancelSessionRecording, recordSyntheticAction, startSessionRecording, stopSessionRecording, } from './recorder'
 import { SESSION_FORMAT_VERSION } from './schema'
 import { createRecorderAwareTimeline } from './timelineActions'
@@ -203,6 +203,94 @@ afterEach(() => {
   vi.useRealTimers()
 })
 
+function at(t: number, extra: Partial<RecordedAction> = {}): RecordedAction {
+  return { t, id: 'flame.setGamma', args: [1], ...extra }
+}
+
+/**
+ * The pacing rule, which the live player and the video exporter share.
+ *
+ * These are the numbers a Teach replay lives or dies by: an agent issues its
+ * edits milliseconds apart and thinks for seconds between them, so the raw
+ * recording is a burst nobody can watch punctuated by pauses charged to the
+ * wrong step.
+ */
+describe('stepGapMs', () => {
+  it('floors a machine-speed burst so each step can be seen', () => {
+    // Six steps inside 26ms is a real measurement, not a hypothetical.
+    expect(stepGapMs(at(353851), at(353852), 1)).toBe(MIN_STEP_GAP_MS)
+    expect(stepGapMs(at(353843), at(353848), 1)).toBe(MIN_STEP_GAP_MS)
+  })
+
+  it('leaves a human-paced gap alone', () => {
+    expect(stepGapMs(at(0), at(600), 1)).toBe(600)
+    expect(stepGapMs(at(0), at(1000), 1)).toBe(1000)
+  })
+
+  it('still clamps a long thinking pause', () => {
+    expect(stepGapMs(at(0), at(15_670), 1)).toBe(MAX_STEP_GAP_MS)
+  })
+
+  it('floors the recording, not the playback, so speed keeps working', () => {
+    // Flooring after the division would pin every step of an agent take to
+    // MIN_STEP_GAP_MS at every speed, and the 4x button would do nothing on
+    // exactly the takes that need it.
+    expect(stepGapMs(at(0), at(1), 4)).toBe(MIN_STEP_GAP_MS / 4)
+    expect(stepGapMs(at(0), at(1), 2)).toBe(MIN_STEP_GAP_MS / 2)
+  })
+
+  it('does not floor the lead-in before the first step', () => {
+    expect(stepGapMs(undefined, at(12), 1)).toBe(12)
+    expect(stepGapMs(undefined, at(0), 1)).toBe(0)
+  })
+
+  it('does not pull a companion pair apart', () => {
+    // Two commands sharing a timestamp are one gesture; the video scheduler
+    // says so in as many words, and a floor between them would stage a single
+    // user action as two.
+    expect(stepGapMs(at(500), at(500), 1)).toBe(0)
+  })
+
+  it('lets an authored hold win, unclamped in both directions', () => {
+    expect(stepGapMs(at(0, { holdMs: 0 }), at(1), 1)).toBe(0)
+    expect(stepGapMs(at(0, { holdMs: 9000 }), at(1), 1)).toBe(9000)
+    expect(stepGapMs(at(0, { holdMs: 9000 }), at(1), 2)).toBe(4500)
+  })
+
+  it('holds a narration step long enough to read it', () => {
+    // The bug this exists for: six sentences shared 10.3ms of screen time
+    // because the pause the agent spent writing them was charged to the edit
+    // BEFORE each one.
+    const note = at(0, { id: 'lesson.note', args: ['one two three four five'] })
+    expect(stepGapMs(note, at(2), 1)).toBe(5 * NARRATION_MS_PER_WORD)
+    expect(stepGapMs(note, at(2), 1)).toBeGreaterThan(MAX_STEP_GAP_MS)
+  })
+
+  it('bounds a narration hold at both ends', () => {
+    const terse = at(0, { id: 'lesson.note', args: ['go'] })
+    expect(stepGapMs(terse, at(2), 1)).toBe(NARRATION_MIN_HOLD_MS)
+    const essay = at(0, {
+      id: 'lesson.note',
+      args: [Array.from({ length: 200 }, () => 'word').join(' ')],
+    })
+    expect(stepGapMs(essay, at(2), 1)).toBe(NARRATION_MAX_HOLD_MS)
+  })
+
+  it('reads a sentence that rode along as a caption', () => {
+    // With narrationAsStep off there is no lesson.note action at all: the
+    // sentence captions the step it introduces. Same prose, same pacing.
+    const captioned = at(0, { note: 'one two three four five' })
+    expect(stepGapMs(captioned, at(2), 1)).toBe(5 * NARRATION_MS_PER_WORD)
+  })
+
+  it('ignores an empty sentence', () => {
+    expect(stepGapMs(at(0, { note: '   ' }), at(2), 1)).toBe(MIN_STEP_GAP_MS)
+    expect(stepGapMs(at(0, { id: 'lesson.note', args: [] }), at(2), 1)).toBe(
+      MIN_STEP_GAP_MS,
+    )
+  })
+})
+
 describe('createSessionPlayer', () => {
   it('clears transient UI before opening the replay batch and loading the baseline', () => {
     createRoot((dispose) => {
@@ -296,17 +384,20 @@ describe('createSessionPlayer', () => {
       const player = createSessionPlayer(gammaSteps, target)
       player.play()
 
-      // The first step waits out its own offset from the session start.
+      // The first step waits out its own offset from the session start, which
+      // is a lead-in rather than a dwell on anything, so no floor applies.
       vi.advanceTimersByTime(0)
       expect(flame.renderSettings.gamma).toBeCloseTo(1.5, 5)
       expect(player.stepIndex()).toBe(0)
 
-      vi.advanceTimersByTime(99)
+      // The recorded 100ms and 150ms gaps are below MIN_STEP_GAP_MS: nobody
+      // can watch a step that lasts a tenth of a second, so both are floored.
+      vi.advanceTimersByTime(MIN_STEP_GAP_MS - 1)
       expect(player.stepIndex()).toBe(0)
       vi.advanceTimersByTime(1)
       expect(flame.renderSettings.gamma).toBeCloseTo(2.5, 5)
 
-      vi.advanceTimersByTime(150)
+      vi.advanceTimersByTime(MIN_STEP_GAP_MS)
       expect(flame.renderSettings.gamma).toBeCloseTo(3.5, 5)
       expect(player.isPlaying()).toBe(false)
       dispose()
@@ -384,11 +475,14 @@ describe('createSessionPlayer', () => {
       // change lands on the step after it — never more than one gap late,
       // which MAX_STEP_GAP_MS bounds.
       setSpeed(10)
-      vi.advanceTimersByTime(100)
+      vi.advanceTimersByTime(MIN_STEP_GAP_MS)
       expect(player.stepIndex()).toBe(1)
 
-      // Step 2's 150ms gap now takes 15ms.
-      vi.advanceTimersByTime(14)
+      // Step 2's gap is floored to MIN_STEP_GAP_MS as a RECORDED gap, then
+      // divided: 50ms, not 500. The floor repairs the recording; it does not
+      // pin playback, or the speed control would do nothing on an agent take,
+      // where every measured gap is under the floor.
+      vi.advanceTimersByTime(MIN_STEP_GAP_MS / 10 - 1)
       expect(player.stepIndex()).toBe(1)
       vi.advanceTimersByTime(1)
       expect(player.stepIndex()).toBe(2)
@@ -447,7 +541,7 @@ describe('createSessionPlayer', () => {
       player.play()
       expect(loaded()).toBe(1)
       expect(player.stepIndex()).toBe(0)
-      vi.advanceTimersByTime(100)
+      vi.advanceTimersByTime(MIN_STEP_GAP_MS)
       expect(player.stepIndex()).toBe(1)
       expect(flame.renderSettings.gamma).toBeCloseTo(2.5, 5)
       dispose()
@@ -475,7 +569,7 @@ describe('createSessionPlayer', () => {
       vi.advanceTimersByTime(0)
       expect(player.stepIndex()).toBe(0)
       expect(flame.renderSettings.gamma).toBeCloseTo(1.5, 5)
-      vi.advanceTimersByTime(100)
+      vi.advanceTimersByTime(MIN_STEP_GAP_MS)
       expect(player.stepIndex()).toBe(1)
       expect(flame.renderSettings.gamma).toBeCloseTo(2.5, 5)
       dispose()
@@ -552,7 +646,7 @@ describe('createSessionPlayer', () => {
       vi.advanceTimersByTime(0)
       expect(player.stepIndex()).toBe(0)
       expect(flame.renderSettings.gamma).toBeCloseTo(1.5, 5)
-      vi.advanceTimersByTime(100)
+      vi.advanceTimersByTime(MIN_STEP_GAP_MS)
       expect(player.stepIndex()).toBe(1)
       expect(flame.renderSettings.gamma).toBeCloseTo(2.5, 5)
       dispose()
@@ -926,7 +1020,7 @@ describe('createSessionPlayer', () => {
       expect(player.stepIndex()).toBe(0)
 
       startSessionRecording(world.flame)
-      vi.advanceTimersByTime(100)
+      vi.advanceTimersByTime(MIN_STEP_GAP_MS)
 
       expect(player.isPlaying()).toBe(false)
       expect(player.stepIndex()).toBe(0)

--- a/packages/app/src/recorder/player.ts
+++ b/packages/app/src/recorder/player.ts
@@ -1,5 +1,6 @@
 import { createSignal } from 'solid-js'
 import { deepClone } from '@/utils/clone'
+import { NARRATION_COMMAND_ID } from './narrationMode'
 import { getLiveWorkspaceMutationGeneration, isSessionRecording, withRecordingSuppressed, } from './recorder'
 import { loadSessionStart } from './replay'
 import type { ReplayTarget } from './replay'
@@ -29,6 +30,124 @@ import type { RecordedAction, RecordedSession } from './schema'
 
 /** Longest wait between two steps, however long the human paused for. */
 export const MAX_STEP_GAP_MS = 1200
+
+/**
+ * Shortest wait between two steps, however fast they were recorded.
+ *
+ * A person cannot issue two commands three milliseconds apart; an agent does
+ * nothing else. A real lesson put `flame.addTransform` and four
+ * `setVariationParams` calls inside 26 ms, and replayed at that speed there is
+ * nothing to see: the follow-cam needs LAYOUT_SETTLE_MS (400) just to measure
+ * its target, and the browser paints at most once across the whole burst.
+ *
+ * Applied to the RECORDED gap, before playback speed divides it. The floor
+ * repairs the recording; speed is then the viewer's business as usual. Putting
+ * it after the division instead would pin every step of an agent take to the
+ * floor at every speed — the 4x button would do nothing on exactly the takes
+ * that need it, because every one of their gaps is under the floor.
+ */
+export const MIN_STEP_GAP_MS = 500
+
+/** 240 words per minute, the usual figure for reading prose on screen. */
+export const NARRATION_MS_PER_WORD = 250
+
+/** Even three words deserve to be seen. */
+export const NARRATION_MIN_HOLD_MS = 1200
+
+/**
+ * ...and even a paragraph does not get to stop the show. Full reading time for
+ * the sentences an agent writes is 8-12 s each; six of those would spend most
+ * of MAX_REPLAY_VIDEO_DURATION_MS on held text. The transport is right there
+ * for a viewer who wants longer.
+ */
+export const NARRATION_MAX_HOLD_MS = 4000
+
+/**
+ * The sentence this step says out loud, in either recording mode.
+ *
+ * With `narrationAsStep` on, a sentence is its own `lesson.note` step. With it
+ * off the recorder attaches it to the step it introduces as a `note`, and a
+ * human author can type one there too. Both are prose somebody is meant to
+ * read, so both are paced the same way.
+ */
+function narrationText(action: RecordedAction): string | undefined {
+  if (action.id === NARRATION_COMMAND_ID) {
+    const [text] = action.args
+    if (typeof text === 'string' && text.trim() !== '') return text
+  }
+  const note = action.note
+  return note !== undefined && note.trim() !== '' ? note : undefined
+}
+
+/**
+ * The reading hold this step earns, or undefined when it says nothing.
+ *
+ * Exported for the tail of a video: the closing sentence has no step after it
+ * to be the dwell on, so without this a take ends on the words the whole
+ * lesson was building to for however long the default tail happens to be.
+ */
+export function narrationHoldFor(
+  action: RecordedAction,
+  speed: number,
+): number | undefined {
+  const text = narrationText(action)
+  return text === undefined ? undefined : narrationHoldMs(text) / speed
+}
+
+function narrationHoldMs(text: string): number {
+  const words = text.trim().split(/\s+/).length
+  return Math.min(
+    NARRATION_MAX_HOLD_MS,
+    Math.max(NARRATION_MIN_HOLD_MS, words * NARRATION_MS_PER_WORD),
+  )
+}
+
+/**
+ * How long to wait before applying `next` — which is the dwell on `previous`.
+ *
+ * That inversion is the whole subtlety here, and getting it wrong is what made
+ * agent lessons unwatchable: a recorded gap is time the viewer spends looking
+ * at the step BEFORE it. An agent thinks for fifteen seconds, writes a
+ * sentence, then edits in a burst, so the pause was being spent holding the
+ * previous burst's last edit while the sentence it produced was replaced a
+ * millisecond later. Six narration steps in one real lesson shared 10.3 ms of
+ * screen time between them.
+ *
+ * The rules, in order:
+ *
+ *  - An authored `holdMs` on the previous step wins and is not clamped in
+ *    either direction. Pacing is authorial; `holdMs: 0` means zero.
+ *  - A previous step that says something is held long enough to read.
+ *  - Otherwise the measured gap, clamped at both ends: MAX so a thinking pause
+ *    does not stall playback, MIN so a machine's burst is watchable.
+ *
+ * The floor is skipped where it would do harm: before the first step, whose
+ * gap is a lead-in rather than a dwell on anything, and between two actions
+ * sharing a timestamp, which is how a companion pair says it is one gesture
+ * and not two. A narration hold and an authored hold both ignore the ceiling —
+ * a sentence nobody can finish reading is the bug being fixed.
+ *
+ * Shared with `createReplayVideoSchedule` so a live replay and an exported
+ * video cannot drift — `replayInterfaceVideo` validates its encoder budget
+ * from the schedule and then screen-records the live player, so a difference
+ * between the two overruns the capture.
+ */
+export function stepGapMs(
+  previous: RecordedAction | undefined,
+  next: RecordedAction | undefined,
+  speed: number,
+): number {
+  if (!next) return 0
+  if (previous?.holdMs !== undefined) return previous.holdMs / speed
+  const sentence = previous === undefined ? undefined : narrationText(previous)
+  if (sentence !== undefined) return narrationHoldMs(sentence) / speed
+  const measured = Math.max(0, previous ? next.t - previous.t : next.t)
+  const paced =
+    previous !== undefined && previous.t !== next.t
+      ? Math.max(MIN_STEP_GAP_MS, measured)
+      : measured
+  return Math.min(MAX_STEP_GAP_MS, paced / speed)
+}
 
 /** Playback speeds the panel offers. 1 = the pace it was recorded at. */
 export const PLAYBACK_SPEEDS = [0.5, 1, 2, 4] as const
@@ -278,22 +397,13 @@ export function createSessionPlayer(
     return withDeferredEffects(() => rebuildToNow(index))
   }
 
-  /**
-   * How long to wait before applying `index`.
-   *
-   * An authored `holdMs` on the PREVIOUS step wins: pacing belongs to the step
-   * an author wants held, not to the one that follows it, and an authored hold
-   * is a deliberate choice so it is not clamped by MAX_STEP_GAP_MS. Otherwise
-   * it is the gap the recording measured, clamped so a long thinking pause
-   * does not stall playback.
-   */
+  /** How long to wait before applying `index`. See {@link stepGapMs}. */
   function gapBefore(index: number): number {
-    const next = actions[index]
-    if (!next) return 0
-    const previous = index > 0 ? actions[index - 1] : undefined
-    if (previous?.holdMs !== undefined) return previous.holdMs / speed()
-    const delta = previous ? next.t - previous.t : next.t
-    return Math.min(MAX_STEP_GAP_MS, Math.max(0, delta) / speed())
+    return stepGapMs(
+      index > 0 ? actions[index - 1] : undefined,
+      actions[index],
+      speed(),
+    )
   }
 
   function scheduleNext() {

--- a/packages/app/src/recorder/replayVideo.test.ts
+++ b/packages/app/src/recorder/replayVideo.test.ts
@@ -48,7 +48,7 @@ describe('replay video timing', () => {
     ])
 
     expect(() => createReplayVideoSchedule(session)).toThrow(
-      /Shorten long holds or choose a faster replay speed/,
+      /Choose a faster replay speed/,
     )
   })
 

--- a/packages/app/src/recorder/replayVideo.ts
+++ b/packages/app/src/recorder/replayVideo.ts
@@ -9,7 +9,7 @@ import { tryValidateFlame } from '@/flame/schema/flameSchema'
 import { defaultTimelineConfig } from '@/flame/schema/timeline'
 import { deepClone } from '@/utils/clone'
 import { applyTracksToFlame, getUserEndFrame, loopOptsFromConfig, resolveLoopValue, } from '@/utils/timeline'
-import { MAX_STEP_GAP_MS } from './player'
+import { narrationHoldFor, stepGapMs } from './player'
 import { paletteRestoreColorsAfterReplayCommand } from './replayPaletteState'
 import { validateSession } from './schema'
 import type { RecordedAction, RecordedSession, SessionViewSnapshot, TransformColorSnapshot, } from './schema'
@@ -389,15 +389,10 @@ export function createReplayVideoSchedule(
   for (let index = 0; index < session.actions.length; index++) {
     const action = session.actions[index]!
     const previous = index > 0 ? session.actions[index - 1] : undefined
-    const gap =
-      previous?.holdMs !== undefined
-        ? previous.holdMs / spec.playbackSpeed
-        : Math.min(
-            MAX_STEP_GAP_MS,
-            Math.max(0, previous ? action.t - previous.t : action.t) /
-              spec.playbackSpeed,
-          )
-    cursor += gap
+    // The same rule the live player uses, not a copy of it: the interface
+    // exporter validates this schedule and then screen-records the player, so
+    // the two drifting apart overruns the capture budget.
+    cursor += stepGapMs(previous, action, spec.playbackSpeed)
     // Two companion commands can share a timestamp. A video cannot represent
     // both on one frame, so advance at least one frame and never silently skip
     // an authored step/caption.
@@ -410,10 +405,19 @@ export function createReplayVideoSchedule(
     actionTimesMs.push((frame * 1000) / fps)
   }
   const finalActionTime = actionTimesMs.at(-1) ?? spec.leadInMs
-  const durationMs = Math.max(cursor, finalActionTime) + spec.tailMs
+  // A closing sentence has no step after it to be the dwell on, so it would
+  // otherwise get the bare tail — on the one line the lesson was building to.
+  const closing = session.actions.at(-1)
+  const effectiveTailMs = Math.max(
+    spec.tailMs,
+    (closing === undefined
+      ? undefined
+      : narrationHoldFor(closing, spec.playbackSpeed)) ?? 0,
+  )
+  const durationMs = Math.max(cursor, finalActionTime) + effectiveTailMs
   if (durationMs > MAX_REPLAY_VIDEO_DURATION_MS) {
     throw new Error(
-      `Replay video is ${Math.ceil(durationMs / 1000)}s; the current limit is ${MAX_REPLAY_VIDEO_DURATION_MS / 1000}s. Shorten long holds or choose a faster replay speed.`,
+      `Replay video is ${Math.ceil(durationMs / 1000)}s; the current limit is ${MAX_REPLAY_VIDEO_DURATION_MS / 1000}s. Choose a faster replay speed, shorten authored holds, or split the take — steps are paced to be watchable, so a long take runs longer than it was recorded.`,
     )
   }
   return {

--- a/packages/app/src/webmcp/tools/arcadeTeach.test.ts
+++ b/packages/app/src/webmcp/tools/arcadeTeach.test.ts
@@ -1,7 +1,7 @@
 import '@/commands/builtins'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { agentDriving, pilot, resetPilot } from '@/arcade/pilot'
-import { TOPIC_IDS } from '@/arcade/topics'
+import { LESSON_TOPICS, TOPIC_IDS } from '@/arcade/topics'
 import { cancelSessionRecording } from '@/recorder/recorder'
 import { clearWebMcpContext, setWebMcpContext } from '@/webmcp/contextBridge'
 import { wrapTool } from '@/webmcp/registerWebMcp'
@@ -108,6 +108,10 @@ describe('Teach tools', () => {
       steps: 2,
       locked: true,
     })
+    // The brief is sent once and cannot be asked for again — a second
+    // arcade_start_lesson is refused as already active — so the half worth
+    // re-reading rides on the free, read-only status call.
+    expect(status.goal).toBe(LESSON_TOPICS.color.goal)
     const ended = (await arcadeEndLesson.execute(
       { title: 'Warm tones', summary: 'Palette then exposure.' },
       {},

--- a/packages/app/src/webmcp/tools/arcadeTeach.ts
+++ b/packages/app/src/webmcp/tools/arcadeTeach.ts
@@ -34,6 +34,15 @@ export const arcadeStatus: WebMcpTool = {
       locked: agentDriving(),
       recorderActive: ctx?.recorder?.isRecording() ?? false,
       narration: narration(),
+      // The brief is sent once and a client that truncates it cannot ask for
+      // it again: a second arcade_start_lesson is refused as already active.
+      // The goal is the half worth re-reading and costs ~240 chars; the
+      // allow-list is the half that caused the truncation and belongs in
+      // list_commands.
+      goal:
+        state.phase !== 'idle' && isTopicId(state.topic)
+          ? LESSON_TOPICS[state.topic].goal
+          : undefined,
       lastEnd:
         state.phase === 'ended'
           ? { reason: state.reason, sessionName: state.sessionName }

--- a/packages/app/src/webmcp/tools/listCommands.argHints.test.ts
+++ b/packages/app/src/webmcp/tools/listCommands.argHints.test.ts
@@ -1,0 +1,42 @@
+import '@/commands/builtins'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { setWebMcpContext } from '@/webmcp/contextBridge'
+import { createMockCommandContext } from '@/webmcp/testUtils'
+import { listCommands } from './listCommands'
+
+type Entry = { id: string; args?: string }
+type Result = { commands: Entry[] }
+
+/**
+ * A lesson brief is sent once. A client that truncates it takes the argument
+ * shapes with it, and a second `arcade_start_lesson` is refused as already
+ * active — a real agent lost the line for `flame.setVariationParams` mid-lesson
+ * and recovered it by reading the app bundle instead.
+ */
+describe('list_commands argument hints', () => {
+  beforeEach(() => {
+    setWebMcpContext(createMockCommandContext())
+  })
+
+  it('re-serves the shape a truncated brief lost', async () => {
+    const result = (await listCommands.execute(
+      { prefix: 'flame.setVariationParams' },
+      {},
+    )) as Result
+    const entry = result.commands.find(
+      (command) => command.id === 'flame.setVariationParams',
+    )
+    expect(entry?.args).toContain('transformId')
+    expect(entry?.args).toContain('paramName')
+  })
+
+  it('leaves an unfiltered page alone', async () => {
+    // Hints run to a line each and exist for a third of the registry, so
+    // attaching them to a full page would push it into the same client
+    // truncation this exists to recover from.
+    const result = (await listCommands.execute({}, {})) as Result
+    expect(result.commands.every((command) => command.args === undefined)).toBe(
+      true,
+    )
+  })
+})

--- a/packages/app/src/webmcp/tools/listCommands.ts
+++ b/packages/app/src/webmcp/tools/listCommands.ts
@@ -1,3 +1,4 @@
+import { commandArgHint } from '@/arcade/commandHints'
 import { getAllCommands } from '@/commands/registry'
 import { getWebMcpContext } from '@/webmcp/contextBridge'
 import type { WebMcpTool } from '@/webmcp/types'
@@ -86,6 +87,13 @@ export const listCommands: WebMcpTool = {
         id: cmd.id,
         label: cmd.label,
         description: cmd.description,
+        // Only on a narrowed query. Hints exist for a third of the registry
+        // and run to a line each, so attaching them to an unfiltered page
+        // would push it into the same client truncation this exists to
+        // recover from.
+        ...(prefix !== undefined && prefix.length > 0
+          ? { args: commandArgHint(cmd.id) }
+          : {}),
       })),
     }
   },


### PR DESCRIPTION
A Teach replay was not showing the lesson. Found by measuring a real recording, not by reading code.

## The bug

`gapBefore(index)` is the delay *before applying* a step, so it is the **dwell on the step before it**. An agent thinks for fifteen seconds, writes a sentence, then edits in a burst — so the pause was spent holding the *previous burst's last edit*, while the sentence it produced was replaced a millisecond later.

Measured on a real 30-action lesson (7 min 06 s recorded, 7.32 s replayed):

| step | dwell before | after |
| --- | --- | --- |
| `flame.setVariationWeight 0.9` | 1200 ms | 500 ms |
| `lesson.note` "For the third family…" (48 words) | **1.3 ms** | **4000 ms** |
| `flame.addTransform pdjVar` | 17 ms | 500 ms |
| four `setVariationParams` | 5, 2, 1, 1 ms | 500 ms each |

**Six narration sentences shared 10.3 milliseconds of screen time.** All 7.3 s of the replay was six editing steps sitting at the 1200 ms clamp. The `pdjVar` burst — six separate recorded actions in 25.8 ms — is the same disease from the other side; it also never let `ReplaySpotlight` land, since it needs 400 ms just to measure its target and the browser painted at most once across the whole burst.

Stepping worked because `seek()` applies with no timer at all, which was the diagnostic: focus resolution was fine, only the clock was wrong.

## The fix

One `stepGapMs` that the live player and the video exporter **share** rather than each implementing. That is not tidiness: `replayInterfaceVideo` validates its encoder budget from the schedule and then screen-records the live player, so the two drifting apart overruns the capture.

- An authored `holdMs` still wins, unclamped in both directions.
- A step that says something is held long enough to read — in **either** recording mode, since with `narrationAsStep` off the sentence rides as the next step's caption instead of standing as its own step. Bounded at 4 s: six sentences at full reading speed would spend most of the video budget on held text, and the transport is right there.
- Otherwise the measured gap, now clamped at **both** ends.

Three details that took a wrong turn first:

- **The floor applies to the recording, before speed divides it.** Flooring the *played* gap instead pins every step of an agent take to the floor at every speed — the 4x button would do nothing on exactly the takes that need it, because every one of their gaps is under the floor. An existing test caught this.
- **Skipped before the first step**, whose gap is a lead-in rather than a dwell on anything.
- **Skipped between two actions sharing a timestamp**, which is how a companion pair says it is one gesture and not two — `replayVideo` says so in as many words.

A closing sentence has no step after it to be the dwell on, so the video tail grows to its reading time.

**Result on that lesson**: 7.3 s → 35.7 s, every sentence up for four seconds, the `pdjVar` burst 2.5 s, exported video 37.8 s against a 120 s cap. The budget error now names pacing instead of blaming the user for holds an agent authored.

## The hint pill

It sat flush with the viewport bottom — exactly where a host browser driving the session puts its own floating Stop control, on top of ours. It now sits above the app's own bottom chrome via CSS anchor positioning against `.bottom-bar`.

Deliberately not a `ResizeObserver` writing a custom property: that fires at frame rate while the timeline is dragged, and needs an `agentDriving()` gate **the in-flight seats branch has already changed** — git would merge that cleanly and wrong. Chrome 125+, with a raised static margin standing in on older engines; the app already requires WebGPU.

Measured live: the pill resolves 12 px above the bar's top edge and stays centred. I could not make the bar change height from the probe, so tracking-on-resize rests on anchor positioning recomputing on layout rather than on an observation.

## What the driving agent asked for

Both gaps it reported itself, both real:

- **It could not re-read its brief** — a second `arcade_start_lesson` is refused as already active. The goal now rides on `arcade_status`, which is already free, zero-arg and read-only. Not the allow-list: that is the 882-char half that caused the truncation.
- **The brief arrived cut** at `flame.setVariationParams [transfo…`, so it recovered the argument shape by reading the app bundle. The truncation happens in the client and the brief cannot be made to fit, so this adds a recovery channel rather than a smaller brief: `list_commands` returns each command's argument hint, on a narrowed query only.

## Verification

- 164 files / 2079 tests passing; typecheck clean; lint clean apart from the pre-existing `AncestryTreeModal.tsx` warning.
- Six existing player tests move to the new gaps — each because the gap genuinely changed — and **eleven new tests** pin each rule: the floor, the human-paced gap left alone, the ceiling, floor-before-speed, the lead-in exemption, the companion exemption, `holdMs` winning unclamped, the narration hold, its bounds, the caption mode, and empty sentences.
- Driven live through `window.webmcp` against the dev server for the hint geometry.

Also in here: the investigation write-up (`docs/superpowers/plans/2026-09-04-teach-replay-pacing.md`) and two corrections to the spotlight feasibility doc — it claimed nothing computes a focus hint on the live path, but the recorder does at four sites, and its `focusFor` lets a command override the central table, so the seam that doc recommended would have lit the wrong control for exactly the commands that say where they live.