### PR TITLE
feat(brand): replace the infinity ribbon with the "Deep C" mark

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -7,6 +7,13 @@
       "runtimeArgs": ["--filter", "chaos-master", "start"],
       "port": 5173,
       "url": "https://localhost:5173"
+    },
+    {
+      "name": "landing-dev",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["--filter", "@chaos-master/landing", "dev"],
+      "port": 4321,
+      "url": "https://localhost:4321"
     }
   ]
 }

--- a/packages/app/src/assets/favicon.svg
+++ b/packages/app/src/assets/favicon.svg
@@ -1,23 +1,18 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
-  <defs>
-    <linearGradient id="cmArm" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#06d6c8" />
-      <stop offset="40%" stop-color="#a3e635" />
-      <stop offset="72%" stop-color="#ffae34" />
-      <stop offset="100%" stop-color="#ff5e7e" />
-    </linearGradient>
-    <radialGradient id="cmCore" cx="50%" cy="50%" r="50%">
-      <stop offset="0%" stop-color="#ffffff" />
-      <stop offset="55%" stop-color="#7be0e8" />
-      <stop offset="100%" stop-color="#7be0e8" stop-opacity="0" />
-    </radialGradient>
-  </defs>
-  <rect width="64" height="64" rx="15" fill="#0a0a12" />
-  <!-- infinity ribbon (lemniscate): an endless, self-crossing IFS flame loop -->
-  <g transform="rotate(-20 32 32)" fill="none" stroke="url(#cmArm)"
-     stroke-width="6.5" stroke-linecap="round" stroke-linejoin="round">
-    <path d="M32 32 C 24 19, 9 19, 9 32 C 9 45, 24 45, 32 32 C 40 19, 55 19, 55 32 C 55 45, 40 45, 32 32 Z" />
+  <rect width="64" height="64" rx="15" fill="#080A0E" />
+  <!-- "Deep C": a heavy band sweeping 249 degrees, its mouth open to the west.
+       Light with no source - the band has no beginning; it gathers out of the
+       ember marks drifting in the mouth, the smallest already detached.
+       Two flat inks and no gradients, on purpose: a favicon is judged at 16px,
+       where a four-stop gradient collapses toward one value and the shape has
+       to carry the mark on its own. Geometry: r=20.03, stroke 9.46, arc from
+       235.62 to 124.38 degrees (mouth 111.24 degrees, centred due west). -->
+  <path d="M 20.69 15.47 A 20.03 20.03 0 1 1 20.69 48.53"
+        fill="none" stroke="#F2F3F5" stroke-width="9.46" stroke-linecap="butt" />
+  <g fill="#FF7448">
+    <rect x="14.79" y="22.76" width="17.22" height="3.72" rx="1.86" />
+    <rect x="14.79" y="30.14" width="13.05" height="3.72" rx="1.86" />
+    <rect x="7.19" y="30.14" width="5.87" height="3.72" rx="1.86" />
+    <rect x="17.40" y="37.52" width="14.61" height="3.72" rx="1.86" />
   </g>
-  <circle cx="32" cy="32" r="7.5" fill="url(#cmCore)" />
-  <circle cx="32" cy="32" r="2.4" fill="#fff" />
 </svg>

--- a/packages/landing/public/favicon.svg
+++ b/packages/landing/public/favicon.svg
@@ -1,23 +1,18 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
-  <defs>
-    <linearGradient id="cmArm" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#06d6c8" />
-      <stop offset="40%" stop-color="#a3e635" />
-      <stop offset="72%" stop-color="#ffae34" />
-      <stop offset="100%" stop-color="#ff5e7e" />
-    </linearGradient>
-    <radialGradient id="cmCore" cx="50%" cy="50%" r="50%">
-      <stop offset="0%" stop-color="#ffffff" />
-      <stop offset="55%" stop-color="#7be0e8" />
-      <stop offset="100%" stop-color="#7be0e8" stop-opacity="0" />
-    </radialGradient>
-  </defs>
-  <rect width="64" height="64" rx="15" fill="#0a0a12" />
-  <!-- infinity ribbon (lemniscate): an endless, self-crossing IFS flame loop -->
-  <g transform="rotate(-20 32 32)" fill="none" stroke="url(#cmArm)"
-     stroke-width="6.5" stroke-linecap="round" stroke-linejoin="round">
-    <path d="M32 32 C 24 19, 9 19, 9 32 C 9 45, 24 45, 32 32 C 40 19, 55 19, 55 32 C 55 45, 40 45, 32 32 Z" />
+  <rect width="64" height="64" rx="15" fill="#080A0E" />
+  <!-- "Deep C": a heavy band sweeping 249 degrees, its mouth open to the west.
+       Light with no source - the band has no beginning; it gathers out of the
+       ember marks drifting in the mouth, the smallest already detached.
+       Two flat inks and no gradients, on purpose: a favicon is judged at 16px,
+       where a four-stop gradient collapses toward one value and the shape has
+       to carry the mark on its own. Geometry: r=20.03, stroke 9.46, arc from
+       235.62 to 124.38 degrees (mouth 111.24 degrees, centred due west). -->
+  <path d="M 20.69 15.47 A 20.03 20.03 0 1 1 20.69 48.53"
+        fill="none" stroke="#F2F3F5" stroke-width="9.46" stroke-linecap="butt" />
+  <g fill="#FF7448">
+    <rect x="14.79" y="22.76" width="17.22" height="3.72" rx="1.86" />
+    <rect x="14.79" y="30.14" width="13.05" height="3.72" rx="1.86" />
+    <rect x="7.19" y="30.14" width="5.87" height="3.72" rx="1.86" />
+    <rect x="17.40" y="37.52" width="14.61" height="3.72" rx="1.86" />
   </g>
