### PR TITLE
feat(arcade): five-minute replays, and the step budgets to fill them

### DIFF
--- a/packages/app/src/arcade/stepBudgetFitsVideo.test.ts
+++ b/packages/app/src/arcade/stepBudgetFitsVideo.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+import { createReplayVideoSchedule, MAX_REPLAY_VIDEO_DURATION_MS, } from '@/recorder/replayVideo'
+import { CINEMA_STEP_BUDGET, LESSON_TOPICS } from './topics'
+import type { RecordedAction, RecordedSession } from '@/recorder/schema'
+
+/**
+ * A step budget is really a video budget.
+ *
+ * An agent that fills its budget produces a take, and a take that will not
+ * export is worse than one step fewer: the lesson exists but nobody can watch
+ * it away from the editor. The two numbers live in different files, so this
+ * holds them together — raise a budget past what the encoder will accept and
+ * this fails rather than the user's export.
+ *
+ * The mix is measured, not invented. The Barnsley Fern lesson an agent
+ * recorded on 2026-09-04 spent 10 of its 22 steps on narration, at about
+ * twenty words each — long enough to hit the narration hold ceiling.
+ */
+const NARRATION_SHARE = 0.5
+const SENTENCE =
+  'Colour speed decides how fast a point commits to the palette, and the body transform runs most of the time here.'
+
+function worstRealisticTake(steps: number): RecordedSession {
+  const actions: RecordedAction[] = []
+  for (let i = 0; i < steps; i++) {
+    actions.push(
+      i % 2 === 0 &&
+        actions.filter((a) => a.id === 'lesson.note').length <
+          Math.round(steps * NARRATION_SHARE)
+        ? { t: i * 1000, id: 'lesson.note', args: [SENTENCE] }
+        : { t: i * 1000, id: 'flame.setGamma', args: [2.2 + i / 100] },
+    )
+  }
+  return { version: 1, actions } as unknown as RecordedSession
+}
+
+describe('step budgets fit inside a replay video', () => {
+  const budgets = [
+    ...Object.values(LESSON_TOPICS).map(
+      (topic) => [topic.id, topic.stepBudget] as const,
+    ),
+    ['cinema', CINEMA_STEP_BUDGET] as const,
+  ]
+
+  for (const [id, steps] of budgets) {
+    it(`${id} (${steps} steps) exports at 1x`, () => {
+      const { durationMs } = createReplayVideoSchedule(
+        worstRealisticTake(steps),
+      )
+      expect(durationMs).toBeLessThanOrEqual(MAX_REPLAY_VIDEO_DURATION_MS)
+    })
+  }
+
+  it('leaves room for a take that runs over the usual mix', () => {
+    // Not a knife-edge: the largest budget should still fit with a quarter of
+    // the cap to spare, or the first chatty agent hits the wall.
+    const largest = Math.max(...budgets.map(([, steps]) => steps))
+    const { durationMs } = createReplayVideoSchedule(
+      worstRealisticTake(largest),
+    )
+    expect(durationMs).toBeLessThanOrEqual(MAX_REPLAY_VIDEO_DURATION_MS * 0.75)
+  })
+})

--- a/packages/app/src/arcade/topics.ts
+++ b/packages/app/src/arcade/topics.ts
@@ -14,6 +14,15 @@ export interface LessonTopic {
   goal: string
   /** Exact ids or prefixes ending in "." (see guard.isCommandAllowed). */
   allowed: readonly string[]
+  /**
+   * How many steps the agent gets, narration included.
+   *
+   * It is capped by the replay VIDEO, not by patience: a narrated step is
+   * held long enough to read, so about four seconds of finished video per step
+   * is the real exchange rate, and MAX_REPLAY_VIDEO_DURATION_MS is what a
+   * budget ultimately spends. `stepBudgetFitsVideo.test.ts` holds the two
+   * numbers together so raising one cannot silently make lessons unexportable.
+   */
   stepBudget: number
   defaultStartFrom: 'blank' | 'current'
 }
@@ -44,7 +53,7 @@ export const LESSON_TOPICS: Record<TopicId, LessonTopic> = {
       'camera.center',
       'camera.zoomTo',
     ],
-    stepBudget: 30,
+    stepBudget: 45,
     defaultStartFrom: 'blank',
   },
   affine: {
@@ -62,7 +71,7 @@ export const LESSON_TOPICS: Record<TopicId, LessonTopic> = {
       'camera.center',
       'camera.zoomTo',
     ],
-    stepBudget: 30,
+    stepBudget: 45,
     defaultStartFrom: 'blank',
   },
   color: {
@@ -82,7 +91,7 @@ export const LESSON_TOPICS: Record<TopicId, LessonTopic> = {
       'flame.setBackgroundColor',
       'flame.setDrawMode',
     ],
-    stepBudget: 25,
+    stepBudget: 40,
     defaultStartFrom: 'current',
   },
   camera: {
@@ -95,7 +104,7 @@ export const LESSON_TOPICS: Record<TopicId, LessonTopic> = {
       'flame.setDrawMode',
       'view.setShowTimeline',
     ],
-    stepBudget: 20,
+    stepBudget: 32,
     defaultStartFrom: 'current',
   },
   genetics: {
@@ -109,7 +118,7 @@ export const LESSON_TOPICS: Record<TopicId, LessonTopic> = {
       'camera.center',
       'camera.zoomTo',
     ],
-    stepBudget: 20,
+    stepBudget: 32,
     defaultStartFrom: 'current',
   },
   sonification: {
@@ -122,7 +131,7 @@ export const LESSON_TOPICS: Record<TopicId, LessonTopic> = {
       'camera.center',
       'camera.zoomTo',
     ],
-    stepBudget: 18,
+    stepBudget: 28,
     defaultStartFrom: 'current',
   },
   render: {
@@ -138,7 +147,7 @@ export const LESSON_TOPICS: Record<TopicId, LessonTopic> = {
       'flame.setDrawMode',
       'camera.zoomTo',
     ],
-    stepBudget: 18,
+    stepBudget: 28,
     defaultStartFrom: 'current',
   },
 }

