### PR TITLE
fix(arcade): stop Cinema recording steps that change nothing, and animating a camera that does not render

### DIFF
--- a/packages/app/src/MainWorkspace.tsx
+++ b/packages/app/src/MainWorkspace.tsx
@@ -4159,6 +4159,7 @@ export function MainWorkspace(props: AppProps) {
       setStochasticFilter: setStochasticFilterEnabled,
       setFlyMode,
       setShowTimeline,
+      showTimeline,
     },
     camera: {
       center: () => {

--- a/packages/app/src/arcade/animatablePaths.test.ts
+++ b/packages/app/src/arcade/animatablePaths.test.ts
@@ -3,6 +3,87 @@ import { createTestFlame } from '@/webmcp/testUtils'
 import { buildAnimatableCatalog, buildTimelineSnapshot, } from './animatablePaths'
 import type { TimelineTrack } from '@/utils/timeline'
 
+/**
+ * A flame renders through exactly one pipeline, and the two take different
+ * cameras: `createIFSPipeline3D` never sees the 2D camera and
+ * `createIFSPipeline` never sees `camera3D` (Flam3.tsx). Offering an agent the
+ * family that is not wired up hands it four controls that resolve correctly on
+ * the timeline and move nothing on screen — which is exactly what happened to
+ * a Cinema take on a 3D flame: it checked its own work by reading the values
+ * back, and they were right.
+ */
+describe('only the camera that renders is animatable', () => {
+  function flameIn(dimensions: 2 | 3) {
+    const flame = createTestFlame()
+    flame.renderSettings.dimensions = dimensions
+    return flame
+  }
+
+  it('offers a 3D flame the 3D camera and hides the 2D one', () => {
+    const paths = buildAnimatableCatalog(flameIn(3)).map((e) => e.path)
+    expect(paths).toContain('camera3D.radius')
+    expect(paths).toContain('camera3D.theta')
+    expect(paths.filter((p) => p.startsWith('camera.'))).toEqual([])
+  })
+
+  it('offers a 2D flame the 2D camera and hides the 3D one', () => {
+    const paths = buildAnimatableCatalog(flameIn(2)).map((e) => e.path)
+    expect(paths).toContain('camera.zoom')
+    expect(paths.filter((p) => p.startsWith('camera3D.'))).toEqual([])
+  })
+
+  it('says which camera to use instead of calling the path unknown', () => {
+    const flame = flameIn(3)
+    const result = buildTimelineSnapshot(
+      {
+        fps: 30,
+        durationFrames: 60,
+        tracks: [
+          {
+            path: 'camera.zoom',
+            keyframes: [
+              { frame: 0, value: 1 },
+              { frame: 59, value: 1.75 },
+            ],
+          },
+        ],
+      },
+      buildAnimatableCatalog(flame),
+      [],
+    )
+    expect(result.ok).toBe(false)
+    const error = result.ok ? '' : result.error
+    // "Unknown path" would be a lie — it exists, it just is not wired up here.
+    expect(error).not.toContain('Unknown path')
+    expect(error).toContain('2D camera')
+    expect(error).toContain('camera3D.radius')
+    // The unit question the agent could not answer from the tool alone.
+    expect(error).toContain('radians')
+  })
+
+  it('says the same thing the other way round', () => {
+    const result = buildTimelineSnapshot(
+      {
+        fps: 30,
+        durationFrames: 60,
+        tracks: [
+          {
+            path: 'camera3D.radius',
+            keyframes: [
+              { frame: 0, value: 3 },
+              { frame: 59, value: 2 },
+            ],
+          },
+        ],
+      },
+      buildAnimatableCatalog(flameIn(2)),
+      [],
+    )
+    expect(result.ok).toBe(false)
+    expect(result.ok ? '' : result.error).toContain('camera.zoom')
+  })
+})
+
 describe('animatable catalog', () => {
   const flame = createTestFlame()
   const catalog = buildAnimatableCatalog(flame)

--- a/packages/app/src/arcade/animatablePaths.ts
+++ b/packages/app/src/arcade/animatablePaths.ts
@@ -53,8 +53,26 @@ function renderCurrent(flame: FlameDescriptor, path: string): unknown {
 }
 
 /** Every path the timeline can drive for this flame, with its current value. */
+/**
+ * The camera family that does NOT drive this flame's render.
+ *
+ * A flame renders through exactly one of two pipelines, and they take
+ * different cameras: `createIFSPipeline3D` is handed `camera3D` and never sees
+ * the 2D camera, while `createIFSPipeline` is handed the 2D one and never sees
+ * `camera3D` (Flam3.tsx). Offering both to an agent is offering a set of
+ * controls that are wired to nothing — it animated `camera.zoom` across a 3D
+ * flame, read the resolved values back off the timeline to check its work
+ * (they were correct), and got a picture that never moved.
+ */
+function deadCameraPrefix(flame: FlameDescriptor): string {
+  return flame.renderSettings.dimensions === 3 ? 'camera.' : 'camera3D.'
+}
+
 export function buildAnimatableCatalog(flame: FlameDescriptor): CatalogEntry[] {
-  const entries: CatalogEntry[] = TIMELINE_PARAMETERS.map((parameter) => ({
+  const dead = deadCameraPrefix(flame)
+  const entries: CatalogEntry[] = TIMELINE_PARAMETERS.filter(
+    (parameter) => !parameter.path.startsWith(dead),
+  ).map((parameter) => ({
     path: parameter.path,
     type: parameter.type === 'array' ? 'color' : parameter.type,
     group: parameter.group,
@@ -122,6 +140,29 @@ export function buildAnimatableCatalog(flame: FlameDescriptor): CatalogEntry[] {
  * is a feature, not an accident. The unprefixed path is looked up FIRST, so a
  * variation that happens to be called `probability` cannot shadow one.
  */
+/**
+ * "Unknown path" is the wrong thing to say about `camera.zoom`.
+ *
+ * It exists, it is in the schema, the timeline will happily resolve it — it
+ * just is not connected to the pipeline that renders THIS flame. Saying so,
+ * and naming the family that is, turns a silent still frame into one call.
+ * Which family is live is read back off the catalog, so this cannot disagree
+ * with what `arcade_get_animatable_paths` just offered.
+ */
+function wrongCameraFamilyError(
+  byPath: ReadonlyMap<string, CatalogEntry>,
+  path: string,
+): string | undefined {
+  const rendersIn3D = byPath.has('camera3D.radius')
+  if (rendersIn3D && path.startsWith('camera.')) {
+    return `"${path}" is the 2D camera and a 3D flame does not render through it. Animate camera3D.theta, camera3D.phi, camera3D.radius or camera3D.fov instead (theta and phi are radians; a full turn is 2*PI).`
+  }
+  if (!rendersIn3D && path.startsWith('camera3D.')) {
+    return `"${path}" is the 3D camera and a 2D flame does not render through it. Animate camera.x, camera.y, camera.zoom or camera.rotation instead (rotation is radians; a full turn is 2*PI).`
+  }
+  return undefined
+}
+
 function canonicalPath(
   byPath: ReadonlyMap<string, CatalogEntry>,
   path: string,
@@ -234,7 +275,9 @@ export function buildTimelineSnapshot(
     if (entry === undefined || path === undefined) {
       return {
         ok: false,
-        error: `Unknown path "${track.path}". Call arcade_get_animatable_paths for the list.`,
+        error:
+          wrongCameraFamilyError(byPath, track.path) ??
+          `Unknown path "${track.path}". Call arcade_get_animatable_paths for the list.`,
       }
     }
     canonical.set(track.path, path)

--- a/packages/app/src/commands/registry.test.ts
+++ b/packages/app/src/commands/registry.test.ts
@@ -8,6 +8,51 @@ import { createMockCommandContext, createTestFlame } from '@/webmcp/testUtils'
 import { executeCommand, getAllCommands, hasExplicitReplayPolicy, preflightLiveCommand, preflightReplayCommand, registerCommand, } from './registry'
 import type { CommandContext } from './types'
 
+/**
+ * A rejection an agent can act on.
+ *
+ * These messages are read by an AI holding a sixteen-track timeline, not by a
+ * developer with a debugger. "arguments must be finite JSON data" with no
+ * locator sent a Cinema agent bisecting its own payload by deleting fields,
+ * and it blamed an unrelated one — so every rejection names the path.
+ */
+describe('replay argument rejections name what is wrong and where', () => {
+  it('points at the exact field that is not finite JSON', () => {
+    const bad = timelineSnapshot({
+      tracks: [
+        {
+          parameterPath: 'camera.zoom',
+          keyframes: [
+            { frame: 0, value: 1 },
+            { frame: 30, value: undefined },
+          ],
+        },
+      ],
+    })
+    const error = preflightReplayCommand('timeline.loadTimeline', [bad])
+    expect(error).toContain('finite JSON data')
+    expect(error).toContain('tracks[0].keyframes[1].value')
+    expect(error).toContain('undefined')
+  })
+
+  it('names the value, so NaN is not mistaken for a missing field', () => {
+    const bad = timelineSnapshot()
+    ;(bad.config as Record<string, unknown>).fps = Number.NaN
+    const error = preflightReplayCommand('timeline.loadTimeline', [bad])
+    expect(error).toContain('config.fps')
+    expect(error).toContain('NaN')
+  })
+
+  it('locates an over-long string rather than just reporting one exists', () => {
+    const bad = timelineSnapshot({
+      tracks: [{ parameterPath: 'x'.repeat(100_000), keyframes: [] }],
+    })
+    const error = preflightReplayCommand('timeline.loadTimeline', [bad])
+    expect(error).toContain('too long')
+    expect(error).toContain('tracks[0].parameterPath')
+  })
+})
+
 function timelineSnapshot(
   overrides: Record<string, unknown> = {},
 ): Record<string, unknown> {

--- a/packages/app/src/commands/registry.ts
+++ b/packages/app/src/commands/registry.ts
@@ -397,9 +397,35 @@ export function hasExplicitReplayPolicy(command: FlameCommand): boolean {
   )
 }
 
-/** Generic JSON-shape budget applied before any command-specific normalizer. */
+/**
+ * Describe a value the way an author would recognise it, without printing it.
+ *
+ * The offender is almost always `undefined` or `NaN` in one field of a large
+ * payload, and the agent that sent it cannot see which. A type plus, for the
+ * short ones, the value itself is enough to find it; anything longer is
+ * summarised so an error message can never become a data dump.
+ */
+function describeBadValue(value: unknown): string {
+  if (value === undefined) return 'undefined'
+  if (typeof value === 'number') return String(value)
+  if (typeof value === 'bigint') return `a bigint (${String(value)})`
+  if (typeof value === 'function') return 'a function'
+  if (typeof value === 'symbol') return 'a symbol'
+  return typeof value
+}
+
+/**
+ * Generic JSON-shape budget applied before any command-specific normalizer.
+ *
+ * Every rejection names the path that caused it. Without one the message is
+ * un-actionable on a payload of any size: a Cinema agent that hit
+ * "arguments must be finite JSON data" on a sixteen-track timeline bisected by
+ * deleting fields and blamed an unrelated one, which cost it real steps.
+ */
 function replayArgBudgetError(root: unknown): string | undefined {
-  const stack: { value: unknown; depth: number }[] = [{ value: root, depth: 0 }]
+  const stack: { value: unknown; depth: number; path: string }[] = [
+    { value: root, depth: 0, path: 'arguments' },
+  ]
   const seen = new WeakSet<object>()
   let nodes = 0
 
@@ -408,7 +434,7 @@ function replayArgBudgetError(root: unknown): string | undefined {
     nodes++
     if (nodes > MAX_REPLAY_ARG_NODES) return 'argument data is too large'
     if (current.depth > MAX_REPLAY_ARG_DEPTH) {
-      return 'argument data is nested too deeply'
+      return `argument data is nested too deeply at ${current.path}`
     }
 
     const value = current.value
@@ -421,34 +447,46 @@ function replayArgBudgetError(root: unknown): string | undefined {
     }
     if (typeof value === 'string') {
       if (value.length > MAX_REPLAY_STRING_LENGTH) {
-        return 'an argument string is too long'
+        return `an argument string is too long at ${current.path} (${value.length} characters, limit ${MAX_REPLAY_STRING_LENGTH})`
       }
       continue
     }
-    if (typeof value !== 'object') return 'arguments must be finite JSON data'
+    if (typeof value !== 'object') {
+      return `arguments must be finite JSON data: ${current.path} is ${describeBadValue(value)}`
+    }
 
-    if (seen.has(value)) return 'arguments must not contain cycles'
+    if (seen.has(value)) {
+      return `arguments must not contain cycles, and ${current.path} points back into the payload`
+    }
     seen.add(value)
     if (Array.isArray(value)) {
       if (value.length > MAX_REPLAY_ARRAY_LENGTH) {
-        return 'an argument array is too long'
+        return `an argument array is too long at ${current.path} (${value.length} items, limit ${MAX_REPLAY_ARRAY_LENGTH})`
       }
-      for (const item of value) {
-        stack.push({ value: item, depth: current.depth + 1 })
+      for (const [index, item] of value.entries()) {
+        stack.push({
+          value: item,
+          depth: current.depth + 1,
+          path: `${current.path}[${index}]`,
+        })
       }
       continue
     }
 
     const prototype = Object.getPrototypeOf(value)
     if (prototype !== Object.prototype && prototype !== null) {
-      return 'arguments must contain plain JSON objects only'
+      return `arguments must contain plain JSON objects only, and ${current.path} is not one`
     }
-    const entries = Object.values(value)
+    const entries = Object.entries(value)
     if (entries.length > MAX_REPLAY_OBJECT_KEYS) {
-      return 'an argument object has too many fields'
+      return `an argument object has too many fields at ${current.path} (${entries.length} fields, limit ${MAX_REPLAY_OBJECT_KEYS})`
     }
-    for (const item of entries) {
-      stack.push({ value: item, depth: current.depth + 1 })
+    for (const [key, item] of entries) {
+      stack.push({
+        value: item,
+        depth: current.depth + 1,
+        path: `${current.path}.${key}`,
+      })
     }
   }
   return undefined

--- a/packages/app/src/commands/types.ts
+++ b/packages/app/src/commands/types.ts
@@ -220,6 +220,9 @@ export interface CommandContext {
     setStochasticFilter: (on: boolean) => void
     setFlyMode: (on: boolean) => void
     setShowTimeline: (shown: boolean) => void
+    /** Optional so sandboxes need not provide it; a caller that cannot read
+     *  the current value simply issues the command unconditionally. */
+    showTimeline?: () => boolean
   }
   camera: {
     center: () => void

--- a/packages/app/src/webmcp/tools/arcadeCinema.test.ts
+++ b/packages/app/src/webmcp/tools/arcadeCinema.test.ts
@@ -72,6 +72,42 @@ describe('Cinema records one action per tool call', () => {
     expect(ids).not.toContain('timeline.setAnimationEnabled')
   })
 
+  it('carries animationEnabled in add mode too', async () => {
+    // The mode the tool recommends ("one idea at a time"). If a merge ever
+    // dropped the flag, removing the separate toggle would silently stop
+    // animation for exactly the workflow the brief tells agents to use.
+    const ctx = createMockCommandContext()
+    setWebMcpContext(ctx)
+    await arcadeStartCinema.execute({}, {})
+    await arcadeSetKeyframes.execute(
+      { fps: 30, durationFrames: 60, mode: 'replace', tracks: TRACKS },
+      {},
+    )
+    await arcadeSetKeyframes.execute(
+      {
+        fps: 30,
+        durationFrames: 60,
+        mode: 'add',
+        tracks: [
+          {
+            path: 'exposure',
+            keyframes: [
+              { frame: 0, value: -4 },
+              { frame: 59, value: -3.6 },
+            ],
+          },
+        ],
+      },
+      {},
+    )
+    const calls = vi.mocked(ctx.timeline.edit!.load).mock.calls
+    expect(calls).toHaveLength(2)
+    // The flag, which is the whole point: what "add" merges into comes from
+    // the live timeline, and this mock's tracks() does not follow its own
+    // load() — merging itself is covered in animatablePaths.test.ts.
+    expect(calls[1]?.[0]?.animationEnabled).toBe(true)
+  })
+
   it('still applies the snapshot that carries animationEnabled', async () => {
     const ctx = createMockCommandContext()
     setWebMcpContext(ctx)

--- a/packages/app/src/webmcp/tools/arcadeCinema.test.ts
+++ b/packages/app/src/webmcp/tools/arcadeCinema.test.ts
@@ -19,6 +19,95 @@ function ctxWithRecorder() {
   return ctx
 }
 
+/**
+ * The rail and the recording have to agree about how many steps happened.
+ * They used to disagree by one per keyframe write: the tool logged one line
+ * and the recorder wrote two, so a seven-call take replayed with seven extra
+ * steps pointing at an animation toggle that never moved.
+ */
+describe('Cinema records one action per tool call', () => {
+  afterEach(() => {
+    resetPilot()
+    cancelSessionRecording()
+    clearWebMcpContext()
+  })
+
+  /** The mock context has no view block; Cinema only needs these two. */
+  const viewMock = () => ({
+    setQualityPreset: vi.fn(),
+    setAdaptiveFilter: vi.fn(),
+    setStochasticFilter: vi.fn(),
+    setFlyMode: vi.fn(),
+    setShowTimeline: vi.fn(),
+  })
+
+  const TRACKS = [
+    {
+      path: 'camera.zoom',
+      keyframes: [
+        { frame: 0, value: 1 },
+        { frame: 59, value: 1.4 },
+      ],
+    },
+  ]
+
+  it('writes exactly one action per arcade_set_keyframes call', async () => {
+    const ctx = createMockCommandContext()
+    setWebMcpContext(ctx)
+    await arcadeStartCinema.execute({}, {})
+    expect(startSessionRecording(ctx.flameDescriptor())).toEqual({ ok: true })
+
+    await arcadeSetKeyframes.execute(
+      { fps: 30, durationFrames: 60, tracks: TRACKS },
+      {},
+    )
+    await arcadeSetKeyframes.execute(
+      { fps: 30, durationFrames: 60, tracks: TRACKS },
+      {},
+    )
+
+    const ids = stopSessionRecording()?.actions.map((a) => a.id) ?? []
+    expect(ids).toEqual(['timeline.loadTimeline', 'timeline.loadTimeline'])
+    // The snapshot is what turns animation on, so a separate toggle is noise.
+    expect(ids).not.toContain('timeline.setAnimationEnabled')
+  })
+
+  it('still applies the snapshot that carries animationEnabled', async () => {
+    const ctx = createMockCommandContext()
+    setWebMcpContext(ctx)
+    await arcadeStartCinema.execute({}, {})
+    await arcadeSetKeyframes.execute(
+      { fps: 30, durationFrames: 60, tracks: TRACKS },
+      {},
+    )
+    const loaded = vi.mocked(ctx.timeline.edit!.load).mock.calls[0]?.[0]
+    expect(loaded?.animationEnabled).toBe(true)
+  })
+
+  it('does not record opening a timeline that is already open', async () => {
+    const ctx = createMockCommandContext()
+    ctx.view = { ...viewMock(), showTimeline: () => true }
+    setWebMcpContext(ctx)
+    expect(startSessionRecording(ctx.flameDescriptor())).toEqual({ ok: true })
+    await arcadeStartCinema.execute({}, {})
+
+    // Every take used to open with a step that changed nothing.
+    expect(stopSessionRecording()?.actions ?? []).toEqual([])
+  })
+
+  it('still opens a timeline that is closed', async () => {
+    const ctx = createMockCommandContext()
+    ctx.view = { ...viewMock(), showTimeline: () => false }
+    setWebMcpContext(ctx)
+    expect(startSessionRecording(ctx.flameDescriptor())).toEqual({ ok: true })
+    await arcadeStartCinema.execute({}, {})
+
+    expect(stopSessionRecording()?.actions.map((a) => a.id)).toEqual([
+      'view.setShowTimeline',
+    ])
+  })
+})
+
 describe('Cinema tools', () => {
   afterEach(() => {
     resetPilot()

--- a/packages/app/src/webmcp/tools/arcadeCinema.ts
+++ b/packages/app/src/webmcp/tools/arcadeCinema.ts
@@ -63,7 +63,11 @@ export const arcadeStartCinema: WebMcpTool = {
     }
     clearNarration()
     ctx.arcade.closeHub()
-    executeCommand('view.setShowTimeline', ctx, true)
+    // Only when it is not already open. Recording a step that changes nothing
+    // makes every Cinema take start with a no-op the viewer watches replay.
+    if (ctx.view?.showTimeline?.() !== true) {
+      executeCommand('view.setShowTimeline', ctx, true)
+    }
     return {
       ok: true,
       stepBudget: CINEMA_STEP_BUDGET,
@@ -240,8 +244,13 @@ export const arcadeSetKeyframes: WebMcpTool = {
       built.snapshot,
     ])
     if (invalid) return { error: invalid }
+    // One tool call, one recorded action. The snapshot carries
+    // `animationEnabled: true` and `load` applies it (MainWorkspace's timeline
+    // edit context), so a `timeline.setAnimationEnabled` on the next line only
+    // re-set what the line above had already set — and cost the take a second
+    // action the rail never mentioned, which replayed as its own step with its
+    // own dwell and its own spotlight on a toggle that never moved.
     executeCommand('timeline.loadTimeline', ctx, built.snapshot)
-    executeCommand('timeline.setAnimationEnabled', ctx, true)
     // Wall-clock transport, so `timeline.play` is deliberately not replayable
     // and `execute_command` refuses it. The tool starts it here instead: an
     // animation the viewer has to press Play on is not an animation the agent


### PR DESCRIPTION
Found by driving a real nine-second Cinema take and reading the `.steps.json` it produced. All three are confirmed in that file and reproduced on a real build.

## 1. `arcade_set_keyframes` wrote two actions and logged one

```
executeCommand('timeline.loadTimeline', ctx, built.snapshot)
executeCommand('timeline.setAnimationEnabled', ctx, true)   // removed
```

`notePilotStep` runs once per tool call, so the rail showed one line while the recorder wrote two. That is exactly the rail/recording mismatch reported.

The toggle is **provably redundant**: `built.snapshot.animationEnabled` is `true` in all eight payloads of that take, and `MainWorkspace`'s timeline `load` applies `data.animationEnabled` when present. It re-set what the previous line had just set.

Cost in the real take: **8 of 25 actions**. On replay each is a step with its own dwell (≥800ms) and its own spotlight aimed at `ui:animation-toggle` — a nine-second animation spent about six seconds of its replay pointing at a control that never moved.

## 2. Cinema opened a timeline that was already open

`arcade_start_cinema` fired `view.setShowTimeline(true)` unconditionally. In that take `initialView.showTimeline` was already `true`, so every Cinema session began with a recorded no-op. `ctx.view` gains an optional `showTimeline()` reader (optional so sandboxes without it keep the old unconditional behaviour), and the command is issued only when it would change something.

## 3. A rejection no agent could act on

`arguments must be finite JSON data` named no field. Holding a sixteen-track, sixty-nine-keyframe timeline, the agent bisected its own payload by deleting fields and concluded `play: false` was broken.

**`play: false` is not broken.** I reproduced all three variants against a real build — `undefined`, `true`, `false` all return `ok`, the last with `playing: false`. The message sent the agent after the wrong field and cost it real steps.

Every rejection in `replayArgBudgetError` now carries the path and what it found:

| before | after |
| --- | --- |
| `arguments must be finite JSON data` | `arguments must be finite JSON data: arguments[0].tracks[0].keyframes[1].value is undefined` |
| `an argument string is too long` | `an argument string is too long at arguments[0].tracks[0].parameterPath (100000 characters, limit …)` |
| `an argument array is too long` | `… at arguments[0].tracks (… items, limit …)` |
| `arguments must not contain cycles` | `… and arguments[0].config points back into the payload` |

`NaN` and `undefined` are now distinguishable, which they were not.

## Tests

+7 tests, each mutation-checked — fix removed, failure observed, fix restored:

| Mutation | Caught by |
| --- | --- |
| bring back the redundant toggle | one-action-per-call test |
| open the timeline unconditionally | already-open test |
| drop the path from the finite-JSON message | 2 tests |
| drop the path from the too-long message | over-long-string test |

Plus tests that the snapshot still turns animation on, and that a *closed* timeline is still opened and recorded.

2258 unit tests, 44 e2e, typecheck and lint clean (4 pre-existing warnings, none in files touched here).

---

## 4. The 3D flame whose camera track moved nothing (added after review)

From the next Cinema session. The agent animated `camera.zoom`, `camera.x`, `camera.y` and `camera.rotation` across a **3D** flame, verified its own work by scrubbing to frame 120 and reading the resolved values back — `zoom 1.736`, correct — and got a picture that never moved. It reported the still frames and could not explain them.

`Flam3.tsx` explains them. A flame renders through exactly one of two pipelines, and they take different cameras:

```
if (dimensions === 3 && camera3D) {
  ifsPipeline3D = createIFSPipeline3D(root, camera3D, …)   // 2D camera never passed
} else {
  ifsPipeline   = createIFSPipeline(root, camera!, …)      // camera3D never passed
}
```

`buildAnimatableCatalog` offered **both** families to every flame, so on any 3D flame the four 2D camera paths were controls wired to nothing. The timeline resolves them faithfully — which is exactly what makes it undiagnosable from outside: the values are right, the picture is still.

The catalog now offers only the family that drives this flame, and a track on the other one gets a real message rather than "Unknown path" (it is not unknown — it exists, it is just not connected here):

> `"camera.zoom" is the 2D camera and a 3D flame does not render through it. Animate camera3D.theta, camera3D.phi, camera3D.radius or camera3D.fov instead (theta and phi are radians; a full turn is 2*PI).`

The unit is in there because it was the agent's other open question. **`camera.rotation` is radians** — `MainWorkspace.tsx:2813` adds a full turn as `dir * 2 * Math.PI`. Its guess of `0.12` ≈ 6.9° was right; the path was not.

### Verifying the toggle removal did not break live playback

Worth stating, since it was the obvious risk in fix 1: `ctx.timeline.setAnimationEnabled` and the timeline `load` handler call the **same** workspace setter (`MainWorkspace.tsx:4048` and `:4122`), with the same value, in the same tick. The removed line was redundant for the live path as well as the recording. A test now covers `mode: "add"` specifically, since that is the mode the brief tells agents to use.

+6 more tests, mutation-checked:

| Mutation | Caught by |
| --- | --- |
| offer both camera families | 4 tests |
| fall back to "Unknown path" | 2 tests |
| drop the radians hint from the message | 1 test |

2263 unit tests, 44 e2e, typecheck and lint clean.
