### PR TITLE
fix(replay): reading-speed pacing, whole captions, and a step list that follows

### DIFF
--- a/packages/app/src/arcade/topics.ts
+++ b/packages/app/src/arcade/topics.ts
@@ -217,7 +217,7 @@ export const WEBMCP_FALLBACK_NOTE =
   "If you cannot see these as tools, drive them from the page instead - they are registered on document.modelContext. Take the tool object from getTools and pass arguments as a JSON string: const t = (await document.modelContext.getTools()).find(x => x.name === 'arcade_status'); await document.modelContext.executeTool(t, JSON.stringify({})). Passing the name, or a plain object, throws."
 
 export function teachPromptCard(topic: TopicId): string {
-  return `Teach me ${LESSON_TOPICS[topic].title.toLowerCase()} in Lumen Apeiron. Call arcade_start_lesson with topic "${topic}", then build the example step by step using only the commands listed in the lesson brief. Before each group of changes call arcade_narrate with one sentence explaining what you are about to do and why. Check your work with get_flame. When done, call arcade_end_lesson with a short title and summary.
+  return `Teach me ${LESSON_TOPICS[topic].title.toLowerCase()} in Lumen Apeiron. Call arcade_start_lesson with topic "${topic}", then build the example step by step using only the commands listed in the lesson brief. Before each group of changes call arcade_narrate with one short sentence — under 25 words — explaining what you are about to do and why; the sentence is shown as a caption over the flame while it changes, so split a longer explanation into two narration steps rather than writing a paragraph. Check your work with get_flame. When done, call arcade_end_lesson with a short title and summary.
 
 ${WEBMCP_FALLBACK_NOTE}`
 }

--- a/packages/app/src/components/SessionRecorder/SessionReplayPanel.test.tsx
+++ b/packages/app/src/components/SessionRecorder/SessionReplayPanel.test.tsx
@@ -57,6 +57,40 @@ describe('SessionReplayPanel accessibility', () => {
     setFollowCamEnabled(true)
   })
 
+  // The list is a scroll container, and on a lesson longer than the panel the
+  // active step used to walk below the fold while the flame kept changing —
+  // conspicuous in a full-interface recording next to a timeline that moves.
+  it('scrolls the step it is playing into view', () => {
+    const spy = vi
+      .spyOn(Element.prototype, 'scrollIntoView')
+      .mockImplementation(() => {})
+    try {
+      const { unmount } = render(() => (
+        <SessionReplayPanel
+          session={makeSession()}
+          target={makeTarget()}
+          onClose={() => {}}
+        />
+      ))
+      fireEvent.click(screen.getByRole('button', { name: /Next step/i }))
+
+      // `mock.instances` is the receiver of each call, so this asks which
+      // element was scrolled rather than trusting that only one was.
+      const index = spy.mock.instances.findIndex(
+        (element) =>
+          element instanceof Element &&
+          element.getAttribute('aria-current') === 'step',
+      )
+      expect(index).toBeGreaterThanOrEqual(0)
+      // 'nearest' so a viewer reading further down the list is not yanked back
+      // on a step that was already visible.
+      expect(spy.mock.calls[index]?.[0]).toMatchObject({ block: 'nearest' })
+      unmount()
+    } finally {
+      spy.mockRestore()
+    }
+  })
+
   it('announces transport progress and exposes the current step', () => {
     const { unmount } = render(() => (
       <SessionReplayPanel

--- a/packages/app/src/components/SessionRecorder/SessionReplayPanel.tsx
+++ b/packages/app/src/components/SessionRecorder/SessionReplayPanel.tsx
@@ -1,5 +1,6 @@
 import { createEffect, createMemo, createSignal, createUniqueId, For, onCleanup, Show, untrack, } from 'solid-js'
 import { createStore, unwrap } from 'solid-js/store'
+import { usePrefersReducedMotion } from '@/components/Home/homePlayback'
 import { ChevronLeft, ChevronRight, Download, Focus, Pause, Pencil, PlayPause, SkipBack, Speech, } from '@/icons'
 import { deriveReplayFocusPreparation } from '@/recorder/focusPreparation'
 import { createSessionPlayer, PLAYBACK_SPEEDS } from '@/recorder/player'
@@ -56,6 +57,7 @@ export function SessionReplayPanel(props: {
     createSignal<ReplayVideoExportMode>('artwork')
   const [exportError, setExportError] = createSignal<string>()
   const panelId = createUniqueId()
+  const reducedMotion = usePrefersReducedMotion()
 
   type LiveReplayWaiter = {
     resolve: () => void
@@ -105,6 +107,28 @@ export function SessionReplayPanel(props: {
     if (!action) return undefined
     const focus = currentPreparation()?.spotlightFocus
     return focus === action.focus ? action : { ...action, focus }
+  })
+  /**
+   * Keep the step the viewer is watching in view.
+   *
+   * The list is a scroll container and the current step carries
+   * `aria-current`, but nothing ever scrolled it — so on a lesson longer than
+   * the panel the active step walked below the fold and the list sat still
+   * while the flame changed, which reads as broken in a full-interface
+   * recording next to a timeline that does move.
+   *
+   * `block: 'nearest'` scrolls only when the step is actually out of view, so
+   * a viewer reading further down the list is not yanked back on every step.
+   */
+  let stepsEl: HTMLOListElement | undefined
+  createEffect(() => {
+    const index = player.stepIndex()
+    if (index < 0 || stepsEl === undefined) return
+    const current = stepsEl.querySelector('[aria-current="step"]')
+    current?.scrollIntoView({
+      block: 'nearest',
+      behavior: reducedMotion() ? 'auto' : 'smooth',
+    })
   })
   createEffect(() => {
     props.onPlaybackChange?.(player.isPlaying())
@@ -400,7 +424,7 @@ export function SessionReplayPanel(props: {
       </Show>
 
       <Show when={props.compact !== true}>
-        <ol class={styles.steps}>
+        <ol class={styles.steps} ref={stepsEl}>
           <For each={session.actions}>
             {(action, index) => {
               const editorId = `${panelId}-step-${index()}-editor`

--- a/packages/app/src/recorder/player.test.ts
+++ b/packages/app/src/recorder/player.test.ts
@@ -223,8 +223,14 @@ describe('stepGapMs', () => {
   })
 
   it('leaves a human-paced gap alone', () => {
-    expect(stepGapMs(at(0), at(600), 1)).toBe(600)
-    expect(stepGapMs(at(0), at(1000), 1)).toBe(1000)
+    // Expressed against the constants rather than as literals: the numbers are
+    // a judgement about how fast a lesson should read and will be tuned again,
+    // and a test that has to be edited each time proves nothing.
+    const human = MIN_STEP_GAP_MS + 200
+    expect(stepGapMs(at(0), at(human), 1)).toBe(human)
+    expect(stepGapMs(at(0), at(MAX_STEP_GAP_MS - 100), 1)).toBe(
+      MAX_STEP_GAP_MS - 100,
+    )
   })
 
   it('still clamps a long thinking pause', () => {
@@ -261,8 +267,9 @@ describe('stepGapMs', () => {
     // The bug this exists for: six sentences shared 10.3ms of screen time
     // because the pause the agent spent writing them was charged to the edit
     // BEFORE each one.
-    const note = at(0, { id: 'lesson.note', args: ['one two three four five'] })
-    expect(stepGapMs(note, at(2), 1)).toBe(5 * NARRATION_MS_PER_WORD)
+    const words = Array.from({ length: 10 }, (_, i) => `w${i}`).join(' ')
+    const note = at(0, { id: 'lesson.note', args: [words] })
+    expect(stepGapMs(note, at(2), 1)).toBe(10 * NARRATION_MS_PER_WORD)
     expect(stepGapMs(note, at(2), 1)).toBeGreaterThan(MAX_STEP_GAP_MS)
   })
 
@@ -279,8 +286,9 @@ describe('stepGapMs', () => {
   it('reads a sentence that rode along as a caption', () => {
     // With narrationAsStep off there is no lesson.note action at all: the
     // sentence captions the step it introduces. Same prose, same pacing.
-    const captioned = at(0, { note: 'one two three four five' })
-    expect(stepGapMs(captioned, at(2), 1)).toBe(5 * NARRATION_MS_PER_WORD)
+    const words = Array.from({ length: 10 }, (_, i) => `w${i}`).join(' ')
+    const captioned = at(0, { note: words })
+    expect(stepGapMs(captioned, at(2), 1)).toBe(10 * NARRATION_MS_PER_WORD)
   })
 
   it('ignores an empty sentence', () => {
@@ -450,7 +458,7 @@ describe('createSessionPlayer', () => {
       const before = deepClone(flame)
       const player = createSessionPlayer(gammaSteps, target)
       player.play()
-      vi.advanceTimersByTime(1000)
+      vi.advanceTimersByTime(10_000)
 
       expect(committed()).toBe(1)
       expect(flame.renderSettings.gamma).toBeCloseTo(3.5, 5)
@@ -937,7 +945,7 @@ describe('createSessionPlayer', () => {
       player.play()
       // Rewound to the initial flame, then plays forward again.
       expect(player.stepIndex()).toBe(-1)
-      vi.advanceTimersByTime(1000)
+      vi.advanceTimersByTime(10_000)
       expect(player.stepIndex()).toBe(2)
       expect(flame.renderSettings.gamma).toBeCloseTo(3.5, 5)
       dispose()
@@ -984,7 +992,7 @@ describe('createSessionPlayer', () => {
       const player = createSessionPlayer(gammaSteps, target)
 
       player.play()
-      vi.advanceTimersByTime(1000)
+      vi.advanceTimersByTime(10_000)
 
       expect(player.isPlaying()).toBe(false)
       expect(player.stepIndex()).toBe(0)

--- a/packages/app/src/recorder/player.ts
+++ b/packages/app/src/recorder/player.ts
@@ -28,8 +28,14 @@ import type { RecordedAction, RecordedSession } from './schema'
  *    be unusable.
  */
 
-/** Longest wait between two steps, however long the human paused for. */
-export const MAX_STEP_GAP_MS = 1200
+/**
+ * Longest wait between two steps, however long the human paused for.
+ *
+ * Raised with the floor below rather than independently: a floor close to the
+ * ceiling squeezes every gap into a narrow band and erases whatever rhythm the
+ * recording had, so the two have to move together.
+ */
+export const MAX_STEP_GAP_MS = 2000
 
 /**
  * Shortest wait between two steps, however fast they were recorded.
@@ -46,21 +52,29 @@ export const MAX_STEP_GAP_MS = 1200
  * floor at every speed — the 4x button would do nothing on exactly the takes
  * that need it, because every one of their gaps is under the floor.
  */
-export const MIN_STEP_GAP_MS = 500
-
-/** 240 words per minute, the usual figure for reading prose on screen. */
-export const NARRATION_MS_PER_WORD = 250
-
-/** Even three words deserve to be seen. */
-export const NARRATION_MIN_HOLD_MS = 1200
+export const MIN_STEP_GAP_MS = 800
 
 /**
- * ...and even a paragraph does not get to stop the show. Full reading time for
- * the sentences an agent writes is 8-12 s each; six of those would spend most
- * of MAX_REPLAY_VIDEO_DURATION_MS on held text. The transport is right there
- * for a viewer who wants longer.
+ * Reading speed for a caption, not for a book: ~170 words per minute.
+ *
+ * The usual 240 wpm figure assumes prose is all the reader is doing. Here the
+ * flame is changing underneath the sentence, which is the entire point, so a
+ * viewer is splitting attention between the two.
  */
-export const NARRATION_MAX_HOLD_MS = 4000
+export const NARRATION_MS_PER_WORD = 350
+
+/** Even three words deserve to be seen, and read twice. */
+export const NARRATION_MIN_HOLD_MS = 2000
+
+/**
+ * ...and even a paragraph does not get to stop the show.
+ *
+ * A sentence long enough to hit this cap is one the agent should have split in
+ * two, which the lesson brief now asks for; the cap is what stops one that was
+ * not from eating MAX_REPLAY_VIDEO_DURATION_MS on its own. The transport is
+ * right there for a viewer who wants longer.
+ */
+export const NARRATION_MAX_HOLD_MS = 7000
 
 /**
  * The sentence this step says out loud, in either recording mode.

--- a/packages/app/src/recorder/replayInterfaceVideo.ts
+++ b/packages/app/src/recorder/replayInterfaceVideo.ts
@@ -1,7 +1,7 @@
 import { deepClone } from '@/utils/clone'
 import { createMetadataPayload, injectMetadataIntoMp4, } from '@/utils/flameInMp4'
 import { createVideoEncoder } from '@/utils/videoEncoder'
-import { createReplayVideoSchedule, MAX_REPLAY_VIDEO_DURATION_MS, REPLAY_VIDEO_FPS, REPLAY_VIDEO_LEAD_IN_MS, REPLAY_VIDEO_TAIL_MS, replayVideoInitialTimelineSnapshot, } from './replayVideo'
+import { createReplayVideoSchedule, MAX_REPLAY_VIDEO_DURATION_MS, REPLAY_VIDEO_FPS, REPLAY_VIDEO_LEAD_IN_MS, replayVideoInitialTimelineSnapshot, } from './replayVideo'
 import { validateSession } from './schema'
 import type { RecordedSession } from './schema'
 import type { VideoEncoderConfig } from '@/utils/videoEncoder'
@@ -321,7 +321,7 @@ export async function captureReplayInterfaceVideo(
   }
   // Validates speed, authored holds and the two-minute resource budget before
   // showing a privacy-sensitive capture chooser.
-  createReplayVideoSchedule(session, request.playbackSpeed)
+  const schedule = createReplayVideoSchedule(session, request.playbackSpeed)
 
   // This call must remain on the direct Export-button stack. getDisplayMedia
   // requires transient user activation and must prompt on every recording.
@@ -385,7 +385,10 @@ export async function captureReplayInterfaceVideo(
     request.prepareReplay()
     await waitFor(REPLAY_VIDEO_LEAD_IN_MS, controller.signal)
     await request.playReplay(controller.signal)
-    await waitFor(REPLAY_VIDEO_TAIL_MS, controller.signal)
+    // The schedule's tail, not the constant: a closing narration step holds
+    // for its reading time, and waiting the flat tail cut the last sentence
+    // off mid-read while the artwork export showed all of it.
+    await waitFor(schedule.tailMs, controller.signal)
     completed = true
     captureOpen = false
     await sampling

--- a/packages/app/src/recorder/replayVideo.test.ts
+++ b/packages/app/src/recorder/replayVideo.test.ts
@@ -344,6 +344,43 @@ describe('drawReplayVideoOverlay', () => {
     } as unknown as CanvasRenderingContext2D
   }
 
+  it('fills the last line it is allowed, not just the word that overflowed', () => {
+    // The loop used to break one line early, leaving the final line holding
+    // only the word that overflowed the previous one — so a four-line budget
+    // bought three filled lines and an orphan, and raising the budget alone
+    // did not fix the truncation it was raised to fix.
+    const drawn: string[] = []
+    const words = Array.from({ length: 200 }, (_, i) => `w${i}`).join(' ')
+    drawReplayVideoOverlay(fontAwareContext(drawn), 1920, 1080, {
+      action: { t: 0, id: 'lesson.note', args: [words], note: words },
+      actionIndex: 0,
+      totalActions: 1,
+      progress: 0.5,
+    })
+    const lines = drawn.filter((text) => /^w\d/.test(text))
+    expect(lines).toHaveLength(4)
+    // Every line carries a real share of the text; none is a lone orphan.
+    const counts = lines.map((line) => line.split(/\s+/).length)
+    expect(Math.min(...counts)).toBeGreaterThan(1)
+  })
+
+  it('does not read an author own ellipsis as a cut', () => {
+    // Sniffing for a trailing '…' shrank the caption for text that already
+    // fitted, because a written sentence may legitimately end in one.
+    const drawn: string[] = []
+    const sentence = 'Watch what happens next…'
+    drawReplayVideoOverlay(fontAwareContext(drawn), 1920, 1080, {
+      action: { t: 0, id: 'lesson.note', args: [sentence], note: sentence },
+      actionIndex: 0,
+      totalActions: 1,
+      progress: 0.5,
+    })
+    // Short enough for one line at full size, so it must not have been
+    // stepped down looking for a fit it already had.
+    const line = drawn.find((text) => text.startsWith('Watch'))
+    expect(line).toBe(sentence)
+  })
+
   it('shows a whole agent-length sentence rather than cutting it', () => {
     // Measured from a real lesson: its narration ran 213-266 characters, and a
     // two-line block at full size holds about 170 — so every sentence was cut,

--- a/packages/app/src/recorder/replayVideo.test.ts
+++ b/packages/app/src/recorder/replayVideo.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import { examples } from '@/flame/examples'
 import { deepClone } from '@/utils/clone'
-import { createReplayVideoDriver, createReplayVideoJobSpec, createReplayVideoSchedule, drawReplayVideoOverlay, MAX_REPLAY_VIDEO_DURATION_MS, REPLAY_VIDEO_DIMENSIONS, REPLAY_VIDEO_FPS, replayActionIndexAtFrame, replayFramesInStateRun, replayVideoFileName, replayVideoVisualFingerprint, } from './replayVideo'
+import { NARRATION_MS_PER_WORD } from './player'
+import { createReplayVideoDriver, createReplayVideoJobSpec, createReplayVideoSchedule, drawReplayVideoOverlay, MAX_REPLAY_VIDEO_DURATION_MS, REPLAY_VIDEO_DIMENSIONS, REPLAY_VIDEO_FPS, REPLAY_VIDEO_TAIL_MS, replayActionIndexAtFrame, replayFramesInStateRun, replayVideoFileName, replayVideoVisualFingerprint, } from './replayVideo'
 import { SESSION_FORMAT_VERSION } from './schema'
 import type { RecordedAction, RecordedSession } from './schema'
 
@@ -266,6 +267,28 @@ describe('createReplayVideoJobSpec', () => {
   })
 })
 
+describe('replay video tail', () => {
+  it('grows the tail to the closing sentence, and publishes it', () => {
+    // The closing sentence has no step after it to be the dwell on. The
+    // interface capture records the live player and waits this value, so a
+    // flat tail cut the last line off mid-read while the artwork export
+    // showed all of it — a 2.5s difference between two exports of one take.
+    const words = Array.from({ length: 12 }, (_, i) => `w${i}`).join(' ')
+    const session = makeSession([
+      { t: 0, id: 'flame.setGamma', args: [1.5] },
+      { t: 2000, id: 'lesson.note', args: [words] },
+    ])
+    const schedule = createReplayVideoSchedule(session, 1)
+    expect(schedule.tailMs).toBe(12 * NARRATION_MS_PER_WORD)
+    expect(schedule.tailMs).toBeGreaterThan(REPLAY_VIDEO_TAIL_MS)
+
+    const quiet = makeSession([{ t: 0, id: 'flame.setGamma', args: [1.5] }])
+    expect(createReplayVideoSchedule(quiet, 1).tailMs).toBe(
+      REPLAY_VIDEO_TAIL_MS,
+    )
+  })
+})
+
 describe('drawReplayVideoOverlay', () => {
   it('keeps an unbroken authored caption inside the output safe width', () => {
     const drawn: string[] = []
@@ -295,5 +318,51 @@ describe('drawReplayVideoOverlay', () => {
     expect(caption).toBeDefined()
     expect(caption?.endsWith('…')).toBe(true)
     expect((caption?.length ?? 0) * 10).toBeLessThanOrEqual(182)
+  })
+
+  // A real canvas measures against the font in effect; the mock above does
+  // not, which is why it cannot see the adaptive fit at all.
+  function fontAwareContext(drawn: string[]) {
+    let font = '650 41px sans-serif'
+    return {
+      save: () => {},
+      restore: () => {},
+      createLinearGradient: () => ({ addColorStop: () => {} }),
+      fillText: (text: string) => drawn.push(text),
+      fillRect: () => {},
+      clearRect: () => {},
+      measureText: (text: string) => ({
+        // ~0.52em average advance for a 650-weight humanist sans.
+        width: text.length * (Number.parseInt(font, 10) || 41) * 0.52,
+      }),
+      set font(next: string) {
+        font = next.replace(/^650 /, '')
+      },
+      get font() {
+        return font
+      },
+    } as unknown as CanvasRenderingContext2D
+  }
+
+  it('shows a whole agent-length sentence rather than cutting it', () => {
+    // Measured from a real lesson: its narration ran 213-266 characters, and a
+    // two-line block at full size holds about 170 — so every sentence was cut,
+    // the longest losing a third of itself.
+    const sentence =
+      'For the third family I will add pdj on its own transform, because its four frequency parameters produce a wave texture that neither spherical nor juliaN can make, and keeping it separate is what lets you attribute the change you are about to see.'
+    expect(sentence.length).toBeGreaterThan(230)
+    const drawn: string[] = []
+    drawReplayVideoOverlay(fontAwareContext(drawn), 1920, 1080, {
+      action: { t: 0, id: 'lesson.note', args: [sentence], note: sentence },
+      actionIndex: 0,
+      totalActions: 1,
+      progress: 0.5,
+    })
+    const lines = drawn.filter((text) => sentence.includes(text.slice(0, 12)))
+    expect(lines.length).toBeGreaterThan(2)
+    expect(lines.length).toBeLessThanOrEqual(4)
+    expect(lines.some((line) => line.endsWith('…'))).toBe(false)
+    // Every word survives, in order.
+    expect(lines.join(' ').split(/\s+/)).toEqual(sentence.split(/\s+/))
   })
 })

--- a/packages/app/src/recorder/replayVideo.ts
+++ b/packages/app/src/recorder/replayVideo.ts
@@ -947,7 +947,12 @@ function fitCaptionLines(
     }
     if (current !== '') lines.push(current)
     current = word
-    if (lines.length === maxLines - 1) break
+    // `maxLines`, not `maxLines - 1`: breaking one line early left the final
+    // line holding only the word that overflowed the previous one, so a
+    // four-line budget bought three filled lines and an orphan. With two lines
+    // that cost half the caption; it is why raising the budget alone did not
+    // fix the truncation.
+    if (lines.length === maxLines) break
   }
   if (current !== '' && lines.length < maxLines) lines.push(current)
   const fitWithEllipsis = (line: string): string => {
@@ -1018,11 +1023,16 @@ export function drawReplayVideoOverlay(
   // taking the largest size and cutting the sentence to fit it.
   let captionScale = 1
   let lines: string[] = []
+  const captionWords = caption.trim().split(/\s+/).filter(Boolean).length
   for (const scale of CAPTION_FONT_STEPS) {
     captionScale = scale
     context.font = `650 ${Math.round(captionFont * scale)}px ui-sans-serif, system-ui, sans-serif`
     lines = fitCaptionLines(context, caption, textWidth, MAX_CAPTION_LINES)
-    if (!lines.some((line) => line.endsWith('…'))) break
+    // Count the words that survived rather than sniffing for a trailing '…':
+    // an author may end a sentence with one, and that must not be read as a
+    // cut and shrink the caption for text that already fitted.
+    const shown = lines.join(' ').split(/\s+/).filter(Boolean).length
+    if (shown >= captionWords) break
   }
   const fittedFont = Math.round(captionFont * captionScale)
   context.font = `650 ${fittedFont}px ui-sans-serif, system-ui, sans-serif`

--- a/packages/app/src/recorder/replayVideo.ts
+++ b/packages/app/src/recorder/replayVideo.ts
@@ -57,6 +57,13 @@ export type ReplayVideoSchedule = {
   actionFrames: number[]
   durationMs: number
   totalFrames: number
+  /**
+   * How long to hold after the last step — the requested tail, or the closing
+   * sentence's reading time when that is longer. The interface capture records
+   * the live player rather than these frames, so it has to wait this and not
+   * the constant, or it cuts the closing line off mid-read.
+   */
+  tailMs: number
 }
 
 export type ReplayVideoFrameState = {
@@ -425,6 +432,7 @@ export function createReplayVideoSchedule(
     actionTimesMs,
     actionFrames,
     durationMs,
+    tailMs: effectiveTailMs,
     // Keep the final authored action representable even when a future caller
     // deliberately asks for no tail. Frame indexes are zero-based, so an
     // action landing on frame N needs at least N + 1 output frames.
@@ -902,6 +910,25 @@ export type ReplayVideoOverlayFrame = {
   flameName?: string
 }
 
+/**
+ * The tallest the caption block may grow, in lines.
+ *
+ * Two lines hold about 170 characters at 1080p, and an agent's sentences
+ * measured 213-266 — so every one of them was cut, the longest losing a third
+ * of itself to an ellipsis. Four lines at the reduced size below hold roughly
+ * 450, which covers anything the brief now asks for.
+ */
+const MAX_CAPTION_LINES = 4
+
+/**
+ * How much the caption shrinks once it needs more than two lines.
+ *
+ * Without this a four-line block at full size is 194px of a 1080px frame,
+ * covering the flame the caption is describing. Shrinking as it grows keeps
+ * the block around 150px, and a short caption still gets the full size.
+ */
+const CAPTION_FONT_STEPS = [1, 0.88, 0.78] as const
+
 function fitCaptionLines(
   context: CanvasRenderingContext2D,
   text: string,
@@ -987,9 +1014,19 @@ export function drawReplayVideoOverlay(
   context.fillText('CREATION REPLAY', margin, margin + tagFont * 1.45)
 
   const textWidth = width - margin * 2
-  context.font = `650 ${captionFont}px ui-sans-serif, system-ui, sans-serif`
-  const lines = fitCaptionLines(context, caption, textWidth, 2)
-  const lineHeight = captionFont * 1.18
+  // Take the largest size that shows the WHOLE sentence, rather than always
+  // taking the largest size and cutting the sentence to fit it.
+  let captionScale = 1
+  let lines: string[] = []
+  for (const scale of CAPTION_FONT_STEPS) {
+    captionScale = scale
+    context.font = `650 ${Math.round(captionFont * scale)}px ui-sans-serif, system-ui, sans-serif`
+    lines = fitCaptionLines(context, caption, textWidth, MAX_CAPTION_LINES)
+    if (!lines.some((line) => line.endsWith('…'))) break
+  }
+  const fittedFont = Math.round(captionFont * captionScale)
+  context.font = `650 ${fittedFont}px ui-sans-serif, system-ui, sans-serif`
+  const lineHeight = fittedFont * 1.18
   const blockHeight = Math.max(1, lines.length) * lineHeight
   const captionY = height - margin - blockHeight - unit * 0.045
   const gradient = context.createLinearGradient(
@@ -1012,7 +1049,7 @@ export function drawReplayVideoOverlay(
 
   context.shadowColor = 'rgba(0, 0, 0, 0.8)'
   context.shadowBlur = unit * 0.012
-  context.font = `650 ${captionFont}px ui-sans-serif, system-ui, sans-serif`
+  context.font = `650 ${fittedFont}px ui-sans-serif, system-ui, sans-serif`
   context.fillStyle = 'rgba(255, 255, 255, 0.98)'
   lines.forEach((line, index) => {
     context.fillText(line, margin, captionY + index * lineHeight)

--- a/packages/app/src/webmcp/tools/arcadeTeach.ts
+++ b/packages/app/src/webmcp/tools/arcadeTeach.ts
@@ -141,13 +141,14 @@ export const arcadeStartLesson: WebMcpTool = {
 export const arcadeNarrate: WebMcpTool = {
   name: 'arcade_narrate',
   description:
-    'Say one sentence to the viewer about the step you are about to take. Shown live and recorded as a caption in the replay. Counts as one step of the budget. Only valid while an Arcade session is active.',
+    'Say one SHORT sentence to the viewer about the step you are about to take. It is burned into the replay as a caption over the flame, so keep it under 25 words — a longer one is held on screen longer but is harder to read while the picture is changing. Two ideas means two calls. Counts as one step of the budget. Only valid while an Arcade session is active.',
   inputSchema: {
     type: 'object',
     properties: {
       text: {
         type: 'string',
-        description: 'One sentence, at most 400 characters',
+        description:
+          'One sentence, at most 400 characters. Aim for under 25 words: it is shown as a caption over the flame, not as prose on a page.',
       },
     },
     required: ['text'],


### PR DESCRIPTION
Follow-up to #155, from watching a real take back and probing two real exports.

## Pacing was right in shape, short in every number

Floor 500 → 800 ms, ceiling 1200 → 2000 ms — moved together, because a floor near the ceiling squeezes every gap into a narrow band and erases whatever rhythm the recording had. Narration 250 → 350 ms/word, bounded 2–7 s instead of 1.2–4 s: 240 wpm assumes prose is all the reader is doing, and here the flame is changing underneath the sentence.

That lesson now runs **60.6 s** instead of 35.7 s; its exported video is ~68 s against the 120 s cap, leaving room for about fourteen full-length sentences before the guard bites.

## The caption was cut, and the closing one twice over

`fitCaptionLines` was fixed at two lines. At 1080p that holds about **170 characters**; the agent's sentences measured **213–266**, so every one ended in an ellipsis and the longest lost a third of itself.

The fit is now adaptive — the largest of three sizes that shows the *whole* sentence, across up to four lines. Shrinking as it grows keeps the block near 150 px rather than 194 px of a 1080 px frame, so a long caption doesn't bury the flame it's describing, and a short one still gets the full size.

Separately, two exports of one take came out **40.375 s** and **37.917 s**. That difference is exactly the closing sentence's hold: `createReplayVideoSchedule` grows its tail to the closing narration's reading time, but `replayInterfaceVideo` called it only to validate its encoder budget and then waited the flat `REPLAY_VIDEO_TAIL_MS`. The schedule now publishes the tail it computed and the capture waits it.

Worth noting: this was raised three times in #155's review and refuted three times, once with "the arithmetic is exactly right… but the divergence points in the safe direction". It is safe for the encoder — and it still cut the last line off mid-read. The two files are the evidence.

## The step list didn't follow

It's a scroll container and the current step carries `aria-current`, but nothing ever scrolled it — so on a lesson longer than the panel the active step walked below the fold while the flame kept changing. Next to a timeline that does move, in a full-interface recording, that reads as broken. `block: 'nearest'` scrolls only when the step is actually out of view, and the smooth behaviour yields to `prefers-reduced-motion`.

## And the agent is asked for captions, not paragraphs

A 48-word sentence is hard to read in four seconds even when it fits. `arcade_narrate` and the prompt card now ask for one idea under 25 words, and for longer explanations to be split into two narration steps.

Deliberately **not** in the lesson brief's tips: the variations brief measured 1486 of the 1500 characters its budget test asserts, and putting it there left 14 characters of headroom. It lives in the tool's own description, which a truncating client cannot take away.

## Verification

- 165 files / **2083 tests** passing; typecheck clean; lint clean apart from the pre-existing `AncestryTreeModal.tsx` warning.
- Every behaviour change has a test, and **each new test was mutation-checked** — the fix removed, the test observed to fail, the fix restored:
  - step-list scroll → `expected -1 to be greater than or equal to 0`
  - the centred-pill CSS ratchet (in #155) → `expected false to be true`
- The caption test uses a **font-aware canvas mock**, because the existing one returns `text.length * 10` regardless of font and therefore cannot see an adaptive fit at all. It asserts every word survives, in order, across at most four lines with no ellipsis.
- The tail test pins both directions: grown for a closing narration, and left at `REPLAY_VIDEO_TAIL_MS` without one.
- The three pacing tests that pinned literals now express themselves against the constants — these numbers are a judgement about how a lesson should read and will be tuned again.