--- a/packages/app/src/recorder/replayVideo.ts
+++ b/packages/app/src/recorder/replayVideo.ts
@@ -36,7 +36,19 @@ export const REPLAY_VIDEO_DIMENSIONS = {
 } as const
 export const REPLAY_VIDEO_LEAD_IN_MS = 650
 export const REPLAY_VIDEO_TAIL_MS = 1400
-export const MAX_REPLAY_VIDEO_DURATION_MS = 120_000
+/**
+ * How long a replay video may be.
+ *
+ * The limit is memory, not taste: the muxer writes into an `ArrayBufferTarget`,
+ * so the whole MP4 is held in RAM until the download starts. At 1920x1080 the
+ * encoder sits on its 8 Mbps floor, which is 1 MB per second of video — five
+ * minutes is ~300 MB resident, and more than that during the buffer's growth.
+ *
+ * Two minutes was too tight in practice. A narrated Teach lesson holds each
+ * sentence long enough to read, so a twenty-two step lesson already ran 92s,
+ * and any lesson worth watching was one sentence away from being unexportable.
+ */
+export const MAX_REPLAY_VIDEO_DURATION_MS = 300_000
 
 // Custom variation definitions are global, executable WGSL today; they are not
 // part of the portable recorder schema. Publishing a take that references one

--- a/packages/app/src/webmcp/tools/arcadeTeach.test.ts
+++ b/packages/app/src/webmcp/tools/arcadeTeach.test.ts
@@ -37,7 +37,10 @@ describe('Teach tools', () => {
     expect(brief).toMatchObject({
       ok: true,
       topic: 'variations',
-      stepBudget: 30,
+      // The topic's own number, not a copy of it: what the budget should BE is
+      // settled by stepBudgetFitsVideo.test.ts, and this only checks that the
+      // brief reports it.
+      stepBudget: LESSON_TOPICS.variations.stepBudget,
     })
     expect(ctx.recorder!.start).toHaveBeenCalledTimes(1)
     expect(ctx.arcade!.closeHub).toHaveBeenCalledTimes(1)


### PR DESCRIPTION
## Why the cap existed

Nothing in the code said, so I traced it. It is **memory, not taste**: `mp4-muxer` writes into an `ArrayBufferTarget`, so the entire MP4 is held in RAM until the download starts. At 1920x1080 the encoder sits on `getDefaultBitrate`'s 8 Mbps floor — about **1 MB per second of video**.

| cap | resident MP4 |
| --- | --- |
| 120s (before) | ~120 MB |
| **300s (now)** | **~300 MB** |

Transient peak is higher while the buffer grows. On a machine that runs WebGPU this is fine; it is the number worth knowing before going further.

## Why 2 minutes was already broken

A narrated step is held long enough to read, so narration — not edits — is what a lesson's runtime is made of. Measured on the real takes:

| take | actions | narrations | replay at 1x |
| --- | --- | --- | --- |
| Barnsley Fern lesson (`color`, budget 25) | 22 | 10 | **92.3s** |
| Nine Seconds Through the Shells (Cinema) | 25 | 3 | 46.9s |

The fern lesson was at 77% of the old cap **without filling its budget**. Under a realistic narration mix, **7 of the 8 modes could fill their budget and produce a take that would not export** — the new ratchet test fails 7 of 9 cases if you put the cap back to 120s.

The wall the agent kept hitting was never its step count. It was the video those steps became.

## What changed

- `MAX_REPLAY_VIDEO_DURATION_MS` 120_000 → **300_000**, with a comment saying what actually constrains it.
- Step budgets raised, since the video now has room for them:

| topic | before | after | worst-case replay |
| --- | --- | --- | --- |
| variations | 30 | **45** | 184s / 300s |
| affine | 30 | **45** | 184s |
| color | 25 | **40** | 161s |
| camera | 20 | **32** | 129s |
| genetics | 20 | **32** | 129s |
| sonification | 18 | **28** | 113s |
| render | 18 | **28** | 113s |
| cinema | 40 | 40 | 161s |

Cinema is unchanged — its takes are edit-heavy, and #161 already gives it back one action per keyframe call.

## The two numbers now hold each other

`stepBudgetFitsVideo.test.ts` plays every budget through the **real** `createReplayVideoSchedule` at the narration mix a real lesson used (half the steps, ~20-word sentences — measured off the fern take, not invented), and requires it to fit with a quarter of the cap still spare. Raising a budget too far now fails there instead of in somebody's export.

Mutation-checked both ways:

| Mutation | Result |
| --- | --- |
| cap back to 120_000 | 7 of 9 fail |
| one budget to 200 | 2 fail |

The one assertion that hardcoded `stepBudget: 30` now reads the topic table, so what the budget *should be* is settled in one place.

## Trade-off worth naming

The interface capture screen-records the live player in real time, so a five-minute replay takes five minutes of wall clock to export. That was true before at two minutes; it is just longer now.

2260 unit tests, 44 e2e, typecheck and lint clean (4 pre-existing warnings, none in files touched here).