### PR TITLE
docs(brand): retire "formerly Chaos Master" and correct the Teach topic count

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -56,7 +56,11 @@ attested server executor is a future extension.
 
 ## Brand Commitments
 
-The public product name is **Lumen Apeiron**, formerly **Chaos Master**. Existing
+The public product name is **Lumen Apeiron**, on its own or in full as
+**Lumen Apeiron — The Chaos Master**. Do not write "formerly Chaos Master" in
+user-facing copy: the rename is finished, and carrying the old name forward
+reads as an apology for it. `chaos-master` survives as the repository, package
+and worker name — an identifier, not a product name. Existing
 flame, attractor, and controlled-chaos language may remain where it helps users
 understand the renderer. The interface should feel like a precise creative
 instrument, not a generic gaming benchmark or an astronomy-themed dashboard.

--- a/docs/webmcp.md
+++ b/docs/webmcp.md
@@ -70,9 +70,10 @@ No tool writes `ctx.setFlameDescriptor` or `ctx.timeline.setTracks` directly.
 `https://lumenapeiron.com/arcade` (the worker sends `/arcade` to the SPA as
 `#arcade`; `#arcade=teach|cinema|duel|beats` deep-links a panel).
 
-- **Teach** — pick one of four topics (`variations`, `affine`, `color`,
-  `camera`). The agent gets a brief with the goal, the allowed commands and
-  their exact argument shapes, and a step budget. It narrates through
+- **Teach** — pick one of seven topics (`variations`, `affine`, `color`,
+  `camera`, `genetics`, `sonification`, `render`). The agent gets a brief with
+  the goal, the allowed commands and their exact argument shapes, and a step
+  budget. It narrates through
   `arcade_narrate` (a real `lesson.note` command, so the sentence replays as a
   caption between the edits it describes) and builds the example with
   `execute_command`. The recording is saved as `Lesson: <Topic> — <title>`.

--- a/packages/app/CHANGELOG.md
+++ b/packages/app/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
-What's new in Lumen Apeiron (formerly Chaos Master). Concise highlights for
-each release; the full developer history lives in `dev.changelog.md`.
+What's new in Lumen Apeiron. Concise highlights for each release; the full
+developer history lives in `dev.changelog.md`.
 
 ## [Unreleased]
 

--- a/packages/app/index.html
+++ b/packages/app/index.html
@@ -3,12 +3,12 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#7928ca" />
+    <meta name="theme-color" content="#080A0E" />
     <link rel="icon" type="image/svg+xml" href="/src/assets/favicon.svg" />
     <title>Lumen Apeiron — WebGPU Fractal Flame Editor</title>
     <meta
       name="description"
-      content="Create, explore, and animate IFS fractal flames in real time with Lumen Apeiron (formerly Chaos Master) — a free, GPU-accelerated fractal flame editor that runs entirely in your browser with WebGPU."
+      content="Create, explore, and animate IFS fractal flames in real time with Lumen Apeiron — a free, GPU-accelerated fractal flame editor that runs entirely in your browser with WebGPU."
     />
     <link rel="canonical" href="https://lumenapeiron.com/" />
 
@@ -54,11 +54,10 @@
     <noscript>
       <h1>Lumen Apeiron — WebGPU Fractal Flame Editor</h1>
       <p>
-        Lumen Apeiron (formerly Chaos Master) is a free, GPU-accelerated tool
-        for creating, exploring, and animating IFS fractal flames in real time —
-        running entirely in your browser with WebGPU. Enable JavaScript and open
-        it in a WebGPU-capable browser (Chrome / Edge 113+, Safari 17+) to
-        launch the editor.
+        Lumen Apeiron is a free, GPU-accelerated tool for creating, exploring,
+        and animating IFS fractal flames in real time — running entirely in your
+        browser with WebGPU. Enable JavaScript and open it in a WebGPU-capable
+        browser (Chrome / Edge 113+, Safari 17+) to launch the editor.
       </p>
       <p>
         <a href="https://about.lumenapeiron.com/"


### PR DESCRIPTION
Small copy and docs corrections to the app, ahead of the prod tag. No behaviour changes.

### The rename is finished

`Lumen Apeiron (formerly Chaos Master)` was still live in three places the user actually sees:

- `packages/app/index.html` — the meta description search engines and link previews read
- the same file's `<noscript>` body copy
- `packages/app/CHANGELOG.md`'s header, which `AboutPanel/Changelog.tsx` imports `?raw` and renders in the About panel

All three now just say **Lumen Apeiron**. `PRODUCT.md` states the rule rather than the history: the name is *Lumen Apeiron*, or in full *Lumen Apeiron — The Chaos Master*, and `chaos-master` survives only as a repository, package and worker identifier.

### theme-color

Was `#7928ca` — a purple matching neither the old palette nor the new one. Now `#080A0E`, the brand void the Deep C mark sits on, so mobile browser chrome agrees with the page.

### Teach topic count

`docs/webmcp.md` said four topics. `packages/app/src/arcade/topics.ts` has seven — `variations`, `affine`, `color`, `camera`, `genetics`, `sonification`, `render`. Corrected. This matters because the doc is the "How it works" link target from the Arcade hub.

### Deliberately not touched

**The Arcade mode list and the tool catalogue in `docs/webmcp.md`.** [#153](https://github.com/chaos-matters/chaos-master/pull/153) already rewrites both (+60/−9) with a thorough Duel section, and editing the same lines here would only conflict with it. Once #153 merges, that file reads exactly as intended: Teach, Cinema and Duel live, Beats, Arena and Director on the hub as roadmap cards — three of six.

One thing to fix **in #153**, not here: its version of the doc says *"32 tools are registered"*. `allTools` on that branch has **33** — main's 30 plus `arcadeStartDuel`, `arcadeDuelReady` and `arcadeEndDuel`. The catalogue table lists only the first two (`arcade_end_duel` exists solely to refuse), which is probably where the 32 came from.

### Still carrying the old name, for the landing PR

- `packages/landing/src/components/Hero.astro:27` — visible hero copy
- `packages/landing/src/layouts/Base.astro:14` — default meta description

Historical changelog entries in both packages keep the old name; they are a record of what shipped.