### PR TITLE
feat(duel): duel in 3D

### DIFF
--- a/packages/app/src/MainWorkspace.tsx
+++ b/packages/app/src/MainWorkspace.tsx
@@ -4896,7 +4896,13 @@ export function MainWorkspace(props: AppProps) {
                         roll={[effectiveRoll, setFlameRoll]}
                         flyMode={flyMode}
                         flySpeed={flySpeed}
+                        // Not while a duel covers this canvas: this camera
+                        // listens on `window` for the orbit keys, and the
+                        // player's seat binds the same setters to its own
+                        // camera — with both live, every key moved the flame
+                        // twice.
                         interactive={() =>
+                          !duelShowing() &&
                           !timeline.isPlaying() &&
                           (!animationExportRunning() ||
                             cameraDuringExportEnabled())

--- a/packages/app/src/MainWorkspace.tsx
+++ b/packages/app/src/MainWorkspace.tsx
@@ -7865,6 +7865,14 @@ export function MainWorkspace(props: AppProps) {
               playerFlame={effectiveFlame}
               playerZoom={[effectiveZoom, setFlameZoom]}
               playerPosition={[effectivePosition, setFlamePosition]}
+              playerCamera3D={{
+                theta: [effectiveTheta, setFlameTheta],
+                phi: [effectivePhi, setFlamePhi],
+                radius: [effectiveRadius, setFlameRadius],
+                target: [effectiveTarget3D, setFlameTarget3D],
+                fov: [effectiveFov, setFlameFov],
+                roll: [effectiveRoll, setFlameRoll],
+              }}
               quality={qualityPresets[qualityPreset()]}
               adaptiveFilter={adaptiveFilterEnabled()}
               stochasticFilter={stochasticFilterEnabled()}

--- a/packages/app/src/arcade/duelActions.ts
+++ b/packages/app/src/arcade/duelActions.ts
@@ -50,13 +50,10 @@ export function beginDuel(
   // A result card left on screen is not a running duel, but its seat is still
   // alive; starting over takes the old screen down first.
   if (duelShowing()) closeDuelView()
+  // 2D and 3D both. The seats bind whichever camera the flame asks for, and
+  // the rival is a mirror of the player, so the two halves are always the same
+  // dimension — there is nothing to reconcile.
   const playerFlame = ctx.flameDescriptor()
-  if (playerFlame.renderSettings.dimensions === 3) {
-    return {
-      error:
-        'Duel runs on 2D flames only for now, and this flame is 3D: the split screen binds a 2D camera per side. Switch to 2D and start again.',
-    }
-  }
   const solo = opts.opponent === 'none'
   const rivalFlame = deepClone(playerFlame)
   if (opts.rivalFrom === 'blank') {

--- a/packages/app/src/arcade/duelActions.ts
+++ b/packages/app/src/arcade/duelActions.ts
@@ -1,3 +1,5 @@
+import { generateDefaults } from '@/commands/builtins/generate'
+import { executeCommand } from '@/commands/registry'
 import { DEFAULT_SEAT } from '@/seats/seatId'
 import { deepClone } from '@/utils/clone'
 import { getWebMcpContext, setWebMcpContext, setWebMcpTarget, } from '@/webmcp/contextBridge'
@@ -26,6 +28,17 @@ import type { CommandContext } from '@/commands/types'
 export type DuelOpponent = 'ai' | 'none'
 
 /**
+ * What the viewer's side starts as.
+ *
+ * `current` is the flame they have loaded, which is the only thing a duel
+ * could start from before. The two random options exist because a duel is
+ * started by the agent, on whatever the viewer happens to have open — so
+ * without this, wanting a 3D duel meant loading a 3D flame by hand first and
+ * hoping the agent asked at the right moment.
+ */
+export type DuelStartFrom = 'current' | 'random-2d' | 'random-3d'
+
+/**
  * The one way a duel starts, whoever is in the other seat.
  *
  * Shared with the tool rather than reimplemented beside it: the 3D refusal,
@@ -38,6 +51,7 @@ export function beginDuel(
   opts: {
     seconds: number
     rivalFrom?: 'mirror' | 'blank'
+    startFrom?: DuelStartFrom
     opponent: DuelOpponent
   },
 ): { ok: true; seconds: number; allowed: string[] } | { error: string } {
@@ -50,6 +64,19 @@ export function beginDuel(
   // A result card left on screen is not a running duel, but its seat is still
   // alive; starting over takes the old screen down first.
   if (duelShowing()) closeDuelView()
+  // Through the registry, so the replacement is one recorded step the viewer
+  // can undo — and so the duel's own take begins from a state that exists.
+  if (opts.startFrom === 'random-2d' || opts.startFrom === 'random-3d') {
+    // The whole config, not `{ dimensions }`: a partial one fails every check
+    // in `asGenerateConfig` and falls back to the flame's current dimension
+    // without saying so, which is the opposite of what was asked for.
+    executeCommand(
+      'flame.randomize',
+      ctx,
+      undefined,
+      generateDefaults(opts.startFrom === 'random-3d' ? 3 : 2),
+    )
+  }
   // 2D and 3D both. The seats bind whichever camera the flame asks for, and
   // the rival is a mirror of the player, so the two halves are always the same
   // dimension — there is nothing to reconcile.

--- a/packages/app/src/arcade/soloDuel.test.ts
+++ b/packages/app/src/arcade/soloDuel.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { clearWebMcpContext, getWebMcpTarget, setWebMcpContext, setWebMcpTarget, } from '@/webmcp/contextBridge'
 import { createMockCommandContext, createTestFlame } from '@/webmcp/testUtils'
-import { duelActive, runningDuel, stopDuel } from './duel'
+import { duelActive, duelRivalSeat, runningDuel, stopDuel } from './duel'
 import { beginDuel, finishDuel } from './duelActions'
 import { agentDriving, resetPilot } from './pilot'
 
@@ -79,18 +79,18 @@ describe('a duel with no agent in it', () => {
     expect(runningDuel()?.rival.flame().transforms).toEqual({})
   })
 
-  it('refuses the same things the agent duel refuses', () => {
+  it('opens on a 3D flame too', () => {
     const ctx = createMockCommandContext()
     const flame = createTestFlame()
     flame.renderSettings.dimensions = 3
     ctx.flameDescriptor = () => flame
     setWebMcpContext(ctx)
 
-    expect(
-      (beginDuel(ctx, { seconds: 90, opponent: 'none' }) as { error: string })
-        .error,
-    ).toMatch(/3D/)
-    expect(duelActive()).toBe(false)
+    expect(beginDuel(ctx, { seconds: 90, opponent: 'none' })).toMatchObject({
+      ok: true,
+    })
+    expect(duelActive()).toBe(true)
+    expect(duelRivalSeat()?.flame().renderSettings.dimensions).toBe(3)
   })
 
   it('refuses a second duel on top of a running one', () => {

--- a/packages/app/src/arcade/soloDuel.test.ts
+++ b/packages/app/src/arcade/soloDuel.test.ts
@@ -93,6 +93,21 @@ describe('a duel with no agent in it', () => {
     expect(duelRivalSeat()?.flame().renderSettings.dimensions).toBe(3)
   })
 
+  it('starts a 3D duel from a 2D flame when asked to', () => {
+    const ctx = createMockCommandContext()
+    setWebMcpContext(ctx)
+    expect(ctx.flameDescriptor().renderSettings.dimensions ?? 2).toBe(2)
+
+    // Only the agent starts a duel, on whatever the viewer has open — so this
+    // is how a 3D duel is asked for without loading a 3D flame by hand first.
+    expect(
+      beginDuel(ctx, { seconds: 90, startFrom: 'random-3d', opponent: 'none' }),
+    ).toMatchObject({ ok: true })
+
+    expect(ctx.flameDescriptor().renderSettings.dimensions).toBe(3)
+    expect(duelRivalSeat()?.flame().renderSettings.dimensions).toBe(3)
+  })
+
   it('refuses a second duel on top of a running one', () => {
     const ctx = createMockCommandContext()
     setWebMcpContext(ctx)

--- a/packages/app/src/arcade/topics.ts
+++ b/packages/app/src/arcade/topics.ts
@@ -1,3 +1,5 @@
+import type { DuelStartFrom } from './duelActions'
+
 export type TopicId =
   | 'variations'
   | 'affine'
@@ -252,10 +254,33 @@ export const DUEL_ALLOWED = ['flame.', 'camera.'] as const
 
 export const DUEL_STEP_BUDGET = 60
 
-export function duelPromptCard(seconds: number): string {
+/**
+ * What the viewer's side starts as, in the words the prompt uses.
+ *
+ * The duel is started by the agent, on whatever the viewer has open, so this
+ * is how a viewer asks for a 3D duel without loading a 3D flame by hand first.
+ */
+const START_FROM_PHRASE: Record<DuelStartFrom, string> = {
+  current: '',
+  'random-2d':
+    ' Pass startFrom: "random-2d" — I want to start from a fresh random 2D flame rather than the one I have open.',
+  'random-3d':
+    ' Pass startFrom: "random-3d" — I want a 3D duel, starting from a fresh random 3D flame rather than the one I have open.',
+}
+
+export function duelPromptCard(
+  seconds: number,
+  startFrom: DuelStartFrom = 'current',
+): string {
   const minutes = Math.round((seconds / 60) * 10) / 10
   const clock = minutes === 1 ? '1 minute' : `${minutes} minutes`
-  return `Duel me in Lumen Apeiron. Call arcade_start_duel to begin: we each get ${clock} and our own flame, side by side, and I am editing mine while you edit yours. Read your flame with get_flame and change it with execute_command — only flame.* and camera.* are allowed, and you have ${DUEL_STEP_BUDGET} steps. Say what you are going for with arcade_narrate as you work. Aim for something striking rather than merely complicated. You cannot end the duel — the clock does, and I can call it early — so when you are happy call arcade_duel_ready with a short title and keep polishing until time runs out.
+  // The 3D camera has no commands of its own; it is reached through the
+  // generic render-setting path, which the agent has no way to guess.
+  const camera3D =
+    startFrom === 'random-3d'
+      ? ' In 3D the camera is orbit, not pan and zoom: read it from get_flame under renderSettings.camera3D and move it with execute_command flame.setRenderSetting on the paths camera3D.theta, camera3D.phi, camera3D.radius, camera3D.target, camera3D.fov and camera3D.roll. camera.* does nothing useful in 3D.'
+      : ''
+  return `Duel me in Lumen Apeiron. Call arcade_start_duel to begin: we each get ${clock} and our own flame, side by side, and I am editing mine while you edit yours.${START_FROM_PHRASE[startFrom]} Read your flame with get_flame and change it with execute_command — only flame.* and camera.* are allowed, and you have ${DUEL_STEP_BUDGET} steps.${camera3D} Say what you are going for with arcade_narrate as you work. Aim for something striking rather than merely complicated. You cannot end the duel — the clock does, and I can call it early — so when you are happy call arcade_duel_ready with a short title and keep polishing until time runs out.
 
 ${WEBMCP_FALLBACK_NOTE}`
 }

--- a/packages/app/src/commands/builtins/generate.ts
+++ b/packages/app/src/commands/builtins/generate.ts
@@ -23,8 +23,13 @@ function mintSeed(): number {
 }
 
 /** The randomizer card's baseline generation shape. An empty
- *  `allowedVariations` means the full variation pool. */
-function generateDefaults(dimensions: Dims): GenerateRandomFlameConfig {
+ *  `allowedVariations` means the full variation pool.
+ *
+ *  Exported because `asGenerateConfig` accepts only a COMPLETE config — a
+ *  partial `{ dimensions: 3 }` fails every one of its checks and falls back to
+ *  the flame's current dimension, silently. A caller that wants to randomize
+ *  at a chosen dimension has to hand over the whole shape. */
+export function generateDefaults(dimensions: Dims): GenerateRandomFlameConfig {
   return {
     strength: 0.5,
     minTransforms: 2,

--- a/packages/app/src/components/AffineEditor/AffineEditor.tsx
+++ b/packages/app/src/components/AffineEditor/AffineEditor.tsx
@@ -9,6 +9,7 @@ import { TrackChangesDiamond } from '@/components/Timeline/TrackChangesDiamond'
 import { useChangeHistory } from '@/contexts/ChangeHistoryContext'
 import { useTheme } from '@/contexts/ThemeContext'
 import { useTimeline } from '@/contexts/TimelineContext'
+import { ensure3DAffine, project3D as projectIso } from '@/flame/affine3DView'
 import { randomizeAffineCoef } from '@/flame/randomize'
 import { ArrowRightToBox, BoxArrowRight, GridIcon, ListIcon, Sparkle, } from '@/icons'
 import { AutoCanvas } from '@/lib/AutoCanvas'
@@ -91,11 +92,8 @@ function cross2d(a: v2f, b: v2f) {
 }
 
 function project3D(x: number, y: number, z: number): v2f {
-  const zAngle = (135 * Math.PI) / 180
-  const zScale = 0.5
-  const px = x + z * Math.cos(zAngle) * zScale
-  const py = y + z * Math.sin(zAngle) * zScale
-  return vec2f(px, py)
+  const p = projectIso(x, y, z)
+  return vec2f(p.x, p.y)
 }
 
 function Grid(props: { isVisible: () => boolean }) {
@@ -433,36 +431,6 @@ function AffineHandle(props: {
     const g = props.transform.g ?? 0
     const k = props.transform.k ?? 1
     return getPointProj(d - c, h - g, l - k)
-  }
-
-  // In a 3D flame the affine handles must operate on a full 3D affine in the
-  // kernel's layout (rows a,b,c,d / e,f,g,h / i,j,k,l; translation d,h,l). A 2D
-  // affine (a..f) dragged here would otherwise be misread: its 2D y-row (d,e,f)
-  // lands in the 3D y-row and the result collapses to a plane (pancake). Promote
-  // it first, mirroring ifsPipeline3D's 2D→3D mapping.
-  const ensure3DAffine = (t: AffineParams): AffineParams => {
-    const already3D =
-      t.g !== undefined ||
-      t.h !== undefined ||
-      t.i !== undefined ||
-      t.j !== undefined ||
-      t.k !== undefined ||
-      t.l !== undefined
-    if (already3D) return t
-    return {
-      a: t.a ?? 1,
-      b: t.b ?? 0,
-      c: 0,
-      d: t.c ?? 0,
-      e: t.d ?? 0,
-      f: t.e ?? 1,
-      g: 0,
-      h: t.f ?? 0,
-      i: 0,
-      j: 0,
-      k: 1,
-      l: 0,
-    }
   }
 
   const startDragging3D = createDragHandler((initEvent) => {

--- a/packages/app/src/components/Arcade/ArcadeModePanel.module.css
+++ b/packages/app/src/components/Arcade/ArcadeModePanel.module.css
@@ -1,0 +1,27 @@
+/* What a duel would run on, said before it starts: only the agent starts one,
+   on whatever the viewer has open, so the dimension is otherwise a surprise. */
+.dimensionRow {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin: 0;
+  font-size: 0.78rem;
+  opacity: 0.72;
+}
+
+.dimensionPill {
+  flex: none;
+  padding: 2px 8px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  background: rgba(255, 255, 255, 0.06);
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
+.dimension3D {
+  border-color: rgba(149, 241, 253, 0.5);
+  background: rgba(149, 241, 253, 0.12);
+  color: #cbf6ff;
+}

--- a/packages/app/src/components/Arcade/ArcadeModePanel.tsx
+++ b/packages/app/src/components/Arcade/ArcadeModePanel.tsx
@@ -5,6 +5,7 @@ import { CINEMA_PRESETS, cinemaPromptCard, duelPromptCard, LESSON_TOPICS, teachP
 import { Copy, Cross, Swords } from '@/icons'
 import { getWebMcpContext } from '@/webmcp/contextBridge'
 import ui from './ArcadeHub.module.css'
+import type { DuelStartFrom } from '@/arcade/duelActions'
 import type { TopicId } from '@/arcade/topics'
 import type { ArcadeMode } from '@/lib/activeTab'
 
@@ -76,6 +77,22 @@ export function ArcadeModePanel(props: {
     String(DEFAULT_DUEL_SECONDS),
   )
   const duelSeconds = () => clampDuelSeconds(duelSecondsText())
+  const [startFrom, setStartFrom] = createSignal<DuelStartFrom>('current')
+  /**
+   * What a duel would run on right now.
+   *
+   * Only the agent starts a duel, on whatever the viewer has open, so without
+   * this the dimension of the duel about to begin is a surprise. Reads the
+   * same bridge the solo button reads.
+   */
+  const loadedDimensions = () =>
+    getWebMcpContext('player')?.flameDescriptor().renderSettings.dimensions ?? 2
+  const duelDimensions = () =>
+    startFrom() === 'random-3d'
+      ? 3
+      : startFrom() === 'random-2d'
+        ? 2
+        : loadedDimensions()
   const [soloError, setSoloError] = createSignal<string>()
   /**
    * The hub is mounted beside the workspace rather than inside it, so it has
@@ -91,6 +108,7 @@ export function ArcadeModePanel(props: {
     }
     const started = beginDuel(ctx, {
       seconds: duelSeconds(),
+      startFrom: startFrom(),
       opponent: 'none',
     })
     setSoloError('error' in started ? started.error : undefined)
@@ -105,7 +123,7 @@ export function ArcadeModePanel(props: {
     props.mode === 'teach'
       ? teachPromptCard(topic())
       : props.mode === 'duel'
-        ? duelPromptCard(duelSeconds())
+        ? duelPromptCard(duelSeconds(), startFrom())
         : cinemaPromptCard(description())
   return (
     <aside
@@ -195,6 +213,38 @@ export function ArcadeModePanel(props: {
           <p>
             You and the agent each get a flame and one clock. Paste the prompt,
             then build against it — both sides are recorded and replayable.
+          </p>
+          <label class={ui.field}>
+            <span>Start from</span>
+            <select
+              value={startFrom()}
+              onChange={(ev) => {
+                setStartFrom(ev.currentTarget.value as DuelStartFrom)
+              }}
+            >
+              <option value="current">The flame I have open</option>
+              <option value="random-2d">A random 2D flame</option>
+              <option value="random-3d">A random 3D flame</option>
+            </select>
+          </label>
+          <p class={ui.dimensionRow}>
+            <span
+              class={ui.dimensionPill}
+              classList={{ [ui.dimension3D!]: duelDimensions() === 3 }}
+            >
+              {duelDimensions() === 3 ? '3D' : '2D'}
+            </span>
+            <Show
+              when={duelDimensions() === 3}
+              fallback={
+                <span>Pan and zoom, and the full 403-variation set.</span>
+              }
+            >
+              <span>
+                Orbit camera per side, and the 43 variations that work in three
+                dimensions.
+              </span>
+            </Show>
           </p>
           <label class={ui.field}>
             <span>Clock, in seconds</span>

--- a/packages/app/src/components/Duel/AffineGrid.module.css
+++ b/packages/app/src/components/Duel/AffineGrid.module.css
@@ -72,3 +72,13 @@
   stroke-width: 0.01;
   stroke-dasharray: 0.06 0.05;
 }
+
+/* The third axis, when there is one: a spoke off the origin rather than a side
+   of the triangle, which is the x/y face. */
+.zSpoke {
+  stroke: rgba(160, 215, 235, 0.75);
+  stroke-width: 0.024;
+  stroke-dasharray: 0.09 0.06;
+  stroke-linecap: round;
+  fill: none;
+}

--- a/packages/app/src/components/Duel/AffineGrid.test.tsx
+++ b/packages/app/src/components/Duel/AffineGrid.test.tsx
@@ -1,0 +1,83 @@
+import { cleanup, render } from '@solidjs/testing-library'
+import { afterEach, describe, expect, it } from 'vitest'
+import { project3D } from '@/flame/affine3DView'
+import { AffineGrid } from './AffineGrid'
+import type { AffineParams } from '@/flame/affineTranform'
+
+const IDENTITY_3D: AffineParams = {
+  a: 1,
+  b: 0,
+  c: 0,
+  d: 0,
+  e: 0,
+  f: 1,
+  g: 0,
+  h: 0,
+  i: 0,
+  j: 0,
+  k: 1,
+  l: 0,
+}
+
+/** The grid spans 2*EXTENT world units; mount it as a 320px square. */
+const EXTENT = 1.6
+const SIZE = 320
+
+/** Screen pixel for a world point, given the stubbed 320px box at (0, 0). */
+function px(world: { x: number; y: number }) {
+  return {
+    clientX: ((world.x / EXTENT + 1) / 2) * SIZE,
+    clientY: ((-world.y / EXTENT + 1) / 2) * SIZE,
+  }
+}
+
+describe('AffineGrid in 3D', () => {
+  afterEach(cleanup)
+
+  it('moves depth once per drag, not once per frame', () => {
+    // jsdom has no layout: give the svg the box the maths assumes.
+    const affine = { current: IDENTITY_3D }
+    const { container } = render(() => (
+      <AffineGrid
+        affine={affine.current}
+        ghosts={[]}
+        is3D
+        onChange={(next) => {
+          affine.current = next
+        }}
+      />
+    ))
+    const svg = container.querySelector('svg')!
+    Object.defineProperty(svg, 'getBoundingClientRect', {
+      value: () => ({ left: 0, top: 0, width: SIZE, height: SIZE }),
+    })
+    const zHandle = container.querySelectorAll('[class*="handleHit"]')[3]!
+    Object.defineProperty(zHandle, 'setPointerCapture', { value: () => {} })
+    Object.defineProperty(zHandle, 'releasePointerCapture', { value: () => {} })
+
+    // Start on the Z handle (world (0,0,1) projected), then drag along the
+    // depth diagonal by exactly one unit of depth, in two half-steps.
+    const zStart = project3D(0, 0, 1)
+    const one = project3D(0, 0, 1)
+    const down = px(zStart)
+    zHandle.dispatchEvent(
+      new MouseEvent('pointerdown', { bubbles: true, ...down }),
+    )
+    const half = px({ x: zStart.x + one.x / 2, y: zStart.y + one.y / 2 })
+    const full = px({ x: zStart.x + one.x, y: zStart.y + one.y })
+    window.dispatchEvent(
+      new MouseEvent('pointermove', { shiftKey: true, ...half }),
+    )
+    window.dispatchEvent(
+      new MouseEvent('pointermove', { shiftKey: true, ...full }),
+    )
+    window.dispatchEvent(new MouseEvent('pointerup', {}))
+
+    // The Z basis image was at depth 1; the drag asked for one more. Reading
+    // the live value each move would have landed at 1 + 0.5 + 1 = 2.5.
+    expect(affine.current.k).toBeCloseTo(2, 5)
+    // And the plane components were held.
+    expect(affine.current.c).toBeCloseTo(0, 5)
+    expect(affine.current.g).toBeCloseTo(0, 5)
+  })
+})

--- a/packages/app/src/components/Duel/AffineGrid.tsx
+++ b/packages/app/src/components/Duel/AffineGrid.tsx
@@ -1,5 +1,6 @@
 import { createSignal, For, Show } from 'solid-js'
 import { composeAffine, decomposeAffine } from '@/arcade/affineControls'
+import { basis3D, depthFromScreenDelta, ensure3DAffine, project3D, unproject3D, } from '@/flame/affine3DView'
 import ui from './AffineGrid.module.css'
 import type { AffineParams } from '@/flame/affineTranform'
 
@@ -23,8 +24,12 @@ import type { AffineParams } from '@/flame/affineTranform'
 const EXTENT = 1.6
 const GRID_STEP = 0.2
 
-type Handle = 'o' | 'x' | 'y'
+type Handle = 'o' | 'x' | 'y' | 'z'
 
+const HANDLES_2D = ['o', 'x', 'y'] as const satisfies readonly Handle[]
+const HANDLES_3D = ['o', 'x', 'y', 'z'] as const satisfies readonly Handle[]
+
+/** The 2D layout: `a,b,c` / `d,e,f`, translation in `c,f`. */
 function points(affine: AffineParams) {
   const { a, b, c, d, e, f } = affine
   return {
@@ -34,10 +39,27 @@ function points(affine: AffineParams) {
   }
 }
 
+/**
+ * The same three handles plus a Z, flattened onto the fixed isometric the
+ * workspace editor draws on — the same `project3D`, so the two diagrams of a
+ * 3D transform agree.
+ */
+function points3D(affine: AffineParams) {
+  const b = basis3D(affine)
+  return {
+    o: project3D(b.o.x, b.o.y, b.o.z),
+    x: project3D(b.x.x, b.x.y, b.x.z),
+    y: project3D(b.y.x, b.y.y, b.y.z),
+    z: project3D(b.z.x, b.z.y, b.z.z),
+  }
+}
+
 export function AffineGrid(props: {
   affine: AffineParams
   /** Every other transform, drawn behind so you can see what you are aiming at. */
   ghosts: readonly AffineParams[]
+  /** Draw and drag the third axis. */
+  is3D?: boolean
   onChange: (affine: AffineParams) => void
   onCommit?: () => void
 }) {
@@ -63,8 +85,52 @@ export function AffineGrid(props: {
     setDragging(handle)
     const target = ev.currentTarget as Element
     target.setPointerCapture(ev.pointerId)
+    const start = toWorld(ev)
+
+    const move3D = (moveEv: PointerEvent) => {
+      const screen = toWorld(moveEv)
+      if (!screen || !start) return
+      const current = ensure3DAffine(props.affine)
+      const b = basis3D(current)
+      const held = b[handle]
+      /*
+       * Two screen axes cannot decide three world ones, so a drag holds one.
+       * Plain drag moves the handle in the projection plane at its own depth;
+       * Shift drags along the projection's own diagonal and moves depth alone,
+       * which is the only axis a flat gesture cannot otherwise reach.
+       */
+      const next = moveEv.shiftKey
+        ? {
+            x: held.x,
+            y: held.y,
+            z:
+              held.z +
+              depthFromScreenDelta(screen.x - start.x, screen.y - start.y),
+          }
+        : { ...unproject3D(screen.x, screen.y, held.z), z: held.z }
+
+      if (handle === 'o') {
+        props.onChange({ ...current, d: next.x, h: next.y, l: next.z })
+        return
+      }
+      // The basis handles are vectors FROM the origin, so what a drag sets is
+      // the difference, not the position.
+      const o = b.o
+      const v = { x: next.x - o.x, y: next.y - o.y, z: next.z - o.z }
+      props.onChange(
+        handle === 'x'
+          ? { ...current, a: v.x, e: v.y, i: v.z }
+          : handle === 'y'
+            ? { ...current, b: v.x, f: v.y, j: v.z }
+            : { ...current, c: v.x, g: v.y, k: v.z },
+      )
+    }
 
     const move = (moveEv: PointerEvent) => {
+      if (props.is3D === true) {
+        move3D(moveEv)
+        return
+      }
       const world = toWorld(moveEv)
       if (!world) return
       const current = props.affine
@@ -95,9 +161,15 @@ export function AffineGrid(props: {
   }
 
   // SVG space: the box is 2*EXTENT wide, centred, y flipped once on the group.
-  const P = () => points(props.affine)
+  // Always four entries, so the guide lines can index by handle whichever
+  // dimension is in play; `z` sits on the origin in 2D and is never drawn.
+  const P = (): Record<Handle, { x: number; y: number }> => {
+    if (props.is3D === true) return points3D(props.affine)
+    const flat = points(props.affine)
+    return { ...flat, z: flat.o }
+  }
   const tri = (affine: AffineParams) => {
-    const p = points(affine)
+    const p = props.is3D === true ? points3D(affine) : points(affine)
     return `${p.o.x},${p.o.y} ${p.x.x},${p.x.y} ${p.y.x},${p.y.y}`
   }
   const lines = () => {
@@ -176,7 +248,19 @@ export function AffineGrid(props: {
 
         <polygon class={ui.shape} points={tri(props.affine)} />
 
-        <For each={['o', 'x', 'y'] as const}>
+        {/* The third axis is a spoke rather than a side: the triangle is the
+            x/y face, and Z leaves it. */}
+        <Show when={props.is3D === true}>
+          <line
+            class={ui.zSpoke}
+            x1={P().o.x}
+            y1={P().o.y}
+            x2={P().z.x}
+            y2={P().z.y}
+          />
+        </Show>
+
+        <For each={props.is3D === true ? HANDLES_3D : HANDLES_2D}>
           {(handle) => (
             <g
               class={ui.handle}

--- a/packages/app/src/components/Duel/AffineGrid.tsx
+++ b/packages/app/src/components/Duel/AffineGrid.tsx
@@ -86,6 +86,12 @@ export function AffineGrid(props: {
     const target = ev.currentTarget as Element
     target.setPointerCapture(ev.pointerId)
     const start = toWorld(ev)
+    // Depth at pointer-down. The delta below is measured from `start`, so it
+    // has to be added to where the handle WAS, not to where the previous move
+    // already put it — re-reading the live value each move re-added the whole
+    // displacement every frame and the depth ran away.
+    const startZ =
+      props.is3D === true ? basis3D(ensure3DAffine(props.affine))[handle].z : 0
 
     const move3D = (moveEv: PointerEvent) => {
       const screen = toWorld(moveEv)
@@ -104,7 +110,7 @@ export function AffineGrid(props: {
             x: held.x,
             y: held.y,
             z:
-              held.z +
+              startZ +
               depthFromScreenDelta(screen.x - start.x, screen.y - start.y),
           }
         : { ...unproject3D(screen.x, screen.y, held.z), z: held.z }

--- a/packages/app/src/components/Duel/DuelChips.module.css
+++ b/packages/app/src/components/Duel/DuelChips.module.css
@@ -815,3 +815,12 @@
 .addBar .addBack {
   margin-left: auto;
 }
+
+/* Depth is the one axis a flat gesture cannot reach, so it is worth one line
+   of prose rather than a control nobody would find. */
+.shapeHint {
+  margin: 0;
+  font-size: 0.68rem;
+  text-align: center;
+  opacity: 0.55;
+}

--- a/packages/app/src/components/Duel/DuelChips.test.tsx
+++ b/packages/app/src/components/Duel/DuelChips.test.tsx
@@ -200,6 +200,37 @@ describe('DuelChips', () => {
     expect(screen.queryByRole('button', { name: /more$/ })).toBeNull()
   })
 
+  it('edits a 3D transform through offsets and a fourth handle', () => {
+    const ctx = createMockCommandContext()
+    ctx.setFlameDescriptor((draft) => {
+      draft.renderSettings.dimensions = 3
+    }, 'test')
+    render(() => <DuelChips ctx={ctx} flame={ctx.flameDescriptor} />)
+    screen.getByRole('button', { name: /Shape/ }).click()
+    const panel = screen.getByLabelText('Shape')
+
+    // Four handles, not three: the triangle is the x/y face and Z is a spoke
+    // off the origin.
+    expect(panel.querySelectorAll('[class*="handleHit"]')).toHaveLength(4)
+    // And the fields are the three translations. A 3x4 does not decompose
+    // into scale/rotation/shear the way a 2x3 does.
+    for (const label of ['X offset', 'Y offset', 'Z offset']) {
+      expect(screen.getByRole('slider', { name: label })).toBeTruthy()
+    }
+    expect(screen.queryByRole('slider', { name: 'Rotate' })).toBeNull()
+
+    screen
+      .getByRole('slider', { name: 'Z offset' })
+      .dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }),
+      )
+
+    expect(firstTransform(ctx.flameDescriptor()).preAffine.l).toBeCloseTo(
+      0.01,
+      6,
+    )
+  })
+
   it('keeps working when a randomize takes the chosen transform away', () => {
     const ctx = mount()
     screen.getByRole('button', { name: /Shape/ }).click()

--- a/packages/app/src/components/Duel/DuelChips.tsx
+++ b/packages/app/src/components/Duel/DuelChips.tsx
@@ -5,6 +5,7 @@ import { executeCommand } from '@/commands/registry'
 import { VariationPreview } from '@/components/VariationSelector/VariationSelector'
 import { ComputeGate } from '@/contexts/ComputeGateContext'
 import { COMPUTE_GATE_CAPACITY } from '@/defaults'
+import { ensure3DAffine } from '@/flame/affine3DView'
 import { palette } from '@/flame/colorMap'
 import { defaultPalettes, paletteToGradientCSS } from '@/flame/palettes'
 import { variationTypesFor } from '@/flame/variationRegistry'
@@ -200,6 +201,7 @@ export function DuelChips(props: {
                 <ShapePanel
                   affine={active().preAffine}
                   ghosts={ghostAffines()}
+                  is3D={(props.flame().renderSettings.dimensions ?? 2) === 3}
                   onChange={(affine) => {
                     dispatch(
                       'flame.setTransformAffine',
@@ -566,9 +568,26 @@ function readableType(type: string): string {
   )
 }
 
+/**
+ * The three translations, which are the only part of a 3D transform a scrub
+ * field can state honestly.
+ *
+ * The 2D panel decomposes into scale, rotation and shear because a 2x3 matrix
+ * decomposes cleanly. A 3x4 does not: rotation needs three angles, the order
+ * matters, and a naive Euler triple gimbal-locks at exactly the default camera
+ * angle. So shape comes from dragging the basis handles — which is what the
+ * grid was always for — and the fields say where the transform sits.
+ */
+const OFFSET_3D = [
+  { key: 'd', label: 'X offset' },
+  { key: 'h', label: 'Y offset' },
+  { key: 'l', label: 'Z offset' },
+] as const
+
 function ShapePanel(props: {
   affine: AffineParams
   ghosts: readonly AffineParams[]
+  is3D?: boolean
   onChange: (affine: AffineParams) => void
 }) {
   const controls = () => decomposeAffine(props.affine)
@@ -578,11 +597,36 @@ function ShapePanel(props: {
         <AffineGrid
           affine={props.affine}
           ghosts={props.ghosts}
+          is3D={props.is3D}
           onChange={props.onChange}
         />
       </div>
+      <Show when={props.is3D === true}>
+        <p class={ui.shapeHint}>
+          Drag a handle to move it flat; hold Shift to move it in depth.
+        </p>
+      </Show>
       <div class={ui.fields}>
-        <For each={AFFINE_CONTROLS}>
+        <Show when={props.is3D === true}>
+          <For each={OFFSET_3D}>
+            {(spec) => (
+              <ScrubField
+                label={spec.label}
+                value={ensure3DAffine(props.affine)[spec.key] ?? 0}
+                step={0.01}
+                perPixel={0.005}
+                decimals={3}
+                onChange={(next) => {
+                  props.onChange({
+                    ...ensure3DAffine(props.affine),
+                    [spec.key]: next,
+                  })
+                }}
+              />
+            )}
+          </For>
+        </Show>
+        <For each={props.is3D === true ? [] : AFFINE_CONTROLS}>
           {(spec) => (
             <ScrubField
               label={spec.label}

--- a/packages/app/src/components/Duel/DuelStage.tsx
+++ b/packages/app/src/components/Duel/DuelStage.tsx
@@ -17,6 +17,7 @@ import type { Accessor, Signal } from 'solid-js'
 import type { v2f } from 'typegpu/data'
 import type { CommandContext } from '@/commands/types'
 import type { FlameDescriptor } from '@/flame/schema/flameSchema'
+import type { Seat3DCamera } from '@/seats/seat'
 
 /**
  * The split screen.
@@ -34,6 +35,8 @@ export function DuelStage(props: {
   playerFlame: Accessor<FlameDescriptor>
   playerZoom: Signal<number>
   playerPosition: Signal<v2f>
+  /** The workspace's own 3D camera, bound when the duel is on a 3D flame. */
+  playerCamera3D: Seat3DCamera
   /**
    * The viewer's own render settings, verbatim. A duel is two flames on one
    * GPU, so ultra converges at about half the rate it does on the workspace —
@@ -124,6 +127,7 @@ export function DuelStage(props: {
                 flame={props.playerFlame}
                 zoom={props.playerZoom}
                 position={props.playerPosition}
+                camera3D={props.playerCamera3D}
                 quality={props.quality}
                 adaptiveFilter={props.adaptiveFilter}
                 stochasticFilter={props.stochasticFilter}
@@ -142,6 +146,7 @@ export function DuelStage(props: {
                 flame={rival().flame}
                 zoom={[rival().zoom, rival().setZoom]}
                 position={[rival().position, rival().setPosition]}
+                camera3D={rival().camera3D}
                 quality={props.quality}
                 adaptiveFilter={props.adaptiveFilter}
                 stochasticFilter={props.stochasticFilter}

--- a/packages/app/src/components/Duel/FlameStill.tsx
+++ b/packages/app/src/components/Duel/FlameStill.tsx
@@ -1,11 +1,14 @@
-import { createSignal } from 'solid-js'
+import { createSignal, Show } from 'solid-js'
 import { vec2f, vec4f } from 'typegpu/data'
 import { DEFAULT_POINT_COUNT } from '@/defaults'
 import { palette as makePalette } from '@/flame/colorMap'
 import { Flam3 } from '@/flame/Flam3'
+import { camera3DDefault } from '@/flame/schema/flameSchema'
 import { AutoCanvas } from '@/lib/AutoCanvas'
 import { Root } from '@/lib/Root'
 import { WheelZoomCamera2D } from '@/lib/WheelZoomCamera2D'
+import { WheelZoomCamera3D } from '@/lib/WheelZoomCamera3D'
+import type { Vec3 } from 'wgpu-matrix'
 import type { FlameDescriptor } from '@/flame/schema/flameSchema'
 import type { ExportImageType } from '@/MainWorkspace'
 
@@ -18,8 +21,9 @@ import type { ExportImageType } from '@/MainWorkspace'
  * the export tracker, because this is a picture the app wants, not a job the
  * viewer asked for.
  *
- * 2D only, deliberately: a duel refuses 3D flames, so there is no dimension
- * to branch on.
+ * Both dimensions, as `ExportJobHost` does: a duel runs on whichever the
+ * viewer's flame is, and a 3D card that fell back to the 2D camera would
+ * render the flame flat.
  */
 export function FlameStill(props: {
   flame: FlameDescriptor
@@ -40,6 +44,17 @@ export function FlameStill(props: {
   const camera = props.flame.renderSettings.camera
   const zoom = createSignal(camera.zoom)
   const position = createSignal(vec2f(camera.position[0], camera.position[1]))
+
+  // Frozen at the flame's own camera, as `OffscreenRender` does: the still is
+  // one frame of a finished duel, so nothing moves it.
+  const is3D = (props.flame.renderSettings.dimensions ?? 2) === 3
+  const c3d = props.flame.renderSettings.camera3D ?? camera3DDefault
+  const theta = createSignal(c3d.theta)
+  const phi = createSignal(c3d.phi)
+  const radius = createSignal(c3d.radius)
+  const target = createSignal<Vec3>(new Float32Array(c3d.target))
+  const fov = createSignal(c3d.fov)
+  const roll = createSignal(c3d.roll)
 
   // The descriptor stores a palette without the provenance a `Palette`
   // carries, so it is rebuilt rather than cast.
@@ -70,31 +85,56 @@ export function FlameStill(props: {
     capture(canvas)
   }
 
+  // A component, not a hoisted JSX value: JSX in a variable is evaluated where
+  // it is written, which put `Flam3` outside `<Root>` and threw on its first
+  // `useRootContext`. As a component it runs where it is rendered — inside
+  // whichever camera the flame asked for.
+  const FlameLayer = () => (
+    <Flam3
+      quality={props.quality}
+      pointCountPerBatch={DEFAULT_POINT_COUNT}
+      adaptiveFilterEnabled={props.adaptiveFilter}
+      stochasticFilterEnabled={props.stochasticFilter}
+      animationEnabled={false}
+      exportDriver
+      flameDescriptor={props.flame}
+      renderInterval={0}
+      edgeFadeColor={vec4f(0)}
+      palette={() => palette}
+      onExportImage={handleExport}
+    />
+  )
+
   return (
     <Root adapterOptions={{ powerPreference: 'high-performance' }}>
       <AutoCanvas
         fixedResolution={{ width: props.width, height: props.height }}
         alphaMode="opaque"
       >
-        <WheelZoomCamera2D
-          zoom={zoom}
-          position={position}
-          interactive={() => false}
+        <Show
+          when={is3D}
+          fallback={
+            <WheelZoomCamera2D
+              zoom={zoom}
+              position={position}
+              interactive={() => false}
+            >
+              <FlameLayer />
+            </WheelZoomCamera2D>
+          }
         >
-          <Flam3
-            quality={props.quality}
-            pointCountPerBatch={DEFAULT_POINT_COUNT}
-            adaptiveFilterEnabled={props.adaptiveFilter}
-            stochasticFilterEnabled={props.stochasticFilter}
-            animationEnabled={false}
-            exportDriver
-            flameDescriptor={props.flame}
-            renderInterval={0}
-            edgeFadeColor={vec4f(0)}
-            palette={() => palette}
-            onExportImage={handleExport}
-          />
-        </WheelZoomCamera2D>
+          <WheelZoomCamera3D
+            theta={theta}
+            phi={phi}
+            radius={radius}
+            target={target}
+            fov={fov}
+            roll={roll}
+            interactive={() => false}
+          >
+            <FlameLayer />
+          </WheelZoomCamera3D>
+        </Show>
       </AutoCanvas>
     </Root>
   )

--- a/packages/app/src/components/Duel/SeatView.tsx
+++ b/packages/app/src/components/Duel/SeatView.tsx
@@ -1,14 +1,16 @@
-import { createMemo } from 'solid-js'
+import { createMemo, Show } from 'solid-js'
 import { vec4f } from 'typegpu/data'
 import { DEFAULT_POINT_COUNT, DEFAULT_RENDER_INTERVAL_MS } from '@/defaults'
 import { palette as makePalette } from '@/flame/colorMap'
 import { Flam3 } from '@/flame/Flam3'
 import { AutoCanvas } from '@/lib/AutoCanvas'
 import { WheelZoomCamera2D } from '@/lib/WheelZoomCamera2D'
+import { WheelZoomCamera3D } from '@/lib/WheelZoomCamera3D'
 import ui from './DuelStage.module.css'
 import type { Accessor, Signal } from 'solid-js'
 import type { v2f } from 'typegpu/data'
 import type { FlameDescriptor } from '@/flame/schema/flameSchema'
+import type { Seat3DCamera } from '@/seats/seat'
 
 /**
  * One half of the split screen: a live flame with its own camera.
@@ -25,6 +27,8 @@ export function SeatView(props: {
   flame: Accessor<FlameDescriptor>
   zoom: Signal<number>
   position: Signal<v2f>
+  /** The same seat's 3D camera, bound when the flame is 3D. */
+  camera3D: Seat3DCamera
   quality: number
   /** The viewer's own filter settings, so a seat matches their workspace. */
   adaptiveFilter: boolean
@@ -48,6 +52,27 @@ export function SeatView(props: {
       : undefined
   })
 
+  // Free per seat: each side orbits its own flame. The viewer's half is
+  // theirs, and the agent reframing its own flame is part of what it is
+  // showing off — so the two cameras are independent rather than locked.
+  const is3D = () => (props.flame().renderSettings.dimensions ?? 2) === 3
+
+  // A component, not a hoisted JSX value: JSX in a variable is evaluated where
+  // it is written, which would put `Flam3` outside the camera it needs.
+  const FlameLayer = () => (
+    <Flam3
+      quality={props.quality}
+      pointCountPerBatch={DEFAULT_POINT_COUNT}
+      renderInterval={DEFAULT_RENDER_INTERVAL_MS}
+      adaptiveFilterEnabled={props.adaptiveFilter}
+      stochasticFilterEnabled={props.stochasticFilter}
+      animationEnabled={false}
+      flameDescriptor={props.flame()}
+      edgeFadeColor={vec4f(0)}
+      palette={seatPalette}
+    />
+  )
+
   return (
     <section class={ui.seat} aria-label={props.label}>
       <h3
@@ -68,23 +93,30 @@ export function SeatView(props: {
         role="img"
         ariaLabel={`${props.label}: fractal flame`}
       >
-        <WheelZoomCamera2D
-          zoom={props.zoom}
-          position={props.position}
-          interactive={() => props.interactive}
+        <Show
+          when={is3D()}
+          fallback={
+            <WheelZoomCamera2D
+              zoom={props.zoom}
+              position={props.position}
+              interactive={() => props.interactive}
+            >
+              <FlameLayer />
+            </WheelZoomCamera2D>
+          }
         >
-          <Flam3
-            quality={props.quality}
-            pointCountPerBatch={DEFAULT_POINT_COUNT}
-            renderInterval={DEFAULT_RENDER_INTERVAL_MS}
-            adaptiveFilterEnabled={props.adaptiveFilter}
-            stochasticFilterEnabled={props.stochasticFilter}
-            animationEnabled={false}
-            flameDescriptor={props.flame()}
-            edgeFadeColor={vec4f(0)}
-            palette={seatPalette}
-          />
-        </WheelZoomCamera2D>
+          <WheelZoomCamera3D
+            theta={props.camera3D.theta}
+            phi={props.camera3D.phi}
+            radius={props.camera3D.radius}
+            target={props.camera3D.target}
+            fov={props.camera3D.fov}
+            roll={props.camera3D.roll}
+            interactive={() => props.interactive}
+          >
+            <FlameLayer />
+          </WheelZoomCamera3D>
+        </Show>
       </AutoCanvas>
     </section>
   )

--- a/packages/app/src/flame/affine3DView.test.ts
+++ b/packages/app/src/flame/affine3DView.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+import { basis3D, depthFromScreenDelta, ensure3DAffine, project3D, unproject3D, } from './affine3DView'
+
+const FLAT = { a: 2, b: 0.5, c: 0.25, d: -0.5, e: 1.5, f: 0.75 }
+
+describe('ensure3DAffine', () => {
+  it('promotes a 2D affine without collapsing it to a plane', () => {
+    // The trap: a 2D affine's y-row (d,e,f) landing in the 3D y-row pancakes
+    // the transform. The mapping has to move `c` and `f` into the translation
+    // column and open a real z-row.
+    const t = ensure3DAffine(FLAT)
+    expect([t.a, t.b, t.c, t.d]).toEqual([2, 0.5, 0, 0.25])
+    expect([t.e, t.f, t.g, t.h]).toEqual([-0.5, 1.5, 0, 0.75])
+    expect([t.i, t.j, t.k, t.l]).toEqual([0, 0, 1, 0])
+  })
+
+  it('leaves an affine that is already 3D alone', () => {
+    const already = { ...ensure3DAffine(FLAT), k: 3 }
+    expect(ensure3DAffine(already)).toEqual(already)
+  })
+})
+
+describe('the isometric projection', () => {
+  it('round-trips through unproject at a known depth', () => {
+    // Two screen axes cannot decide three world ones, so the inverse is only
+    // a bijection with z held — which is exactly how a drag uses it.
+    for (const [x, y, z] of [
+      [0, 0, 0],
+      [1.25, -0.5, 2],
+      [-3, 4, -1.5],
+    ] as const) {
+      const p = project3D(x, y, z)
+      const back = unproject3D(p.x, p.y, z)
+      expect(back.x).toBeCloseTo(x, 10)
+      expect(back.y).toBeCloseTo(y, 10)
+    }
+  })
+
+  it('leaves the x/y plane untouched', () => {
+    expect(project3D(1.5, -2, 0)).toEqual({ x: 1.5, y: -2 })
+  })
+
+  it('reads a depth from a drag along its own diagonal', () => {
+    // One unit of depth displaces the handle by exactly project3D(0,0,1).
+    const one = project3D(0, 0, 1)
+    expect(depthFromScreenDelta(one.x, one.y)).toBeCloseTo(1, 10)
+    expect(depthFromScreenDelta(-one.x, -one.y)).toBeCloseTo(-1, 10)
+    // A drag square to the diagonal asks for no depth at all.
+    expect(depthFromScreenDelta(one.y, -one.x)).toBeCloseTo(0, 10)
+  })
+})
+
+describe('basis3D', () => {
+  it('reads the origin and the three basis images off the matrix', () => {
+    const b = basis3D(ensure3DAffine(FLAT))
+    expect(b.o).toEqual({ x: 0.25, y: 0.75, z: 0 })
+    // Images are the origin plus each column, which is why a drag sets the
+    // difference and not the position.
+    expect(b.x).toEqual({ x: 2.25, y: 0.25, z: 0 })
+    expect(b.y).toEqual({ x: 0.75, y: 2.25, z: 0 })
+    expect(b.z).toEqual({ x: 0.25, y: 0.75, z: 1 })
+  })
+})

--- a/packages/app/src/flame/affine3DView.ts
+++ b/packages/app/src/flame/affine3DView.ts
@@ -1,0 +1,94 @@
+import type { AffineParams } from './affineTranform'
+
+/**
+ * The fixed isometric projection the affine handles are drawn on.
+ *
+ * Not a camera: the handles are a diagram of the transform, not a view of the
+ * scene, and a diagram that swung around with the flame's orbit would be
+ * unreadable. 135 degrees at half scale is the workspace editor's choice and
+ * this is that function, lifted so the duel's own grid draws the same picture.
+ */
+const Z_ANGLE = (135 * Math.PI) / 180
+const Z_SCALE = 0.5
+const Z_COS = Math.cos(Z_ANGLE) * Z_SCALE
+const Z_SIN = Math.sin(Z_ANGLE) * Z_SCALE
+
+export function project3D(
+  x: number,
+  y: number,
+  z: number,
+): { x: number; y: number } {
+  return { x: x + z * Z_COS, y: y + z * Z_SIN }
+}
+
+/**
+ * The exact inverse, for a known depth.
+ *
+ * Two screen axes cannot decide three world ones, so a drag has to hold one
+ * of them: with `z` fixed this is a bijection, which is what makes dragging a
+ * handle in the projection plane an honest edit rather than a guess.
+ */
+export function unproject3D(
+  px: number,
+  py: number,
+  z: number,
+): { x: number; y: number } {
+  return { x: px - z * Z_COS, y: py - z * Z_SIN }
+}
+
+/**
+ * How far a screen displacement moves a handle when depth is what is changing.
+ *
+ * The projection sends `+z` along one diagonal, so the depth a drag asks for
+ * is that displacement's component on it, divided by the diagonal's length.
+ */
+export function depthFromScreenDelta(dx: number, dy: number): number {
+  const lengthSquared = Z_COS * Z_COS + Z_SIN * Z_SIN
+  return (dx * Z_COS + dy * Z_SIN) / lengthSquared
+}
+
+/**
+ * Promote a 2D affine to the kernel's 3D layout.
+ *
+ * Rows are `a,b,c,d` / `e,f,g,h` / `i,j,k,l`, translation in `d,h,l`. A 2D
+ * affine dragged as if it were one of these is misread — its 2D y-row
+ * `(d,e,f)` lands in the 3D y-row and the transform collapses to a plane.
+ * Mirrors `ifsPipeline3D`'s own 2D-to-3D mapping, and is the same function the
+ * workspace's editor uses.
+ */
+export function ensure3DAffine(t: AffineParams): AffineParams {
+  const already3D =
+    t.g !== undefined ||
+    t.h !== undefined ||
+    t.i !== undefined ||
+    t.j !== undefined ||
+    t.k !== undefined ||
+    t.l !== undefined
+  if (already3D) return t
+  return {
+    a: t.a ?? 1,
+    b: t.b ?? 0,
+    c: 0,
+    d: t.c ?? 0,
+    e: t.d ?? 0,
+    f: t.e ?? 1,
+    g: 0,
+    h: t.f ?? 0,
+    i: 0,
+    j: 0,
+    k: 1,
+    l: 0,
+  }
+}
+
+/** The origin and the three basis images, in world space. */
+export function basis3D(t: AffineParams) {
+  const a = ensure3DAffine(t)
+  const o = { x: a.d ?? 0, y: a.h ?? 0, z: a.l ?? 0 }
+  return {
+    o,
+    x: { x: o.x + (a.a ?? 1), y: o.y + (a.e ?? 0), z: o.z + (a.i ?? 0) },
+    y: { x: o.x + (a.b ?? 0), y: o.y + (a.f ?? 1), z: o.z + (a.j ?? 0) },
+    z: { x: o.x + (a.c ?? 0), y: o.y + (a.g ?? 0), z: o.z + (a.k ?? 1) },
+  }
+}

--- a/packages/app/src/lib/WheelZoomCamera3D.tsx
+++ b/packages/app/src/lib/WheelZoomCamera3D.tsx
@@ -44,6 +44,22 @@ const MOVE_KEYS = new Set([
 // Fly-only keys: Q/E roll, Space/C move up/down (along the camera's local up).
 const FLY_KEYS = new Set(['q', 'e', ' ', 'c'])
 
+/**
+ * Whether a key press is the focused control's, not the camera's.
+ *
+ * Text fields were always exempt. A focused `role="slider"` is the same case:
+ * the duel's scrub fields nudge on the arrow keys, and this handler — bound
+ * on `window`, in the capture phase — was orbiting the flame on the very same
+ * press, so a nudge to an X offset also turned the camera.
+ */
+export function keyBelongsToTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof Element)) return false
+  const tag = target.tagName
+  if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return true
+  if (target.getAttribute('role') === 'slider') return true
+  return (target as HTMLElement).isContentEditable
+}
+
 type WheelZoomCamera3DProps = {
   theta: Signal<number>
   phi: Signal<number>
@@ -488,9 +504,7 @@ export function WheelZoomCamera3D(props: ParentProps<WheelZoomCamera3DProps>) {
   }
 
   function onKeyDown(ev: KeyboardEvent) {
-    // Don't capture when typing in inputs
-    const tag = (ev.target as HTMLElement)?.tagName
-    if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return
+    if (keyBelongsToTarget(ev.target)) return
 
     const key = ev.key.toLowerCase()
     // Modifier combos (e.g. Ctrl+D theme toggle) are app shortcuts, not camera

--- a/packages/app/src/lib/keyBelongsToTarget.test.ts
+++ b/packages/app/src/lib/keyBelongsToTarget.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { keyBelongsToTarget } from './WheelZoomCamera3D'
+
+function el(tag: string, attrs: Record<string, string> = {}): Element {
+  const node = document.createElement(tag)
+  for (const [k, v] of Object.entries(attrs)) node.setAttribute(k, v)
+  return node
+}
+
+describe('keyBelongsToTarget', () => {
+  it('leaves the camera keys alone on the body and on plain elements', () => {
+    expect(keyBelongsToTarget(document.body)).toBe(false)
+    expect(keyBelongsToTarget(el('canvas'))).toBe(false)
+    expect(keyBelongsToTarget(el('button'))).toBe(false)
+    expect(keyBelongsToTarget(null)).toBe(false)
+  })
+
+  it('yields to text fields, as before', () => {
+    expect(keyBelongsToTarget(el('input'))).toBe(true)
+    expect(keyBelongsToTarget(el('textarea'))).toBe(true)
+    expect(keyBelongsToTarget(el('select'))).toBe(true)
+  })
+
+  it('yields to a focused slider, which the duel scrub fields are', () => {
+    // The arrow keys nudge the field; the camera must not also orbit.
+    expect(keyBelongsToTarget(el('span', { role: 'slider' }))).toBe(true)
+  })
+})

--- a/packages/app/src/seats/seat.ts
+++ b/packages/app/src/seats/seat.ts
@@ -3,15 +3,16 @@ import { createStore } from 'solid-js/store'
 import { vec2f } from 'typegpu/data'
 import { clamp } from 'typegpu/std'
 import { executeCommand } from '@/commands/registry'
-import { MAX_CAMERA_ZOOM_VALUE, MIN_CAMERA_ZOOM_VALUE, } from '@/flame/schema/flameSchema'
+import { camera3DDefault, MAX_CAMERA_ZOOM_VALUE, MIN_CAMERA_ZOOM_VALUE, } from '@/flame/schema/flameSchema'
 import { recorderStream } from '@/recorder/recorder'
 import { deepClone } from '@/utils/clone'
 import { createStoreHistory } from '@/utils/createStoreHistory'
 import { createTimelineState } from '@/utils/timeline'
 import { clearWebMcpContext } from '@/webmcp/contextBridge'
 import { DEFAULT_SEAT } from './seatId'
-import type { Accessor, Setter } from 'solid-js'
+import type { Accessor, Setter, Signal } from 'solid-js'
 import type { v2f } from 'typegpu/data'
+import type { Vec3 } from 'wgpu-matrix'
 import type { SeatId } from './seatId'
 import type { CommandContext } from '@/commands/types'
 import type { FlameDescriptor } from '@/flame/schema/flameSchema'
@@ -44,7 +45,24 @@ export interface Seat {
   setZoom: Setter<number>
   position: Accessor<v2f>
   setPosition: Setter<v2f>
+  /**
+   * The 3D camera, in the shape `WheelZoomCamera3D` binds.
+   *
+   * Always present, whatever the flame's dimension: the seat reads and writes
+   * `renderSettings.camera3D`, which the schema fills with `camera3DDefault`
+   * for every flame. A 2D seat simply never mounts the camera that uses it.
+   */
+  camera3D: Seat3DCamera
   dispose(): void
+}
+
+export type Seat3DCamera = {
+  theta: Signal<number>
+  phi: Signal<number>
+  radius: Signal<number>
+  target: Signal<Vec3>
+  fov: Signal<number>
+  roll: Signal<number>
 }
 
 export function createSeat(id: SeatId, initial: FlameDescriptor): Seat {
@@ -70,6 +88,7 @@ export function createSeat(id: SeatId, initial: FlameDescriptor): Seat {
 
     const zoom = () => flame.renderSettings.camera.zoom
     const position = () => vec2f(...flame.renderSettings.camera.position)
+    const camera3D = () => flame.renderSettings.camera3D ?? camera3DDefault
 
     const ctx: CommandContext = createSeatCommandContext({
       id,
@@ -102,6 +121,46 @@ export function createSeat(id: SeatId, initial: FlameDescriptor): Seat {
       return vec2f(...flame.renderSettings.camera.position)
     }) as Setter<v2f>
 
+    /*
+     * The 3D six, derived and dispatched exactly as the 2D pair above: read
+     * through the store so a seat's camera IS its flame's camera, write
+     * through `flame.setRenderSetting` so the move is recorded and replays.
+     * The workspace builds its own five the same way (`makeCamera3DSetter`);
+     * `target` is a vec3 and stays bespoke, as it does there.
+     */
+    const scalar3D = (
+      field: 'theta' | 'phi' | 'radius' | 'fov' | 'roll',
+    ): Signal<number> => [
+      () => camera3D()[field],
+      (value: number | ((previous: number) => number)) => {
+        const current = camera3D()[field]
+        const next = typeof value === 'function' ? value(current) : value
+        executeCommand('flame.setRenderSetting', ctx, `camera3D.${field}`, next)
+        return camera3D()[field]
+      },
+    ]
+    const target3D: Signal<Vec3> = [
+      () => new Float32Array(camera3D().target),
+      (value: Vec3 | ((previous: Vec3) => Vec3)) => {
+        const current = new Float32Array(camera3D().target) as Vec3
+        const next = typeof value === 'function' ? value(current) : value
+        executeCommand('flame.setRenderSetting', ctx, 'camera3D.target', [
+          next[0],
+          next[1],
+          next[2],
+        ])
+        return new Float32Array(camera3D().target) as Vec3
+      },
+    ]
+    const seatCamera3D: Seat3DCamera = {
+      theta: scalar3D('theta'),
+      phi: scalar3D('phi'),
+      radius: scalar3D('radius'),
+      target: target3D,
+      fov: scalar3D('fov'),
+      roll: scalar3D('roll'),
+    }
+
     ctx.zoom = zoom
     ctx.setZoom = setZoom
     ctx.position = position
@@ -118,6 +177,7 @@ export function createSeat(id: SeatId, initial: FlameDescriptor): Seat {
       setZoom,
       position,
       setPosition,
+      camera3D: seatCamera3D,
       dispose: () => {
         stream.cancel()
         // The bridge is a module-level map: a context left behind here points

--- a/packages/app/src/webmcp/tools/arcadeDuel.test.ts
+++ b/packages/app/src/webmcp/tools/arcadeDuel.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from 'vitest'
-import { duelActive, duelReady, stopDuel } from '@/arcade/duel'
+import { duelActive, duelReady, duelRivalSeat, stopDuel } from '@/arcade/duel'
 import { resetPilot } from '@/arcade/pilot'
 import { clearWebMcpContext, getWebMcpTarget, setWebMcpContext, } from '@/webmcp/contextBridge'
 import { createMockCommandContext, createTestFlame } from '@/webmcp/testUtils'
@@ -20,14 +20,19 @@ describe('arcade duel tools', () => {
     expect(await run(arcadeStartDuel, {})).toHaveProperty('error')
   })
 
-  it('refuses a 3D flame, naming the reason', async () => {
+  it('duels a 3D flame, with both seats at that dimension', async () => {
     const ctx = createMockCommandContext()
     const flame = createTestFlame()
     flame.renderSettings.dimensions = 3
     ctx.flameDescriptor = () => flame
     setWebMcpContext(ctx)
-    const result = await run(arcadeStartDuel, {})
-    expect(String(result.error)).toMatch(/3D/)
+
+    const result = await run(arcadeStartDuel, { durationSeconds: 60 })
+
+    // The rival is a mirror of the player, so the two halves are the same
+    // dimension by construction and the seats bind a 3D camera each.
+    expect(result.ok).toBe(true)
+    expect(duelRivalSeat()?.flame().renderSettings.dimensions).toBe(3)
   })
 
   it('starts and points the tools at the rival', async () => {

--- a/packages/app/src/webmcp/tools/arcadeDuel.ts
+++ b/packages/app/src/webmcp/tools/arcadeDuel.ts
@@ -26,6 +26,12 @@ export const arcadeStartDuel: WebMcpTool = {
         description:
           "mirror (default) starts you from a copy of the viewer's flame; blank starts you from an empty canvas",
       },
+      startFrom: {
+        type: 'string',
+        enum: ['current', 'random-2d', 'random-3d'],
+        description:
+          "What the viewer's side starts as. current (default) is the flame they have open; random-2d and random-3d replace it with a generated one, which is how a 3D duel is asked for. Use whichever the viewer named in the prompt.",
+      },
     },
   },
   execute: (input) => {
@@ -34,6 +40,7 @@ export const arcadeStartDuel: WebMcpTool = {
     const raw = (input ?? {}) as {
       durationSeconds?: unknown
       rivalFrom?: unknown
+      startFrom?: unknown
     }
     const seconds = clampDuelSeconds(raw.durationSeconds)
     // Everything a duel start does lives in `beginDuel`, so the hub's
@@ -41,6 +48,10 @@ export const arcadeStartDuel: WebMcpTool = {
     const started = beginDuel(ctx, {
       seconds,
       rivalFrom: raw.rivalFrom === 'blank' ? 'blank' : 'mirror',
+      startFrom:
+        raw.startFrom === 'random-2d' || raw.startFrom === 'random-3d'
+          ? raw.startFrom
+          : 'current',
       opponent: 'ai',
     })
     if ('error' in started) return { error: started.error }

--- a/packages/app/src/webmcp/tools/getFlame.ts
+++ b/packages/app/src/webmcp/tools/getFlame.ts
@@ -54,8 +54,39 @@ export const getFlame: WebMcpTool = {
       }
     })
 
+    /*
+     * The camera, which this tool never returned.
+     *
+     * An agent could move it — `camera.*`, and `camera3D.*` through
+     * `flame.setRenderSetting` — and never read where it was, so every framing
+     * decision had to be relative and hope. That is survivable in 2D, where
+     * one zoom and one offset are easy to feel out, and not in 3D, where six
+     * coupled numbers decide whether the flame is on screen at all.
+     *
+     * The 3D block is included only for a 3D flame: `get_flame`'s whole point
+     * is that it fits in about 1.5 KB.
+     */
+    const dimensions = flame.renderSettings?.dimensions ?? 2
+    const c3d = flame.renderSettings?.camera3D
     const renderSettings = {
-      dimensions: flame.renderSettings?.dimensions ?? 2,
+      dimensions,
+      camera: {
+        zoom: flame.renderSettings?.camera?.zoom ?? 1,
+        position: flame.renderSettings?.camera?.position ?? [0, 0],
+        rotation: flame.renderSettings?.camera?.rotation ?? 0,
+      },
+      ...(dimensions === 3 && c3d
+        ? {
+            camera3D: {
+              theta: c3d.theta,
+              phi: c3d.phi,
+              radius: c3d.radius,
+              target: c3d.target,
+              fov: c3d.fov,
+              roll: c3d.roll,
+            },
+          }
+        : {}),
       exposure: flame.renderSettings?.exposure ?? 0.25,
       gamma: flame.renderSettings?.gamma ?? 2.2,
       vibrancy: flame.renderSettings?.vibrancy ?? 0.5,

--- a/packages/app/src/webmcp/tools/getFlameCamera.test.ts
+++ b/packages/app/src/webmcp/tools/getFlameCamera.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+import { setWebMcpContext } from '@/webmcp/contextBridge'
+import { createMockCommandContext, createTestFlame } from '@/webmcp/testUtils'
+import { getFlame } from './getFlame'
+
+type Camera = { zoom: number; position: readonly number[] }
+type Camera3D = { theta: number; phi: number; radius: number }
+
+async function read(dimensions: 2 | 3) {
+  const ctx = createMockCommandContext()
+  const flame = createTestFlame()
+  flame.renderSettings.dimensions = dimensions
+  flame.renderSettings.camera = {
+    zoom: 2.5,
+    position: [0.25, -0.5],
+    rotation: 0,
+  }
+  flame.renderSettings.camera3D = {
+    theta: 0.9,
+    phi: 1.1,
+    radius: 7,
+    target: [0, 1, 0],
+    fov: 45,
+    roll: 0.2,
+  }
+  ctx.flameDescriptor = () => flame
+  setWebMcpContext(ctx)
+  const result = await getFlame.execute({}, {})
+  return (result as { renderSettings: Record<string, unknown> }).renderSettings
+}
+
+describe('get_flame reports the camera', () => {
+  it('returns the 2D camera, which it never used to', async () => {
+    // An agent could move the camera and never read where it was, so every
+    // framing decision had to be relative and hope.
+    const rs = await read(2)
+    expect(rs.camera as Camera).toMatchObject({
+      zoom: 2.5,
+      position: [0.25, -0.5],
+    })
+  })
+
+  it('adds the orbit camera for a 3D flame', async () => {
+    const rs = await read(3)
+    expect(rs.camera3D as Camera3D).toMatchObject({
+      theta: 0.9,
+      phi: 1.1,
+      radius: 7,
+    })
+  })
+
+  it('leaves the orbit camera out of a 2D flame', async () => {
+    // `get_flame`'s whole point is that it fits in about 1.5 KB.
+    expect(await read(2)).not.toHaveProperty('camera3D')
+  })
+})

--- a/packages/app/src/webmcp/tools/scoreFlame.ts
+++ b/packages/app/src/webmcp/tools/scoreFlame.ts
@@ -53,6 +53,25 @@ const SYMMETRY = new Set([
   'postPointSymmetryWfVar',
   'postRotateVar',
   'preRotateVar',
+  /*
+   * The 3D registry, which had no entry here at all — so every 3D flame
+   * scored 0.0 symmetry by construction and lost a quarter of the duel
+   * score's range.
+   *
+   * The rule is the same one the 2D list follows: the direct counterparts of
+   * names already above (julia, polar, the cylinder family), plus the radial
+   * maps about a point that only exist in three dimensions and are the
+   * strongest symmetry there is here. Deliberately not `spiral3D`, `swirl3D`
+   * or `curl3D` — rotational is not symmetric — nor `disc3D`/`fan3D`, whose
+   * 2D counterparts are not in the list either.
+   */
+  'julia3D',
+  'polar3D',
+  'cylinder3D',
+  'cylindrical3D',
+  'spherical3D',
+  'sphere3D',
+  'hemisphere3D',
 ])
 
 export function calculateFlameStats(flame: FlameDescriptor) {


### PR DESCRIPTION
Duelling in 3D, per `47-duel-3d-feasibility.md` and the decisions taken with maff.

Almost nothing in the duel knew what dimension a flame was. Three things did, and this handles all three.

## The seats

A seat's 3D camera is derived from its own flame exactly as the 2D pair already was — `renderSettings.camera3D` read through the store, written back through `flame.setRenderSetting` so the move is recorded and replays. `SeatView` binds whichever camera the flame asks for.

**Cameras are free per seat, not locked together.** The viewer's half is theirs, and the agent reframing its own flame is part of what it is showing off. Accepted cost: a flatteringly-angled flame can beat a better one.

`FlameStill` regains the 3D branch the original extraction dropped, so a 3D card is not rendered flat, and `beginDuel` no longer refuses 3D. Both seats are always the same dimension by construction — the rival is a mirror of the player — so there is nothing to reconcile.

## Asking for a 3D duel

Only the agent starts a duel, on whatever flame the viewer has open (`beginDuel`'s one production caller is `arcade_start_duel`; the hub's solo button is DEV-only). So wanting a 3D duel meant loading a 3D flame by hand and hoping the agent asked at the right moment.

The Duel panel now carries a **Start from** choice — the flame I have open / a random 2D flame / a random 3D flame — beside the clock, and a **2D/3D pill** saying what a duel would run on right now. The choice rides the pasted prompt exactly as the clock does, and `arcade_start_duel` takes a matching `startFrom`.

## The Shape panel

It was 2D-only, and in a 3D duel worse than absent: it decomposed a 3x4 matrix as if it were a 2x3, which reads the transform's y-row as its own translation and collapses the shape to a plane.

The workspace's `AffineEditor` cannot be reused here — `AffineGrid`'s own docblock says why: it draws its grid with a WGSL shader and positions its handles from GPU uniform buffers, so lifting it into a duel would mean a fourth live WebGPU context beside the two seat canvases that are the point of the mode. But the two pieces that make it *3D* are pure, tiny and free of that coupling, so they move to `flame/affine3DView.ts` and both editors share them: the fixed isometric `project3D`, and `ensure3DAffine` with its pancake trap documented in place.

The duel's grid gains a fourth handle — the triangle stays the x/y face and Z is a spoke off the origin, on the same projection the workspace draws, so the two diagrams of one transform agree. Two screen axes cannot decide three world ones, so a drag holds one: plain drag moves a handle in the projection plane at its own depth (an exact inverse, not a guess), and **Shift** drags along the projection's own diagonal to move depth alone. One line of prose in the panel says so.

The fields become the three translations. A 2x3 decomposes cleanly into scale, rotation and shear; a 3x4 does not — rotation needs three angles, the order matters, and a naive Euler triple gimbal-locks at exactly the default camera angle. So shape comes from dragging the basis handles, which is what the grid was always for.

## Two gaps found while building it

**`get_flame` never returned the camera at all.** An agent could move it and never read where it was, so every framing decision had to be relative and hope. Survivable in 2D, where one zoom and one offset are easy to feel out; not in 3D, where six coupled numbers decide whether the flame is on screen. It now reports `renderSettings.camera` always and `camera3D` only for a 3D flame, because the tool's whole point is that it fits in about 1.5 KB. This is what the agent's own duel feedback was circling — it fell back to `camera.center` then `camera.zoomBy` because it could not read absolute values.

**The judge had no 3D names in its symmetry set**, so every 3D flame scored 0.0 there and lost a quarter of the score's range. Added on the same rule the 2D list follows: the direct counterparts of names already in it (julia, polar, the cylinder family) plus the radial maps about a point that only exist in three dimensions. Not spiral, swirl or curl — rotational is not symmetric. The 2D list is under-populated on its own account, which is why maff's own 2D duel read 0.0/0.0; that is a separate pass.

## Traps, named in place

- **JSX assigned to a variable is evaluated where it is written.** Hoisting `<Flam3>` out to share between the two camera branches ran it outside `<Root>` and threw on the first `useRootContext`. It is a component in both files now.
- **`asGenerateConfig` accepts only a COMPLETE generator config.** A partial `{ dimensions: 3 }` fails every one of its checks and falls back to the flame's current dimension in silence, so "start from a random 3D flame" produced a 2D one. `generateDefaults` is exported with a comment saying why.

## Verification

192 test files / 2287 tests pass; `recorder/recorder.test.ts` untouched. The two tests that asserted the 3D refusal now assert a 3D duel starts with both seats at that dimension. New unit cases cover the projection round-trip, the promotion's pancake trap, the depth-from-drag maths, and a 3D transform edited through the panel to `preAffine.l`.

A Playwright probe against a real GPU passes 9/9 of the steps it reaches: a duel started with `startFrom: "random-3d"`, both seat canvases painting at 818x1017, `get_flame` reporting both cameras, the agent orbiting its own seat through `camera3D.theta`, the Shape panel showing four handles and the three translation fields, the result card, the still at 904x784, and the exported PNG round-tripping a 3D flame out of its chunk.

**Review pass, after the first push** (commit `fix(duel): three things a review of the 3D duel turned up`): the workspace's own 3D camera kept listening on `window` while the duel covered it, doubling every orbit key; the same handler took arrow keys from focused scrub fields; and the Shift-drag depth gesture accumulated per frame. All three fixed, each with a test that fails without it — so the depth gesture is now verified at the unit level, though still worth a manual try since the browser probe's locator for the Z handle never resolved.