### PR TITLE
feat(arcade): a ring follows the AI's hand while it drives

### DIFF
--- a/packages/app/src/MainWorkspace.tsx
+++ b/packages/app/src/MainWorkspace.tsx
@@ -7846,7 +7846,7 @@ export function MainWorkspace(props: AppProps) {
             })()}
           </Show>
 
-          <PilotOverlay ctx={cmdContext} />
+          <PilotOverlay ctx={cmdContext} onPrepareFocus={prepareReplayFocus} />
 
           <Show when={showArena()}>
             <ArenaOverlay

--- a/packages/app/src/arcade/pilot.ts
+++ b/packages/app/src/arcade/pilot.ts
@@ -1,4 +1,5 @@
 import { createSignal } from 'solid-js'
+import { clearPilotFocus } from './pilotFocus'
 import type { RecordedSession } from '@/recorder/schema'
 
 /**
@@ -161,6 +162,7 @@ export function notePilotSaveResult(saved: boolean): void {
 
 export function resetPilot(): void {
   setPilot({ phase: 'idle' })
+  clearPilotFocus()
   setPilotLog([])
   setLastPilotSession(undefined)
 }

--- a/packages/app/src/arcade/pilotActions.ts
+++ b/packages/app/src/arcade/pilotActions.ts
@@ -1,5 +1,6 @@
 import { clearNarration } from './narration'
 import { appendPilotLog, drivingState, endPilot, notePilotSaveResult, } from './pilot'
+import { clearPilotFocus } from './pilotFocus'
 import { isTopicId, LESSON_TOPICS } from './topics'
 import type { PilotDriving, PilotEnded, PilotEndReason } from './pilot'
 import type { CommandContext } from '@/commands/types'
@@ -44,6 +45,7 @@ export async function finishPilot(
   const session = ctx.recorder?.stop()
   const sessionName = session ? sessionNameFor(state, title, reason) : undefined
   clearNarration()
+  clearPilotFocus()
   // Leave `driving` in the same tick the recorder stops. Awaiting the save
   // first left a window in which the guard still said "driving" while nothing
   // was being recorded, so a tool call landing there ran and counted a step

--- a/packages/app/src/arcade/pilotFocus.ts
+++ b/packages/app/src/arcade/pilotFocus.ts
@@ -1,0 +1,38 @@
+import { createSignal } from 'solid-js'
+import type { RecordedAction } from '@/recorder/schema'
+
+/**
+ * The AI's latest step, in the shape replay reads, for the live spotlight.
+ *
+ * It carries the whole action rather than just a hint because that is what
+ * `deriveReplayFocusPreparation` reads: the id and args decide which panel to
+ * open, which transform to select and which affine tab to show, and a hint
+ * alone cannot say. Handing over the same action the recorder writes is what
+ * makes the live view and the replay of the same take reveal the same UI.
+ */
+export type PilotFocusStep = {
+  readonly action: RecordedAction
+  readonly label: string
+  readonly seq: number
+}
+
+const [pilotFocus, setPilotFocus] = createSignal<PilotFocusStep | undefined>()
+export { pilotFocus }
+
+let sequence = 0
+
+/**
+ * One agent step happened. `action` is the same record the recorder appends,
+ * `focus` included; a step the focus vocabulary cannot place still counts, so
+ * the overlay can retire the previous ring on its own schedule instead of
+ * having it snapped away mid-dwell.
+ */
+export function notePilotFocus(action: RecordedAction, label: string): void {
+  sequence += 1
+  setPilotFocus({ action, label, seq: sequence })
+}
+
+/** No agent is driving any more: drop the ring now, dwell or no dwell. */
+export function clearPilotFocus(): void {
+  setPilotFocus(undefined)
+}

--- a/packages/app/src/components/Arcade/PilotOverlay.test.tsx
+++ b/packages/app/src/components/Arcade/PilotOverlay.test.tsx
@@ -1,9 +1,10 @@
 import { cleanup, render, screen } from '@solidjs/testing-library'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { endPilot, notePilotSaveResult, resetPilot, startPilot, } from '@/arcade/pilot'
+import { clearPilotFocus, notePilotFocus } from '@/arcade/pilotFocus'
 import { createMockCommandContext } from '@/webmcp/testUtils'
 import { PilotOverlay } from './PilotOverlay'
-import type { RecordedSession } from '@/recorder/schema'
+import type { RecordedAction, RecordedSession } from '@/recorder/schema'
 
 const take = {
   version: 1,
@@ -107,5 +108,92 @@ describe('PilotOverlay end card', () => {
     expect(
       screen.getByText('Saved to your library as "Lesson: Colour and tone"'),
     ).toBeTruthy()
+  })
+})
+
+/**
+ * The ring belongs to the lock, not to the app: it exists exactly as long as
+ * the AI holds the controls. One left behind on the end card would point at a
+ * control the viewer can now touch.
+ */
+describe('PilotOverlay live spotlight', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) =>
+      setTimeout(() => {
+        cb(globalThis.performance.now())
+      }, 16),
+    )
+    vi.stubGlobal('cancelAnimationFrame', (id: number) => {
+      clearTimeout(id)
+    })
+    const control = document.createElement('div')
+    control.setAttribute('data-parameter-path', 'gamma')
+    control.getBoundingClientRect = () => ({
+      x: 40,
+      y: 60,
+      width: 200,
+      height: 24,
+      left: 40,
+      top: 60,
+      right: 240,
+      bottom: 84,
+      toJSON: () => ({}),
+    })
+    document.body.append(control)
+  })
+
+  afterEach(() => {
+    cleanup()
+    resetPilot()
+    clearPilotFocus()
+    document.body.innerHTML = ''
+    vi.unstubAllGlobals()
+    vi.useRealTimers()
+  })
+
+  function step(focus: string): RecordedAction {
+    return { t: 0, id: 'pilot.test', args: [], focus }
+  }
+
+  function ring(): HTMLElement | null {
+    return document.querySelector('[aria-hidden="true"][style*="left"]')
+  }
+
+  function startTeach() {
+    startPilot({
+      mode: 'teach',
+      topic: 'color',
+      title: 'Teaching: Colour and tone',
+      stepBudget: 25,
+      allowed: ['flame.'],
+      qualityRankAtStart: 1,
+    })
+  }
+
+  it('rings the control a step moved while the AI drives', () => {
+    startTeach()
+    render(() => <PilotOverlay ctx={createMockCommandContext()} />)
+
+    notePilotFocus(step('param:gamma'), 'Gamma: 2.4')
+    vi.advanceTimersByTime(200)
+
+    expect(ring()?.style.left).toBe('40px')
+  })
+
+  it('takes the ring down with the lock', () => {
+    startTeach()
+    render(() => <PilotOverlay ctx={createMockCommandContext()} />)
+    notePilotFocus(step('param:gamma'), 'Gamma: 2.4')
+    vi.advanceTimersByTime(200)
+    expect(ring()).not.toBeNull()
+
+    endPilot('stopped', {
+      title: 'Warm tones',
+      sessionName: 'Lesson: Colour and tone',
+      session: take,
+    })
+
+    expect(ring()).toBeNull()
   })
 })