-  <circle cx="32" cy="32" r="7.5" fill="url(#cmCore)" />
-  <circle cx="32" cy="32" r="2.4" fill="#fff" />
 </svg>

--- a/packages/landing/src/components/Nav.astro
+++ b/packages/landing/src/components/Nav.astro
@@ -9,32 +9,19 @@ const repoUrl = 'https://github.com/chaos-matters/chaos-master'
   <div class="wrap nav-in">
     <a class="brand" href="#top">
       <svg class="brand-mark" viewBox="0 0 64 64" aria-hidden="true">
-        <defs>
-          <linearGradient id="navArm" x1="0" y1="0" x2="1" y2="1">
-            <stop offset="0%" stop-color="#06d6c8" />
-            <stop offset="40%" stop-color="#a3e635" />
-            <stop offset="72%" stop-color="#ffae34" />
-            <stop offset="100%" stop-color="#ff5e7e" />
-          </linearGradient>
-          <radialGradient id="navCore" cx="50%" cy="50%" r="50%">
-            <stop offset="0%" stop-color="#fff" />
-            <stop offset="55%" stop-color="#7be0e8" />
-            <stop offset="100%" stop-color="#7be0e8" stop-opacity="0" />
-          </radialGradient>
-        </defs>
-        <rect width="64" height="64" rx="15" fill="#0a0a12" />
-        <g
-          transform="rotate(-20 32 32)"
+        <rect width="64" height="64" rx="15" fill="#080A0E"></rect>
+        <path
+          d="M 20.69 15.47 A 20.03 20.03 0 1 1 20.69 48.53"
           fill="none"
-          stroke="url(#navArm)"
-          stroke-width="6.5"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-        >
-          <path d="M32 32 C 24 19, 9 19, 9 32 C 9 45, 24 45, 32 32 C 40 19, 55 19, 55 32 C 55 45, 40 45, 32 32 Z" />
+          stroke="#F2F3F5"
+          stroke-width="9.46"
+          stroke-linecap="butt"></path>
+        <g fill="#FF7448">
+          <rect x="14.79" y="22.76" width="17.22" height="3.72" rx="1.86"></rect>
+          <rect x="14.79" y="30.14" width="13.05" height="3.72" rx="1.86"></rect>
+          <rect x="7.19" y="30.14" width="5.87" height="3.72" rx="1.86"></rect>
+          <rect x="17.40" y="37.52" width="14.61" height="3.72" rx="1.86"></rect>
         </g>
-        <circle cx="32" cy="32" r="7.5" fill="url(#navCore)" />
-        <circle cx="32" cy="32" r="2.4" fill="#fff" />
       </svg>
       Lumen Apeiron
     </a>
@@ -81,7 +68,7 @@ const repoUrl = 'https://github.com/chaos-matters/chaos-master'
     height: 24px;
     flex: none;
     border-radius: 7px;
-    filter: drop-shadow(0 0 10px rgba(123, 224, 232, 0.35));
+    filter: drop-shadow(0 0 10px rgba(255, 116, 72, 0.35));
   }
   .nav-links {
     display: flex;


### PR DESCRIPTION
Swaps the provisional infinity-ribbon favicon and nav mark for **Deep C**, the direction picked out of the scored six-direction branding pass.

### Why the old one had to go

The lemniscate is a four-stop gradient stroked at 6.5 units. It was never designed for the size a favicon is actually judged at — by 16px the gradient collapses toward a single value and the two crossing arms merge into each other, so the mark stops carrying any shape of its own.

Measured 16px legibility, as the greyscale standard deviation of the downsampled mark:

| | 16px sd |
|---|---|
| infinity ribbon | 0.245 |
| Deep C | **0.325** |

### What Deep C is

A heavy band sweeping 249 degrees with its mouth open to the west. Three ember marks drift in the mouth, the smallest already detached. Light with no source: the band has no beginning, it gathers out of the scattered samples — which is the same thing an IFS does to a point cloud.

Two flat inks, no gradients, so the silhouette does the work.

### The geometry is fitted, not eyeballed

The concept render was measured (circle fit on the outer boundary, angular occupancy for the mouth, connected components for the ember marks) and the SVG parameters were then optimised against it by coordinate descent on ink IoU.

- **99.10%** ink IoU against the chosen render (99.14% on the band, 98.89% on the marks)
- arc snapped symmetric about due west — the render's 0.39 degree tilt is an artifact, not a design decision, and dropping it costs 0.19% fidelity
- r=20.03, stroke 9.46, arc 235.62 to 124.38 degrees, mouth 111.24 degrees

### Files

- `packages/landing/public/favicon.svg` — landing favicon
- `packages/app/src/assets/favicon.svg` — app favicon
- `packages/landing/src/components/Nav.astro` — inline brand mark; the drop-shadow glow moves from the old cyan to ember
- `.claude/launch.json` — adds a `landing-dev` entry; the landing package had no preview config, which is why this needed a full build to verify

### Verification

`pnpm --filter @chaos-master/landing build` passes. In `dist/index.html`: the new arc path is present, all four ember rects survive minification, and there are zero remaining references to `navArm` / `cmArm` / `#7be0e8` / the old lemniscate path.

### Not in this PR

- No PNG or ICO fallbacks. Nothing in the repo references one today, and the SVG covers every current consumer.
- `packages/app/index.html` still sets `theme-color` to `#7928ca`, a stale purple that matches neither palette. Left alone to keep this diff to branding assets.
- The **Gathering Fold** anchor render is preserved as a live candidate in the brand kit; this PR only adopts Deep C.

A prior-art and trademark-similarity sweep across both candidates is running separately. Worth having that result before merge.