### PR TITLE
fix(replay): hold the closing step before calling the take finished

### DIFF
--- a/packages/app/src/recorder/player.test.ts
+++ b/packages/app/src/recorder/player.test.ts
@@ -7,7 +7,7 @@ import { examples } from '@/flame/examples'
 import { deepClone } from '@/utils/clone'
 import { createStoreHistory } from '@/utils/createStoreHistory'
 import { createTimelineState } from '@/utils/timeline'
-import { createSessionPlayer, MAX_STEP_GAP_MS, MIN_STEP_GAP_MS, NARRATION_MAX_HOLD_MS, NARRATION_MIN_HOLD_MS, NARRATION_MS_PER_WORD, stepGapMs, } from './player'
+import { closingHoldMs, createSessionPlayer, MAX_STEP_GAP_MS, MIN_STEP_GAP_MS, NARRATION_MAX_HOLD_MS, NARRATION_MIN_HOLD_MS, NARRATION_MS_PER_WORD, stepGapMs, } from './player'
 import { cancelSessionRecording, recordSyntheticAction, startSessionRecording, stopSessionRecording, } from './recorder'
 import { SESSION_FORMAT_VERSION } from './schema'
 import { createRecorderAwareTimeline } from './timelineActions'
@@ -299,6 +299,28 @@ describe('stepGapMs', () => {
   })
 })
 