--- a/packages/app/src/components/Arcade/PilotOverlay.tsx
+++ b/packages/app/src/components/Arcade/PilotOverlay.tsx
@@ -4,8 +4,10 @@ import { finishPilot } from '@/arcade/pilotActions'
 import { Robot, Stop } from '@/icons'
 import { formatElapsed, reasonLabel, savedLine } from './pilotFormat'
 import ui from './PilotOverlay.module.css'
+import { PilotSpotlight } from './PilotSpotlight'
 import type { PilotEnded } from '@/arcade/pilot'
 import type { CommandContext } from '@/commands/types'
+import type { ReplayFocusPreparationHandler } from '@/recorder/focusPreparation'
 
 const ESC_ARM_MS = 1500
 
@@ -15,7 +17,10 @@ const ESC_ARM_MS = 1500
  * take and still saves it. When the pilot ends, the same component shows the
  * end card with Replay / Back to Arcade.
  */
-export function PilotOverlay(props: { ctx: CommandContext }) {
+export function PilotOverlay(props: {
+  ctx: CommandContext
+  onPrepareFocus?: ReplayFocusPreparationHandler
+}) {
   const [escArmed, setEscArmed] = createSignal(false)
   const [elapsed, setElapsed] = createSignal(0)
   let escTimer: number | undefined
@@ -133,6 +138,9 @@ export function PilotOverlay(props: { ctx: CommandContext }) {
             </div>
           </div>
         )}
+      </Show>
+      <Show when={agentDriving()}>
+        <PilotSpotlight onPrepareFocus={props.onPrepareFocus} />
       </Show>
       <Show when={ended()}>
         {(end) => (

--- a/packages/app/src/components/Arcade/PilotSpotlight.module.css
+++ b/packages/app/src/components/Arcade/PilotSpotlight.module.css
@@ -1,0 +1,45 @@
+/* Above the pilot lock (10010), because it points AT the locked editor. It
+   never swallows input: the lock below it is what does that, and a ring that
+   ate clicks would change what Stop and Esc can reach. */
+.ring {
+  position: fixed;
+  z-index: 10011;
+  pointer-events: none;
+  border-radius: 8px;
+  box-shadow:
+    0 0 0 2px rgba(138, 180, 255, 0.9),
+    0 0 0 6px rgba(138, 180, 255, 0.22),
+    0 0 22px rgba(138, 180, 255, 0.35);
+  transition:
+    left 0.22s ease,
+    top 0.22s ease,
+    width 0.22s ease,
+    height 0.22s ease;
+}
+
+/* The ring says where; this says what. Positioned above the control so it does
+   not cover the value that just changed. */
+.label {
+  position: absolute;
+  bottom: calc(100% + 6px);
+  left: 0;
+  max-width: 22rem;
+  width: max-content;
+  padding: 3px 9px;
+  border-radius: 999px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: rgba(255, 255, 255, 0.92);
+  font:
+    11px system-ui,
+    sans-serif;
+  background: rgba(10, 14, 24, 0.88);
+  border: 1px solid rgba(138, 180, 255, 0.35);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ring {
+    transition: none;
+  }
+}

--- a/packages/app/src/components/Arcade/PilotSpotlight.test.tsx
+++ b/packages/app/src/components/Arcade/PilotSpotlight.test.tsx
@@ -1,0 +1,226 @@
+import { cleanup, render } from '@solidjs/testing-library'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { clearPilotFocus, notePilotFocus } from '@/arcade/pilotFocus'
+import { PilotSpotlight } from './PilotSpotlight'
+import type { ReplayFocusPreparation } from '@/recorder/focusPreparation'
+import type { RecordedAction } from '@/recorder/schema'
+
+/**
+ * The live spotlight's contract: while the AI drives, a ring says WHICH
+ * control each step moved, resolved through the same hints replay uses. It
+ * must survive an agent that fires its steps as fast as its tool loop allows
+ * — six inside 26ms in a real lesson — without turning into a strobe.
+ */
+
+/**
+ * One agent step. The id is deliberately unknown to the focus table, so these
+ * tests drive the ring from the hint alone; the derivation from a real command
+ * id gets its own test below.
+ */
+function step(focus: string | undefined): RecordedAction {
+  return { t: 0, id: 'pilot.test', args: [], focus }
+}
+
+/** Give a control a size, so `resolveFocusElement` accepts it in jsdom. */
+function sized(element: HTMLElement, box: Partial<DOMRect> = {}): HTMLElement {
+  const rect = { x: 10, y: 20, width: 120, height: 30, ...box }
+  element.getBoundingClientRect = () => ({
+    ...rect,
+    left: rect.x,
+    top: rect.y,
+    right: rect.x + rect.width,
+    bottom: rect.y + rect.height,
+    toJSON: () => rect,
+  })
+  return element
+}
+
+function control(path: string, box?: Partial<DOMRect>): HTMLElement {
+  const element = document.createElement('div')
+  element.setAttribute('data-parameter-path', path)
+  document.body.append(element)
+  return sized(element, box)
+}
+
+function ring(): HTMLElement | null {
+  return document.querySelector('[aria-hidden="true"][style*="left"]')
+}
+
+/** Run every timer and the frame the tracker schedules after it. */
+function settle(ms: number): void {
+  vi.advanceTimersByTime(ms)
+}
+
+describe('PilotSpotlight', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    // Frame callbacks run as timers so the rect tracker advances in step with
+    // the settle timeout instead of hanging on a real vsync jsdom never fires.
+    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) =>
+      setTimeout(() => {
+        cb(globalThis.performance.now())
+      }, 16),
+    )
+    vi.stubGlobal('cancelAnimationFrame', (id: number) => {
+      clearTimeout(id)
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+    clearPilotFocus()
+    document.body.innerHTML = ''
+    vi.unstubAllGlobals()
+    vi.useRealTimers()
+  })
+
+  it('rings the control the step moved, where that control actually is', () => {
+    control('gamma', { x: 40, y: 60, width: 200, height: 24 })
+    render(() => <PilotSpotlight />)
+
+    notePilotFocus(step('param:gamma'), 'Set Gamma 2.4')
+    settle(200)
+
+    const frame = ring()
+    expect(frame).not.toBeNull()
+    expect(frame?.style.left).toBe('40px')
+    expect(frame?.style.top).toBe('60px')
+    expect(frame?.style.width).toBe('200px')
+    expect(frame?.style.height).toBe('24px')
+    expect(frame?.textContent).toBe('Set Gamma 2.4')
+  })
+
+  it('opens whatever has to be open before it measures', () => {
+    const prepared: ReplayFocusPreparation[] = []
+    control('transform.t1.probability')
+    render(() => (
+      <PilotSpotlight onPrepareFocus={(p) => void prepared.push(p)} />
+    ))
+
+    notePilotFocus(step('param:transform.t1.probability'), 'Set Weight t1 0.50')
+    settle(200)
+
+    // The same preparation replay derives, so the live view and the replay of
+    // the same take reveal the same panels.
+    expect(prepared).toHaveLength(1)
+    expect(prepared[0]?.sidebar).toBeDefined()
+  })
+
+  it('scrolls the control into view before ringing it', () => {
+    const element = control('gamma')
+    const scrolled = vi.spyOn(Element.prototype, 'scrollIntoView')
+    render(() => <PilotSpotlight />)
+
+    notePilotFocus(step('param:gamma'), 'Set Gamma 2.4')
+    settle(200)
+
+    // A control scrolled out of a sidebar would otherwise get a ring drawn
+    // over whatever happens to sit at its stale coordinates.
+    expect(scrolled.mock.instances).toContain(element)
+    scrolled.mockRestore()
+  })
+
+  it('holds one ring through a burst and lands on the last step', () => {
+    control('gamma', { x: 40, y: 60 })
+    control('exposure', { x: 300, y: 90 })
+    control('contrast', { x: 500, y: 120 })
+    render(() => <PilotSpotlight />)
+
+    // An agent's three tool calls inside a single frame.
+    notePilotFocus(step('param:gamma'), 'Set Gamma 2.4')
+    notePilotFocus(step('param:exposure'), 'Set Exposure 0.42')
+    notePilotFocus(step('param:contrast'), 'Set Contrast 1.1')
+    settle(200)
+
+    // First ring stays put: retargeting three times in 0ms is a strobe.
+    expect(ring()?.style.left).toBe('40px')
+
+    // When its dwell expires the ring goes to the LAST step, never the middle
+    // one — the agent's final position is the one worth showing.
+    settle(800)
+    expect(ring()?.style.left).toBe('500px')
+  })
+
+  it('retires the ring for a step no hint can place', () => {
+    control('gamma')
+    render(() => <PilotSpotlight />)
+
+    notePilotFocus(step('param:gamma'), 'Set Gamma 2.4')
+    settle(200)
+    expect(ring()).not.toBeNull()
+
+    notePilotFocus(step(undefined), 'Saved the flame')
+    settle(1000)
+    // Leaving the ring where it was would claim the AI touched gamma again.
+    expect(ring()).toBeNull()
+  })
+
+  it('drops the ring the moment the pilot ends, dwell or no dwell', () => {
+    control('gamma')
+    render(() => <PilotSpotlight />)
+
+    notePilotFocus(step('param:gamma'), 'Set Gamma 2.4')
+    settle(200)
+    expect(ring()).not.toBeNull()
+
+    clearPilotFocus()
+    expect(ring()).toBeNull()
+  })
+
+  it('says nothing rather than framing a control that is not on screen', () => {
+    render(() => <PilotSpotlight />)
+
+    notePilotFocus(step('param:nowhere'), 'Set Something 1')
+    settle(1000)
+
+    expect(ring()).toBeNull()
+  })
+
+  it('derives the target from the command, not just the saved hint', () => {
+    control('gamma', { x: 40, y: 60 })
+    render(() => <PilotSpotlight />)
+
+    // No `focus` on the action at all: the id and args are enough, which is
+    // what lets the live ring and replay agree about an old session whose
+    // hints predate the current vocabulary.
+    notePilotFocus({ t: 0, id: 'flame.setGamma', args: [2.4] }, 'Set Gamma 2.4')
+    settle(200)
+
+    expect(ring()?.style.left).toBe('40px')
+  })
+
+  it('points at the list when the row it named is gone', () => {
+    const list = document.createElement('div')
+    list.setAttribute('data-tour-target', 'transform-list')
+    document.body.append(list)
+    sized(list, { x: 12, y: 300, width: 260, height: 400 })
+    render(() => <PilotSpotlight />)
+
+    // The action still names the transform it deleted. Ringing that row would
+    // frame a control that no longer exists, so the derivation moves up to the
+    // list — the same upgrade replay applies.
+    notePilotFocus(
+      { t: 0, id: 'flame.removeTransform', args: ['t1'], focus: 'focus:tx:t1' },
+      'Delete transform t1',
+    )
+    settle(200)
+
+    expect(ring()?.style.left).toBe('12px')
+    expect(ring()?.style.height).toBe('400px')
+  })
+
+  it('follows a control that moves while the ring is on it', () => {
+    const element = control('gamma', { x: 40, y: 60 })
+    render(() => <PilotSpotlight />)
+
+    notePilotFocus(step('param:gamma'), 'Set Gamma 2.4')
+    settle(200)
+    expect(ring()?.style.left).toBe('40px')
+
+    // A panel opening above it, a sidebar scrolling: the ring has to keep up
+    // or it points at empty space.
+    sized(element, { x: 240, y: 60 })
+    settle(100)
+    expect(ring()?.style.left).toBe('240px')
+  })
+})