+describe('closingHoldMs', () => {
+  it('holds a closing sentence for its reading time', () => {
+    const words = Array.from({ length: 10 }, (_, i) => `w${i}`).join(' ')
+    const note = at(0, { id: 'lesson.note', args: [words] })
+    expect(closingHoldMs(note, 1)).toBe(10 * NARRATION_MS_PER_WORD)
+    expect(closingHoldMs(note, 2)).toBe((10 * NARRATION_MS_PER_WORD) / 2)
+  })
+
+  it('asks for nothing when the last step says nothing', () => {
+    // A silent last step finishes as it always has. A default beat here would
+    // have to be added to the exporter's tail too, and at 0.5x it exceeded
+    // that tail — caught by the identity test in replayVideo.test.ts.
+    expect(closingHoldMs(at(0), 1)).toBeUndefined()
+  })
+
+  it('lets an authored hold win, and holds nothing for no take', () => {
+    expect(closingHoldMs(at(0, { holdMs: 0 }), 1)).toBe(0)
+    expect(closingHoldMs(at(0, { holdMs: 9000 }), 1)).toBe(9000)
+    expect(closingHoldMs(undefined, 1)).toBeUndefined()
+  })
+})
+
 describe('createSessionPlayer', () => {
   it('clears transient UI before opening the replay batch and loading the baseline', () => {
     createRoot((dispose) => {
@@ -407,7 +429,61 @@ describe('createSessionPlayer', () => {
 
       vi.advanceTimersByTime(MIN_STEP_GAP_MS)
       expect(flame.renderSettings.gamma).toBeCloseTo(3.5, 5)
+
+      // This take's last step says nothing, so it finishes on the tick that
+      // applied it, as it always has. A closing sentence is held instead —
+      // see 'holds a closing sentence before it finishes'.
       expect(player.isPlaying()).toBe(false)
+      dispose()
+    })
+  })
+
+  it('holds a closing sentence before it finishes', () => {
+    // The bug: the last step was applied and playback declared itself finished
+    // in the same tick, so the end card opened over the sentence the whole
+    // lesson was built to land on.
+    const words = Array.from({ length: 10 }, (_, i) => `w${i}`).join(' ')
+    const hold = 10 * NARRATION_MS_PER_WORD
+    const closing = makeSession([
+      { t: 0, id: 'flame.setGamma', args: [1.5], label: 'Set Gamma' },
+      { t: 900, id: 'lesson.note', args: [words], label: words },
+    ])
+    createRoot((dispose) => {
+      const { target } = makeTarget(examples.initExample)
+      const player = createSessionPlayer(closing, target)
+      player.play()
+      vi.advanceTimersByTime(0)
+      // The recorded 900ms gap is above the floor, so it is used as recorded.
+      vi.advanceTimersByTime(900)
+      expect(player.stepIndex()).toBe(1)
+
+      expect(player.isPlaying()).toBe(true)
+      expect(player.isFinished()).toBe(false)
+      vi.advanceTimersByTime(hold - 1)
+      expect(player.isFinished()).toBe(false)
+      vi.advanceTimersByTime(1)
+      expect(player.isPlaying()).toBe(false)
+      expect(player.isFinished()).toBe(true)
+      dispose()
+    })
+  })
+
+  it('drops the closing hold when the viewer pauses inside it', () => {
+    const words = Array.from({ length: 10 }, (_, i) => `w${i}`).join(' ')
+    const closing = makeSession([
+      { t: 0, id: 'flame.setGamma', args: [1.5], label: 'Set Gamma' },
+      { t: 900, id: 'lesson.note', args: [words], label: words },
+    ])
+    createRoot((dispose) => {
+      const { target } = makeTarget(examples.initExample)
+      const player = createSessionPlayer(closing, target)
+      player.play()
+      vi.advanceTimersByTime(0)
+      vi.advanceTimersByTime(900)
+      player.pause()
+      vi.advanceTimersByTime(60_000)
+      // Paused inside the hold is paused, not finished: the viewer took over.
+      expect(player.isFinished()).toBe(false)
       dispose()
     })
   })

--- a/packages/app/src/recorder/player.ts
+++ b/packages/app/src/recorder/player.ts
@@ -117,6 +117,31 @@ function narrationHoldMs(text: string): number {
 }
 
 /**
+ * How long to hold the LAST step before playback calls itself finished.
+ *
+ * Every other step is held by the gap before the step that follows it. The
+ * last one has no successor, so it was applied and playback declared itself
+ * finished in the same tick — the end card opened over the sentence the whole
+ * lesson was built to land on. The video exporter already grew its tail for
+ * exactly this; this is the same beat for the live player, and it is the same
+ * function so the two cannot disagree.
+ *
+ * Only a hold the take itself asked for — an authored `holdMs`, or the reading
+ * time of a closing sentence. A silent last step finishes as it always has: a
+ * default beat here would have to be added to the exporter's tail as well, and
+ * at 0.5x it exceeded that tail and ran the interface capture past the
+ * duration its own schedule validated the encoder budget against.
+ */
+export function closingHoldMs(
+  last: RecordedAction | undefined,
+  speed: number,
+): number | undefined {
+  if (!last) return undefined
+  if (last.holdMs !== undefined) return last.holdMs / speed
+  return narrationHoldFor(last, speed)
+}
+
+/**
  * How long to wait before applying `next` — which is the dwell on `previous`.
  *
  * That inversion is the whole subtlety here, and getting it wrong is what made
@@ -420,13 +445,29 @@ export function createSessionPlayer(
     )
   }
 
+  function finish() {
+    setIsPlaying(false)
+    setIsFinished(true)
+    closeBatch()
+    options.onFinished?.()
+  }
+
   function scheduleNext() {
     const next = stepIndex() + 1
     if (next >= actions.length) {
-      setIsPlaying(false)
-      setIsFinished(true)
-      closeBatch()
-      options.onFinished?.()
+      // Hold the last step before finishing, rather than finishing on the same
+      // tick that applied it. `isPlaying` stays true through the hold, because
+      // it is still playing — the final beat — so Pause cancels it like any
+      // other gap.
+      const hold = closingHoldMs(actions.at(-1), speed()) ?? 0
+      if (hold <= 0) {
+        finish()
+        return
+      }
+      timer = setTimeout(() => {
+        if (!isPlaying()) return
+        finish()
+      }, hold)
       return
     }
     timer = setTimeout(() => {

--- a/packages/app/src/recorder/replayInterfaceVideo.ts
+++ b/packages/app/src/recorder/replayInterfaceVideo.ts
@@ -1,6 +1,7 @@
 import { deepClone } from '@/utils/clone'
 import { createMetadataPayload, injectMetadataIntoMp4, } from '@/utils/flameInMp4'
 import { createVideoEncoder } from '@/utils/videoEncoder'
+import { closingHoldMs } from './player'
 import { createReplayVideoSchedule, MAX_REPLAY_VIDEO_DURATION_MS, REPLAY_VIDEO_FPS, REPLAY_VIDEO_LEAD_IN_MS, replayVideoInitialTimelineSnapshot, } from './replayVideo'
 import { validateSession } from './schema'
 import type { RecordedSession } from './schema'
@@ -385,10 +386,17 @@ export async function captureReplayInterfaceVideo(
     request.prepareReplay()
     await waitFor(REPLAY_VIDEO_LEAD_IN_MS, controller.signal)
     await request.playReplay(controller.signal)
-    // The schedule's tail, not the constant: a closing narration step holds
-    // for its reading time, and waiting the flat tail cut the last sentence
-    // off mid-read while the artwork export showed all of it.
-    await waitFor(schedule.tailMs, controller.signal)
+    // Only the REMAINDER of the tail. This mode records the live player, and
+    // the player now holds the last step itself before resolving, so waiting
+    // the whole tail on top would hold the closing sentence twice and run the
+    // capture past the duration the schedule validated the encoder budget
+    // against. What is left over is the beat the end card gets.
+    const heldByPlayer =
+      closingHoldMs(session.actions.at(-1), request.playbackSpeed) ?? 0
+    await waitFor(
+      Math.max(0, schedule.tailMs - heldByPlayer),
+      controller.signal,
+    )
     completed = true
     captureOpen = false
     await sampling

--- a/packages/app/src/recorder/replayVideo.test.ts
+++ b/packages/app/src/recorder/replayVideo.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { examples } from '@/flame/examples'
 import { deepClone } from '@/utils/clone'
-import { NARRATION_MS_PER_WORD } from './player'
+import { closingHoldMs, NARRATION_MS_PER_WORD } from './player'
 import { createReplayVideoDriver, createReplayVideoJobSpec, createReplayVideoSchedule, drawReplayVideoOverlay, MAX_REPLAY_VIDEO_DURATION_MS, REPLAY_VIDEO_DIMENSIONS, REPLAY_VIDEO_FPS, REPLAY_VIDEO_TAIL_MS, replayActionIndexAtFrame, replayFramesInStateRun, replayVideoFileName, replayVideoVisualFingerprint, } from './replayVideo'
 import { SESSION_FORMAT_VERSION } from './schema'
 import type { RecordedAction, RecordedSession } from './schema'
@@ -286,6 +286,31 @@ describe('replay video tail', () => {
     expect(createReplayVideoSchedule(quiet, 1).tailMs).toBe(
       REPLAY_VIDEO_TAIL_MS,
     )
+  })
+
+  // The live player now holds the last step itself, and the interface capture
+  // waits only the remainder. This identity is what keeps that mode inside the
+  // duration its own schedule validated the encoder budget against.
+  it('always covers the hold the live player will take', () => {
+    const words = Array.from({ length: 12 }, (_, i) => `w${i}`).join(' ')
+    const endings = [
+      { t: 2000, id: 'lesson.note', args: [words] },
+      { t: 2000, id: 'flame.setGamma', args: [2] },
+      { t: 2000, id: 'flame.setGamma', args: [2], holdMs: 30_000 },
+    ]
+    for (const ending of endings) {
+      for (const speed of [0.5, 1, 2, 4]) {
+        const session = makeSession([
+          { t: 0, id: 'flame.setGamma', args: [1.5] },
+          ending,
+        ])
+        const schedule = createReplayVideoSchedule(session, speed)
+        const held = closingHoldMs(session.actions.at(-1), speed) ?? 0
+        expect(schedule.tailMs).toBeGreaterThanOrEqual(held)
+        // player hold + capture wait === the tail the schedule budgeted for
+        expect(held + Math.max(0, schedule.tailMs - held)).toBe(schedule.tailMs)
+      }
+    }
   })
 })
 

--- a/packages/app/src/recorder/replayVideo.ts
+++ b/packages/app/src/recorder/replayVideo.ts
@@ -9,7 +9,7 @@ import { tryValidateFlame } from '@/flame/schema/flameSchema'
 import { defaultTimelineConfig } from '@/flame/schema/timeline'
 import { deepClone } from '@/utils/clone'
 import { applyTracksToFlame, getUserEndFrame, loopOptsFromConfig, resolveLoopValue, } from '@/utils/timeline'
-import { narrationHoldFor, stepGapMs } from './player'
+import { closingHoldMs, stepGapMs } from './player'
 import { paletteRestoreColorsAfterReplayCommand } from './replayPaletteState'
 import { validateSession } from './schema'
 import type { RecordedAction, RecordedSession, SessionViewSnapshot, TransformColorSnapshot, } from './schema'
@@ -414,12 +414,13 @@ export function createReplayVideoSchedule(
   const finalActionTime = actionTimesMs.at(-1) ?? spec.leadInMs
   // A closing sentence has no step after it to be the dwell on, so it would
   // otherwise get the bare tail — on the one line the lesson was building to.
-  const closing = session.actions.at(-1)
+  // The same hold the live player gives its last step, so the two agree for
+  // an authored `holdMs` as well as for a closing sentence — and so the
+  // interface capture, which waits the remainder, always adds up to exactly
+  // this.
   const effectiveTailMs = Math.max(
     spec.tailMs,
-    (closing === undefined
-      ? undefined
-      : narrationHoldFor(closing, spec.playbackSpeed)) ?? 0,
+    closingHoldMs(session.actions.at(-1), spec.playbackSpeed) ?? 0,
   )
   const durationMs = Math.max(cursor, finalActionTime) + effectiveTailMs
   if (durationMs > MAX_REPLAY_VIDEO_DURATION_MS) {


### PR DESCRIPTION
Reported from a real replay: the last step's narration wasn't held — the take auto-closed straight after step 30.

## The cause

Every step is held by the gap *before the step that follows it*. The last one has no successor, so `scheduleNext` applied it and ran the finish path **on the same tick** — zero dwell. The end card opened over the sentence the whole lesson was built to land on.

The video tail already solved this for the exports (#156). The live player never had the equivalent.

## The fix

`closingHoldMs` is that hold, and all three consumers share it rather than each deciding:

- **The player** waits it before finishing. `isPlaying` stays true through the hold, because it *is* still playing — the final beat — so Pause cancels it like any other gap and a viewer who takes over mid-sentence isn't finished for them.
- **The schedule's tail** is now `max(requestedTail, closingHoldMs)`, so an authored `holdMs` on the last action is honoured in an export too. It only grew for a closing *sentence* before — a divergence raised in #156's review and refuted as pre-existing, which it was; adding the shared function is what makes fixing it free.
- **The interface capture** records the live player, so it waits only the **remainder**. Without that it would hold the sentence twice and run past the duration its own schedule validated the encoder budget against.

## What I deliberately didn't do

A silent last step finishes exactly as it always has. Giving it a default beat read nicer, and I wrote it that way first — but it has to be added to the exporter's tail as well, and **at 0.5× it exceeded that tail by 200 ms**, which would have run the interface capture past its validated duration. The identity test below is what caught it; the beat isn't worth the coupling.

## Verification

- 165 files / **2091 tests**; typecheck clean; lint clean apart from the pre-existing `AncestryTreeModal.tsx` warning.
- **Mutation-checked**: forcing the hold to 0 fails two tests (`expected false to be true`).
- New tests: the closing sentence is held for its reading time and not a tick less; pausing inside the hold leaves the take paused, not finished; `closingHoldMs` honours an authored hold, scales with speed, and asks for nothing when the step says nothing.
- An identity test over three endings (narration, silent, authored 30 s hold) × four speeds asserts `playerHold + captureWait === schedule.tailMs` — the invariant that keeps the capture inside its budget. It failed on the first attempt at 0.5×, which is how the default-beat problem was found.