--- a/packages/app/src/components/Arcade/PilotSpotlight.test.tsx
+++ b/packages/app/src/components/Arcade/PilotSpotlight.test.tsx
@@ -189,6 +189,22 @@ describe('PilotSpotlight', () => {
     expect(ring()).toBeNull()
   })
 
+  it('waits for a control that has not mounted yet', () => {
+    render(() => <PilotSpotlight />)
+
+    notePilotFocus(step('param:gamma'), 'Gamma: 2.4')
+    settle(200)
+    // The card is still opening: nothing to point at on the first look.
+    expect(ring()).toBeNull()
+
+    control('gamma', { x: 40, y: 60 })
+    settle(100)
+
+    // Giving up on the first miss would mean no ring at all for every control
+    // that mounts with its card, which is most of the sidebar.
+    expect(ring()?.style.left).toBe('40px')
+  })
+
   it('says nothing rather than framing a control that is not on screen', () => {
     render(() => <PilotSpotlight />)
 

--- a/packages/app/src/components/Arcade/PilotSpotlight.test.tsx
+++ b/packages/app/src/components/Arcade/PilotSpotlight.test.tsx
@@ -141,6 +141,28 @@ describe('PilotSpotlight', () => {
     expect(ring()?.style.left).toBe('500px')
   })
 
+  it('never wears the next step\u2019s caption on the last step\u2019s ring', () => {
+    control('gamma', { x: 40, y: 60 })
+    control('contrast', { x: 500, y: 120 })
+    render(() => <PilotSpotlight />)
+
+    notePilotFocus(step('param:gamma'), 'Gamma: 2.4')
+    settle(1000)
+    expect(ring()?.textContent).toBe('Gamma: 2.4')
+
+    notePilotFocus(step('param:contrast'), 'Contrast: 1.1')
+    // The panel the next control lives in may take a moment to open, and the
+    // ring cannot move until it has. Relabelling first put the new caption on
+    // the old box, which reads as the AI pointing at the wrong control.
+    settle(50)
+    expect(ring()?.style.left).toBe('40px')
+    expect(ring()?.textContent).toBe('Gamma: 2.4')
+
+    settle(200)
+    expect(ring()?.style.left).toBe('500px')
+    expect(ring()?.textContent).toBe('Contrast: 1.1')
+  })
+
   it('retires the ring for a step no hint can place', () => {
     control('gamma')
     render(() => <PilotSpotlight />)

--- a/packages/app/src/components/Arcade/PilotSpotlight.tsx
+++ b/packages/app/src/components/Arcade/PilotSpotlight.tsx
@@ -71,12 +71,12 @@ export function PilotSpotlight(props: {
   }
 
   const measure = (hint: string) => {
+    // A control that is not there YET is the normal case, not a dead end: a
+    // card that has to expand first mounts its contents a frame or two after
+    // the preparation asks it to. Keep looking for the whole tracking window
+    // rather than giving up on the first miss and showing no ring at all.
     const element = resolveFocusElement(hint)
-    if (element === null) {
-      setRect(undefined)
-      return
-    }
-    const next = rectOf(element)
+    const next = element === null ? undefined : rectOf(element)
     setRect((previous) => (same(previous, next) ? previous : next))
     if (globalThis.performance.now() < trackUntil) {
       frame = requestAnimationFrame(() => {

--- a/packages/app/src/components/Arcade/PilotSpotlight.tsx
+++ b/packages/app/src/components/Arcade/PilotSpotlight.tsx
@@ -104,13 +104,16 @@ export function PilotSpotlight(props: {
       setRect(undefined)
       setLabel(undefined)
     } else {
-      setLabel(target.label)
       // Open whatever has to be open before the control exists to be measured.
       props.onPrepareFocus?.(preparation)
       settleTimer = window.setTimeout(() => {
         const element = resolveFocusElement(hint)
         if (element !== null) revealFocusElement(element)
         trackUntil = globalThis.performance.now() + TRACK_MS
+        // The label changes with the box, not before it: relabelling first
+        // left the previous step's ring wearing the next step's caption for
+        // as long as the panel took to settle.
+        setLabel(target.label)
         measure(hint)
       }, SETTLE_MS)
     }
@@ -154,6 +157,7 @@ export function PilotSpotlight(props: {
       {(box) => (
         <div
           class={ui.ring}
+          data-testid="pilot-spotlight"
           aria-hidden="true"
           style={{
             left: `${box().x}px`,

--- a/packages/app/src/components/Arcade/PilotSpotlight.tsx
+++ b/packages/app/src/components/Arcade/PilotSpotlight.tsx
@@ -1,0 +1,172 @@
+import { createEffect, createSignal, onCleanup, Show } from 'solid-js'
+import { pilotFocus } from '@/arcade/pilotFocus'
+import { resolveFocusElement, revealFocusElement } from '@/recorder/focus'
+import { deriveReplayFocusPreparation } from '@/recorder/focusPreparation'
+import ui from './PilotSpotlight.module.css'
+import type { PilotFocusStep } from '@/arcade/pilotFocus'
+import type { ReplayFocusPreparationHandler } from '@/recorder/focusPreparation'
+
+/**
+ * How long a ring stays put before a newer step may move it.
+ *
+ * An agent issues its edits as fast as the tool loop allows — six inside 26ms
+ * in a real lesson — and a ring chasing every one of those is a strobe, not a
+ * pointer. Newer targets are held and applied when the dwell expires, so a
+ * burst reads as a few deliberate moves and always ends on the last one.
+ */
+const MIN_DWELL_MS = 700
+
+/** Long enough for a panel to open and lay out before the ring is measured. */
+const SETTLE_MS = 120
+
+/** Nothing has moved for this long, so stop re-measuring until the next step. */
+const TRACK_MS = 1600
+
+type Rect = { x: number; y: number; width: number; height: number }
+
+function rectOf(element: Element): Rect | undefined {
+  const box = element.getBoundingClientRect()
+  if (box.width <= 0 || box.height <= 0) return undefined
+  return { x: box.left, y: box.top, width: box.width, height: box.height }
+}
+
+function same(a: Rect | undefined, b: Rect | undefined): boolean {
+  if (a === b) return true
+  if (!a || !b) return false
+  return (
+    a.x === b.x && a.y === b.y && a.width === b.width && a.height === b.height
+  )
+}
+
+/**
+ * A ring around the control the AI just used, over the pilot lock.
+ *
+ * Deliberately NOT the replay follow-cam. That one dims everything it is not
+ * pointing at, which is exactly wrong here: the lock was just made almost
+ * transparent so the lesson stays watchable, and a scrim would undo that. It
+ * also sits below the lock in the stacking order and would have to be raised
+ * above it, where it would dim the overlay's own banner and rail.
+ *
+ * So: no scrim, no mask, no dimming. A ring and a label, above the lock.
+ */
+export function PilotSpotlight(props: {
+  onPrepareFocus?: ReplayFocusPreparationHandler
+}) {
+  const [rect, setRect] = createSignal<Rect>()
+  const [label, setLabel] = createSignal<string>()
+
+  // The step whose ring is currently shown, and the one waiting for the dwell
+  // to expire. Plain variables: neither is rendered, and making them signals
+  // would re-run the effect that writes them.
+  let shownSeq = 0
+  let pending: PilotFocusStep | undefined
+  let dwellTimer: number | undefined
+  let settleTimer: number | undefined
+  let frame: number | undefined
+  let trackUntil = 0
+
+  const stopTracking = () => {
+    if (frame !== undefined) cancelAnimationFrame(frame)
+    frame = undefined
+  }
+
+  const measure = (hint: string) => {
+    const element = resolveFocusElement(hint)
+    if (element === null) {
+      setRect(undefined)
+      return
+    }
+    const next = rectOf(element)
+    setRect((previous) => (same(previous, next) ? previous : next))
+    if (globalThis.performance.now() < trackUntil) {
+      frame = requestAnimationFrame(() => {
+        measure(hint)
+      })
+    } else {
+      frame = undefined
+    }
+  }
+
+  const show = (target: PilotFocusStep) => {
+    shownSeq = target.seq
+    window.clearTimeout(settleTimer)
+    stopTracking()
+
+    // Replay's own derivation, on the action the recorder just wrote: it both
+    // says which panels have to be open and upgrades the hint (a deleted
+    // transform points at the list, not at the row that no longer exists).
+    const preparation = deriveReplayFocusPreparation(target.action)
+    const hint = preparation.spotlightFocus
+
+    if (hint === undefined) {
+      // A step the focus vocabulary cannot place. Say nothing, rather than
+      // leave the ring on the last control and imply the AI touched it again.
+      setRect(undefined)
+      setLabel(undefined)
+    } else {
+      setLabel(target.label)
+      // Open whatever has to be open before the control exists to be measured.
+      props.onPrepareFocus?.(preparation)
+      settleTimer = window.setTimeout(() => {
+        const element = resolveFocusElement(hint)
+        if (element !== null) revealFocusElement(element)
+        trackUntil = globalThis.performance.now() + TRACK_MS
+        measure(hint)
+      }, SETTLE_MS)
+    }
+
+    window.clearTimeout(dwellTimer)
+    dwellTimer = window.setTimeout(() => {
+      dwellTimer = undefined
+      const queued = pending
+      pending = undefined
+      if (queued) show(queued)
+    }, MIN_DWELL_MS)
+  }
+
+  createEffect(() => {
+    const focus = pilotFocus()
+    if (!focus) {
+      pending = undefined
+      setRect(undefined)
+      setLabel(undefined)
+      return
+    }
+    if (focus.seq === shownSeq) return
+    if (dwellTimer !== undefined) {
+      // Mid-dwell: remember the newest and let the timer bring it up. Only the
+      // newest, so a burst of ten steps costs one extra ring, not ten — and
+      // the burst still ends on the step the agent actually finished on.
+      pending = focus
+      return
+    }
+    show(focus)
+  })
+
+  onCleanup(() => {
+    window.clearTimeout(dwellTimer)
+    window.clearTimeout(settleTimer)
+    stopTracking()
+  })
+
+  return (
+    <Show when={rect()}>
+      {(box) => (
+        <div
+          class={ui.ring}
+          aria-hidden="true"
+          style={{
+            left: `${box().x}px`,
+            top: `${box().y}px`,
+            width: `${box().width}px`,
+            height: `${box().height}px`,
+          }}
+        >
+          <Show when={label()}>
+            {(text) => <span class={ui.label}>{text()}</span>}
+          </Show>
+        </div>
+      )}
+    </Show>
+  )
+}

--- a/packages/app/src/components/Arcade/pilotSpotlightCss.test.ts
+++ b/packages/app/src/components/Arcade/pilotSpotlightCss.test.ts
@@ -1,0 +1,47 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Two properties of the ring are load-bearing and invisible in review.
+ *
+ * It sits ABOVE the lock, because it points at the editor the lock covers —
+ * and being above the lock is exactly what makes `pointer-events: none`
+ * mandatory. A ring that swallowed clicks would sit over the Stop button and
+ * the banner and quietly take the take away from the person watching.
+ */
+describe('PilotSpotlight stylesheet', () => {
+  const css = readFileSync(
+    join(import.meta.dirname, 'PilotSpotlight.module.css'),
+    'utf8',
+  )
+  const overlay = readFileSync(
+    join(import.meta.dirname, 'PilotOverlay.module.css'),
+    'utf8',
+  )
+  const declarations = css.replace(/\/\*[\s\S]*?\*\//g, '')
+
+  function zIndexOf(body: string | undefined): number {
+    const value = body === undefined ? undefined : /z-index:\s*(\d+)/.exec(body)
+    expect(value?.[1]).toBeDefined()
+    return Number(value?.[1])
+  }
+
+  it('never takes a click away from Stop', () => {
+    const ring = /\.ring\s*\{[^{}]*\}/.exec(declarations)?.[0]
+    expect(ring).toBeDefined()
+    expect(/pointer-events:\s*none/.test(ring ?? '')).toBe(true)
+  })
+
+  it('stacks above the lock it points through', () => {
+    expect(
+      zIndexOf(/\.ring\s*\{[^{}]*\}/.exec(declarations)?.[0]),
+    ).toBeGreaterThan(
+      zIndexOf(
+        /\.shield\s*\{[^{}]*\}/.exec(
+          overlay.replace(/\/\*[\s\S]*?\*\//g, ''),
+        )?.[0],
+      ),
+    )
+  })
+})

--- a/packages/app/src/recorder/focus.test.ts
+++ b/packages/app/src/recorder/focus.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { focusHintFor, focusSelectors, resolveFocusElement, revealFocusElement, } from './focus'
+import { focusForCommand, focusHintFor, focusSelectors, resolveFocusElement, revealFocusElement, } from './focus'
 import { snapshotOrigin } from './snapshotOrigin'
 
 /**
@@ -9,6 +9,33 @@ import { snapshotOrigin } from './snapshotOrigin'
  * the app's existing anchor vocabulary, and a hint that resolves to nothing
  * degrades to "show the whole canvas" rather than framing an empty box.
  */
+
+describe('focusForCommand', () => {
+  it('falls back to the central table when a command says nothing', () => {
+    expect(focusForCommand({ id: 'flame.setGamma' }, [2.4])).toBe('param:gamma')
+  })
+
+  it('lets a command that declares its own focus win', () => {
+    // The whole reason the override exists: a command that knows where it
+    // lives beats a table entry derived from its arguments. Every caller has
+    // to go through here, or the recorder and the live spotlight would point
+    // at different controls for the same step.
+    const cmd = {
+      id: 'flame.setGamma',
+      focus: () => 'ui:recorder-dock',
+    }
+    expect(focusForCommand(cmd, [2.4])).toBe('ui:recorder-dock')
+  })
+
+  it('falls back when the command’s own focus declines this invocation', () => {
+    const cmd = {
+      id: 'flame.setGamma',
+      focus: (args: unknown[]) =>
+        args[0] === 0 ? 'ui:recorder-dock' : undefined,
+    }
+    expect(focusForCommand(cmd, [2.4])).toBe('param:gamma')
+  })
+})
 
 describe('focusHintFor', () => {
   it('derives a parameter hint from the path a render-setting command carries', () => {

--- a/packages/app/src/recorder/focus.ts
+++ b/packages/app/src/recorder/focus.ts
@@ -26,6 +26,7 @@
 
 import { affineFocusId, affineRandomizeFocusId, affineResetFocusId, colorFocusId, colorRandomizeFocusId, colorResetFocusId, FINAL_AFFINE_FOCUS_ID, FINAL_AFFINE_RANDOMIZE_FOCUS_ID, transformColorRandomizeFocusId, transformFocusId, transformVisibilityFocusId, variationParamsFocusId, variationRandomizeFocusId, variationTypeFocusId, variationVisibilityFocusId, } from './focusIds'
 import { snapshotOriginFocus, snapshotOriginForCommand } from './snapshotOrigin'
+import type { FlameCommand } from '@/commands/types'
 
 /** Elements the follow-cam can be asked to look at, most specific first. */
 export function focusSelectors(hint: string): string[] {
@@ -116,6 +117,23 @@ function cssQuote(value: string): string {
 function transformOwnerFocusId(value: string): string | undefined {
   const match = /^tx:([^:]+)(?::|$)/.exec(value)
   return match?.[1] ? transformFocusId(match[1]) : undefined
+}
+
+/**
+ * The hint for one command invocation — a command's own `focus()` if it has
+ * one, else the table below.
+ *
+ * The override matters: a command that bothers to say where it lives knows
+ * better than the central table, and a caller that reaches for `focusHintFor`
+ * directly silently loses that for exactly those commands. Both the recorder
+ * and the live pilot resolve their hints through here so the two cannot say
+ * different things about the same command.
+ */
+export function focusForCommand(
+  cmd: Pick<FlameCommand, 'id' | 'focus'>,
+  args: unknown[],
+): string | undefined {
+  return cmd.focus?.(args) ?? focusHintFor(cmd.id, args)
 }
 
 /**

--- a/packages/app/src/recorder/recorder.ts
+++ b/packages/app/src/recorder/recorder.ts
@@ -5,7 +5,7 @@ import { deepClone } from '@/utils/clone'
 import { currentUndoSeq } from '@/utils/undoJournal'
 import { VERSION } from '@/version'
 import { setDocumentWriteReporter, setTimelineTransportReporter, } from './documentWriteHook'
-import { focusHintFor } from './focus'
+import { focusForCommand, focusHintFor } from './focus'
 import { NARRATION_COMMAND_ID, narrationAsStep } from './narrationMode'
 import { MAX_ACTION_TIMESTAMP_MS, MAX_SESSION_ACTIONS, MAX_SESSION_FILE_BYTES, MAX_SESSION_JSON_CHARS, serializeSession, SESSION_FORMAT_VERSION, validateRecordedAction, validateSession, } from './schema'
 import type { RecordedAction, RecordedSession, SessionViewSnapshot, } from './schema'
@@ -136,7 +136,7 @@ function focusFor(
   cmd: Pick<FlameCommand, 'id' | 'focus'>,
   args: unknown[],
 ): string | undefined {
-  return cmd.focus?.(args) ?? focusHintFor(cmd.id, args)
+  return focusForCommand(cmd, args)
 }
 
 function resetGestureState() {

--- a/packages/app/src/webmcp/tools/executeCommand.test.ts
+++ b/packages/app/src/webmcp/tools/executeCommand.test.ts
@@ -1,6 +1,7 @@
 import '@/commands/builtins'
 import { afterEach, describe, expect, it } from 'vitest'
 import { pilotLog, resetPilot, startPilot } from '@/arcade/pilot'
+import { clearPilotFocus, pilotFocus } from '@/arcade/pilotFocus'
 import { cancelSessionRecording, startSessionRecording, stopSessionRecording, } from '@/recorder/recorder'
 import { clearWebMcpContext, setWebMcpContext } from '@/webmcp/contextBridge'
 import { createMockCommandContext } from '@/webmcp/testUtils'
@@ -11,6 +12,7 @@ describe('execute_command dispatch', () => {
     cancelSessionRecording()
     clearWebMcpContext()
     resetPilot()
+    clearPilotFocus()
   })
 
   it('records the command in an active session and honours beforeCommand', async () => {
@@ -131,6 +133,92 @@ describe('execute_command dispatch', () => {
     const line = pilotLog().find((e) => e.kind === 'command')?.text
     expect(line).toBe('Centre the camera')
     expect(line).not.toContain('[')
+  })
+
+  // The live spotlight and the replay follow-cam have to agree, or watching a
+  // lesson live and watching its recording would point at different controls.
+  it('publishes the same focus hint the recorder stamps on the action', async () => {
+    const ctx = createMockCommandContext()
+    setWebMcpContext(ctx)
+    expect(startSessionRecording(ctx.flameDescriptor())).toEqual({ ok: true })
+    startPilot({
+      mode: 'teach',
+      topic: 'color',
+      title: 'Teaching: Colour and tone',
+      stepBudget: 5,
+      allowed: ['flame.'],
+      qualityRankAtStart: 3,
+    })
+
+    // A command whose hint is derived FROM its arguments, so the test fails if
+    // the live path ever resolves the hint from anything but the same
+    // normalized args the recorder describes.
+    await executeCommandTool.execute(
+      { commandId: 'flame.setRenderSetting', args: ['gamma', 2.4] },
+      {},
+    )
+
+    const recorded = stopSessionRecording()?.actions[0]
+    expect(recorded?.focus).toBe('param:gamma')
+    // The whole action, not just the hint: the panel to open, the transform to
+    // select and the affine tab to show are all derived from the id and args.
+    expect(pilotFocus()?.action.focus).toBe(recorded?.focus)
+    expect(pilotFocus()?.action.id).toBe(recorded?.id)
+    expect(pilotFocus()?.action.args).toEqual(recorded?.args)
+    // And it carries the rail's own wording, so the ring's label and the rail
+    // entry cannot describe the step differently.
+    expect(pilotFocus()?.label).toBe(
+      pilotLog().find((e) => e.kind === 'command')?.text,
+    )
+  })
+
+  it('publishes a step even when no hint can place it', async () => {
+    const ctx = createMockCommandContext()
+    setWebMcpContext(ctx)
+    startPilot({
+      mode: 'teach',
+      topic: 'color',
+      title: 'Teaching: Colour and tone',
+      stepBudget: 5,
+      allowed: ['flame.'],
+      qualityRankAtStart: 3,
+    })
+
+    // `flame.reset` rearranges everything and points at nothing.
+    await executeCommandTool.execute({ commandId: 'flame.reset', args: [] }, {})
+
+    // A step with no hint still advances the sequence: the overlay needs it to
+    // retire the previous ring instead of leaving a stale one up.
+    expect(pilotFocus()?.seq).toBeGreaterThan(0)
+    expect(pilotFocus()?.action.focus).toBeUndefined()
+  })
+
+  it('leaves the ring where it is while the agent narrates', async () => {
+    const ctx = createMockCommandContext()
+    setWebMcpContext(ctx)
+    startPilot({
+      mode: 'teach',
+      topic: 'color',
+      title: 'Teaching: Colour and tone',
+      stepBudget: 5,
+      allowed: ['flame.', 'lesson.'],
+      qualityRankAtStart: 3,
+    })
+
+    await executeCommandTool.execute(
+      { commandId: 'flame.setGamma', args: [2.4] },
+      {},
+    )
+    const afterEdit = pilotFocus()
+    await executeCommandTool.execute(
+      { commandId: 'lesson.note', args: ['Gamma lifts the shadows.'] },
+      {},
+    )
+
+    // The sentence explains the edit that is still ringed. Moving the ring off
+    // it — or clearing it — would point away from what is being explained.
+    expect(pilotFocus()).toBe(afterEdit)
+    expect(pilotFocus()?.action.focus).toBe('param:gamma')
   })
 
   // The line the user actually reported: a boolean argument rendered as JSON.

--- a/packages/app/src/webmcp/tools/executeCommand.ts
+++ b/packages/app/src/webmcp/tools/executeCommand.ts
@@ -1,6 +1,9 @@
 import { guardCommand } from '@/arcade/guard'
 import { appendPilotLog, drivingState, notePilotStep, pilotStepsRemaining, } from '@/arcade/pilot'
+import { notePilotFocus } from '@/arcade/pilotFocus'
 import { executeCommand, getCommand, preflightLiveCommand, } from '@/commands/registry'
+import { focusForCommand } from '@/recorder/focus'
+import { NARRATION_COMMAND_ID } from '@/recorder/narrationMode'
 import { getWebMcpContext } from '@/webmcp/contextBridge'
 import type { WebMcpTool } from '@/webmcp/types'
 
@@ -132,10 +135,29 @@ export const executeCommandTool: WebMcpTool = {
       // its canonical shape — `sonification.setConfig` cannot say
       // "Sonification model: ambient" from the flat config an agent typed,
       // only from the snapshot normalization builds.
-      const remaining = notePilotStep(
-        'command',
-        describeStep(commandId, preflight.args),
-      )
+      const line = describeStep(commandId, preflight.args)
+      const remaining = notePilotStep('command', line)
+      // Point the overlay at the control this step moved. Same hint the
+      // recorder stamps on the action, resolved the same way, so the live
+      // spotlight and the replay follow-cam cannot pick different targets for
+      // the same command.
+      //
+      // Narration is the exception: a sentence is the agent SPEAKING about
+      // what it just did, not a move on the interface. Retiring the ring for
+      // it would pull the pointer off the control the sentence is explaining.
+      if (commandId !== NARRATION_COMMAND_ID) {
+        const cmd = getCommand(commandId)
+        const args = [...preflight.args]
+        notePilotFocus(
+          {
+            t: 0,
+            id: commandId,
+            args,
+            focus: cmd === undefined ? undefined : focusForCommand(cmd, args),
+          },
+          line,
+        )
+      }
       return { success: true, commandId, steps: driving.steps + 1, remaining }
     }
 

--- a/tests/pilot-spotlight.spec.ts
+++ b/tests/pilot-spotlight.spec.ts
@@ -1,0 +1,229 @@
+import { dismissWelcomeIfPresent, expect, test } from './helpers'
+import type { Page } from '@playwright/test'
+
+/**
+ * The live spotlight, in a real browser.
+ *
+ * The unit tests prove the sequencing in jsdom, where every rectangle is a
+ * stub. What only a real layout can answer: does the ring land on the control
+ * the agent actually moved, does the preparation open the panel that control
+ * lives in, and — since the ring is painted ABOVE the pilot lock — can the
+ * viewer still press Stop with one on screen.
+ */
+
+type Envelope = { content: { type: string; text: string }[]; isError?: boolean }
+
+async function callTool(
+  page: Page,
+  name: string,
+  input: unknown,
+): Promise<Record<string, unknown>> {
+  const envelope = await page.evaluate(
+    async ([n, i]) => {
+      const win = window as unknown as {
+        webmcp: {
+          execute: (name: string, input: unknown) => Promise<Envelope>
+        }
+      }
+      return await win.webmcp.execute(n, i)
+    },
+    [name, input] as const,
+  )
+  return JSON.parse(envelope.content[0]!.text) as Record<string, unknown>
+}
+
+/** Fire several steps inside one JS turn, the way an agent's loop does. */
+async function burst(
+  page: Page,
+  steps: { commandId: string; args: unknown[] }[],
+): Promise<void> {
+  await page.evaluate(async (calls) => {
+    const win = window as unknown as {
+      webmcp: { execute: (name: string, input: unknown) => Promise<unknown> }
+    }
+    for (const call of calls) await win.webmcp.execute('execute_command', call)
+  }, steps)
+}
+
+async function openEditor(page: Page) {
+  await page.goto('/', { waitUntil: 'domcontentloaded' })
+  await dismissWelcomeIfPresent(page, 12_000)
+  await page.waitForFunction(() => 'webmcp' in window, undefined, {
+    timeout: 20_000,
+  })
+}
+
+/** The on-screen box of the first element matching any of these selectors. */
+async function boxOf(page: Page, selectors: string[]) {
+  return await page.evaluate((list) => {
+    for (const selector of list) {
+      for (const element of document.querySelectorAll(selector)) {
+        const rect = element.getBoundingClientRect()
+        if (rect.width > 0 && rect.height > 0) {
+          return { x: rect.left, y: rect.top, width: rect.width }
+        }
+      }
+    }
+    return undefined
+  }, selectors)
+}
+
+/**
+ * The ring eases between targets over ~220ms, so a single `boundingBox()` can
+ * land mid-flight. Poll until it settles on the control's own box.
+ */
+async function expectRingOn(page: Page, selectors: string[]) {
+  await expect
+    .poll(
+      async () => {
+        const control = await boxOf(page, selectors)
+        const frame = await page.getByTestId('pilot-spotlight').boundingBox()
+        if (control === undefined || frame === null) return 'not found'
+        const off =
+          Math.abs(frame.x - control.x) +
+          Math.abs(frame.y - control.y) +
+          Math.abs(frame.width - control.width)
+        return off <= 1 ? 'on target' : `off by ${Math.round(off)}px`
+      },
+      { timeout: 5_000 },
+    )
+    .toBe('on target')
+}
+
+const GAMMA = [
+  '[data-parameter-path="gamma"]',
+  '[data-tour-target="gamma-slider"]',
+]
+const CONTRAST = [
+  '[data-parameter-path="contrast"]',
+  '[data-tour-target="contrast-slider"]',
+]
+
+test.describe('Teach live spotlight', () => {
+  test('rings the control the AI just moved', async ({
+    page,
+    consoleErrors,
+  }) => {
+    await openEditor(page)
+    await callTool(page, 'arcade_start_lesson', { topic: 'color' })
+    const ring = page.getByTestId('pilot-spotlight')
+    // Nothing has happened yet, so there is nothing to point at.
+    await expect(ring).toHaveCount(0)
+
+    await callTool(page, 'execute_command', {
+      commandId: 'flame.setGamma',
+      args: [2.4],
+    })
+    await expect(ring).toBeVisible()
+
+    // The preparation opened the panel gamma lives in, and the ring is on it.
+    await expectRingOn(page, GAMMA)
+
+    // And it says which step put it there, in the rail's own words.
+    await expect(ring).toContainText('Gamma')
+    expect(consoleErrors).toEqual([])
+  })
+
+  test('never takes the Stop button away from the viewer', async ({ page }) => {
+    await openEditor(page)
+    await callTool(page, 'arcade_start_lesson', { topic: 'color' })
+    await callTool(page, 'execute_command', {
+      commandId: 'flame.setGamma',
+      args: [2.4],
+    })
+    const ring = page.getByTestId('pilot-spotlight')
+    await expect(ring).toBeVisible()
+
+    // The ring is painted above the lock, so a stray `pointer-events` would
+    // put an invisible sheet over the banner. Stop has to still work.
+    expect(
+      await ring.evaluate(
+        (el) => globalThis.getComputedStyle(el).pointerEvents,
+      ),
+    ).toBe('none')
+    await page.getByRole('button', { name: /Stop the AI/ }).click()
+    await expect(
+      page.getByRole('dialog', { name: /Stopped by you/ }),
+    ).toBeVisible()
+    // The lock is gone and so is the ring: the controls are the viewer's again.
+    await expect(ring).toHaveCount(0)
+  })
+
+  test('holds one ring through a burst, then lands on the last step', async ({
+    page,
+  }) => {
+    await openEditor(page)
+    await callTool(page, 'arcade_start_lesson', { topic: 'color' })
+    const ring = page.getByTestId('pilot-spotlight')
+
+    // Three steps inside a single turn — an agent's tool loop, not a human.
+    await burst(page, [
+      { commandId: 'flame.setGamma', args: [2.4] },
+      { commandId: 'flame.setExposure', args: [0.42] },
+      { commandId: 'flame.setContrast', args: [1.1] },
+    ])
+    await expect(ring).toBeVisible()
+
+    await expectRingOn(page, GAMMA)
+    await expect(ring).toContainText('Gamma')
+
+    // When the dwell expires it goes to the step the agent finished on, never
+    // the one in the middle.
+    await expect(ring).toContainText('Contrast', { timeout: 3_000 })
+    await expectRingOn(page, CONTRAST)
+  })
+
+  test('opens the transform card before pointing inside it', async ({
+    page,
+  }) => {
+    await openEditor(page)
+    await callTool(page, 'arcade_start_lesson', { topic: 'variations' })
+    await callTool(page, 'execute_command', {
+      commandId: 'flame.addTransform',
+      args: ['linearVar', 't1', 'v1'],
+    })
+    // A control that only exists once its card is expanded. If the live view
+    // skipped replay's preparation, this would resolve to nothing.
+    await callTool(page, 'execute_command', {
+      commandId: 'flame.setProbability',
+      args: ['t1', 0.5],
+    })
+
+    const ring = page.getByTestId('pilot-spotlight')
+    await expect(ring).toBeVisible()
+    // Two tool calls land well inside one dwell, so the ring is still on the
+    // first step; the second is queued.
+    await expect(ring).toContainText('Add a transform')
+
+    await expect(ring).toContainText('Transform probability', {
+      timeout: 3_000,
+    })
+    await expectRingOn(page, [
+      '[data-parameter-path="transform.t1.probability"]',
+    ])
+  })
+
+  test('leaves the ring where it is while the agent narrates', async ({
+    page,
+  }) => {
+    await openEditor(page)
+    await callTool(page, 'arcade_start_lesson', { topic: 'color' })
+    await callTool(page, 'execute_command', {
+      commandId: 'flame.setGamma',
+      args: [2.4],
+    })
+    const ring = page.getByTestId('pilot-spotlight')
+    await expectRingOn(page, GAMMA)
+    const before = await ring.boundingBox()
+
+    await callTool(page, 'arcade_narrate', {
+      text: 'Gamma lifts the shadows without touching the highlights.',
+    })
+    await page.waitForTimeout(1200)
+
+    // The sentence is about the edit that is still ringed.
+    const after = await ring.boundingBox()
+    expect(after).toEqual(before)
+    await expect(ring).toContainText('Gamma')
+  })
+})


### PR DESCRIPTION
## What

While an agent drives Teach or Cinema, a ring now marks the control each step moved, with the step's own label above it.

The lock said *that* an AI was working and the rail said *what* it did. Nothing said **where** — a viewer had to find the moved control by spotting the value change, which is the thing the lesson exists to teach.

## How

Replay already solves this. Every recorded action carries a focus hint, and `deriveReplayFocusPreparation` turns it into "open this panel, select that transform, look here". The live path had the same information at `execute_command` time and dropped it.

- `arcade/pilotFocus.ts` (new) publishes the latest step as **the same action the recorder writes** — id, args and hint — not just a hint. The id and args are what decide which panel opens and which transform is selected, so handing over the whole action is what makes live and replay reveal the same UI.
- `recorder/focus.ts` gains `focusForCommand(cmd, args)` — `cmd.focus?.() ?? focusHintFor(...)`. The recorder now delegates to it, so a command that declares its own `focus` can no longer be honoured by the recorder and ignored by the live view.
- `components/Arcade/PilotSpotlight.tsx` (new) runs replay's own derivation, applies the preparation through `MainWorkspace`'s existing `prepareReplayFocus`, reveals the element and tracks its rect.

## Why not the replay follow-cam

`ReplaySpotlight` dims everything it is not pointing at. The lock was deliberately made almost transparent (#154) so the flame stays watchable during a lesson — a scrim undoes exactly that. It also sits at z-index 300, below the 10010 lock, and raising it above would dim the overlay's own banner and rail, which exempt only `[data-replay-region]`.

So this is a ring and a label. No scrim, no mask, no dimming, `pointer-events: none` so it can never take a click away from Stop.

## Pacing

An agent fires its steps as fast as its tool loop allows — six inside 26ms in the lesson we measured. A ring chasing every one is a strobe, not a pointer.

- Each ring holds **700ms**. Newer steps queue; only the newest survives, so a burst of ten costs one extra ring and always ends where the agent actually finished.
- A step the focus vocabulary cannot place (`flame.reset`, a load) retires the ring rather than leaving it on a control the AI did not touch again — but through the same dwell, so it cannot snap one away mid-hold.
- **Narration never moves the ring.** A sentence explains the edit that is still ringed; retiring it there would point away from what is being said.
- Ends with the lock: `finishPilot` and `resetPilot` clear it, and the component is gated on `agentDriving()`.

## Tests

+17 tests. Every behaviour above was mutation-checked — the fix removed, the failure observed, the fix restored:

| Mutation | Caught by |
| --- | --- |
| no dwell latch (retarget every step) | burst test |
| keep the *first* queued step, not the newest | burst test |
| no rect tracking after first measure | moving-control test |
| unhinted step leaves the old ring up | retire test |
| pilot end does not hard-clear | teardown test |
| spotlight not gated on `agentDriving()` | overlay teardown test |
| ring the raw hint, not the derived one | 2 tests |
| never prepare the UI | preparation test |
| never `scrollIntoView` | reveal test |
| narration retires the ring | narration test |
| no focus published at all | 3 tests |
| hint from raw instead of normalized args | parity test |
| ring eats pointer events | CSS ratchet |
| ring below the lock | CSS ratchet |

The parity test asserts the live hint **equals the one the recorder stamped on the same action**, so the two cannot drift.

`167 files, 2111 tests` pass. Typecheck clean, lint clean (one pre-existing warning in `AncestryTreeModal`).




---

## Verified in a real browser

My earlier note about the self-signed cert was wrong — `playwright.config.ts` already runs headless Chromium against the production preview with `ignoreHTTPSErrors`. `tests/pilot-spotlight.spec.ts` drives the same WebMCP dev mock an agent would, with no AI in the loop:

| Test | Asserts |
| --- | --- |
| rings the control the AI just moved | the ring's box equals the gamma slider's box to within 1px, and it carries the rail's wording |
| never takes the Stop button away | computed `pointer-events: none`, Stop still ends the lesson, ring goes with the lock |
| holds one ring through a burst | three steps in one JS turn: ring stays on the first, then lands on the **last** |
| opens the transform card before pointing inside it | `flame.setProbability` on a fresh transform — the card expands and the ring lands on the probability slider |
| leaves the ring where it is while the agent narrates | box is byte-identical before and after `arcade_narrate` |

**Full e2e suite: 44 passed**, no regressions. Units 2112 passed, typecheck and lint clean.

### One bug the browser found that jsdom could not

The caption changed the instant a step arrived, but the ring cannot move until the panel it points into has opened (~120ms). In that window the previous step's ring wore the next step's words. The label now changes with the box; `PilotSpotlight.test.tsx` locks it, and the mutation that reintroduces it fails that test.
