### PR TITLE
fix(load): say so when a drop arrives with nothing in it

### DIFF
--- a/packages/app/src/components/Dropzone/Dropzone.test.tsx
+++ b/packages/app/src/components/Dropzone/Dropzone.test.tsx
@@ -1,5 +1,7 @@
-import { cleanup, render } from '@solidjs/testing-library'
+import { cleanup, render, screen } from '@solidjs/testing-library'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { ToastHost } from '@/components/Toast/Toast'
+import { ToastProvider } from '@/contexts/ToastContext'
 import { Dropzone } from './Dropzone'
 
 type FakeTransfer = {
@@ -25,10 +27,14 @@ function dragEvent(type: string, transfer: FakeTransfer = {}): Event {
 
 function setup() {
   const onDrop = vi.fn()
+  // The zone tells the user when a drop arrives empty, so it needs the host.
   const { container } = render(() => (
-    <Dropzone onDrop={onDrop}>
-      <div data-testid="child">child</div>
-    </Dropzone>
+    <ToastProvider>
+      <ToastHost />
+      <Dropzone onDrop={onDrop}>
+        <div data-testid="child">child</div>
+      </Dropzone>
+    </ToastProvider>
   ))
   const zone = container.querySelector('.dropzone') as HTMLElement
   const child = container.querySelector('[data-testid="child"]') as HTMLElement
@@ -37,6 +43,20 @@ function setup() {
 
 describe('Dropzone', () => {
   afterEach(cleanup)
+
+  it('says so on screen when a drop arrives with nothing in it', async () => {
+    // The failure the user actually hit: four drops, four console warnings
+    // nobody sees, and the file they dropped got the blame for a drag that
+    // never carried it. The console line stays for diagnosis; this is the
+    // half a person can read.
+    const { zone } = setup()
+    zone.dispatchEvent(dragEvent('drop', { types: [] }))
+
+    const toast = await screen.findByText(/drop arrived empty/i)
+    expect(toast).toBeTruthy()
+    // It has to say the file is not the problem, and where to go instead.
+    expect(toast.textContent).toMatch(/Load Flame/)
+  })
 
   it('clears the highlight and takes the drop even when no file arrives', () => {
     // A drop with no File (a URL dragged from another window, or a file

--- a/packages/app/src/components/Dropzone/Dropzone.tsx
+++ b/packages/app/src/components/Dropzone/Dropzone.tsx
@@ -1,5 +1,6 @@
 import { createEffect, onCleanup } from 'solid-js'
-import { filesFromDataTransfer } from '@/utils/dataTransferFiles'
+import { useToast } from '@/contexts/ToastContext'
+import { EMPTY_DROP_MESSAGE, filesFromDataTransfer, } from '@/utils/dataTransferFiles'
 import { createFileDragState } from '@/utils/fileDragState'
 import ui from './Dropzone.module.css'
 import type { ParentProps } from 'solid-js'
@@ -25,6 +26,7 @@ export function Dropzone(props: ParentProps<DropzoneProps>) {
   // Shared with the Load Flame modal's own zone so the two cannot drift — they
   // already had different enter/leave behaviour, and only one of them flickered.
   const fileDrag = createFileDragState()
+  const { showToast } = useToast()
   const dropping = fileDrag.active
 
   preventDraggingAnyElement()
@@ -47,10 +49,14 @@ export function Dropzone(props: ParentProps<DropzoneProps>) {
         fileDrag.reset()
         const [file] = filesFromDataTransfer(ev.dataTransfer)
         if (!file) {
+          // A console warning is invisible to the person who just dropped
+          // something: the app looked broken, and the file they dropped got
+          // the blame for a drag that never carried it. Say so on screen.
           console.warn(
             'Dropzone: drop carried no file; types:',
             Array.from(ev.dataTransfer?.types ?? []),
           )
+          showToast(EMPTY_DROP_MESSAGE, 8000)
           return
         }
         const report = (err: unknown) => {

--- a/packages/app/src/components/LoadFlameModal/LoadFlameModal.tsx
+++ b/packages/app/src/components/LoadFlameModal/LoadFlameModal.tsx
@@ -16,7 +16,7 @@ import { Camera2D } from '@/lib/Camera2D'
 import { Default3DPreviewCamera } from '@/lib/Camera3D'
 import { Root } from '@/lib/Root'
 import { deepClone } from '@/utils/clone'
-import { filesFromDataTransfer } from '@/utils/dataTransferFiles'
+import { EMPTY_DROP_MESSAGE, filesFromDataTransfer, } from '@/utils/dataTransferFiles'
 import { createFileDragState } from '@/utils/fileDragState'
 import { applyFlameImport, MAX_IMPORT_FILE_SIZE, parseFlameEnvelope, readFlameFiles, summarizeImport, } from '@/utils/flameImport'
 import { extractFlameFromPng } from '@/utils/flameInPng'
@@ -882,6 +882,10 @@ export function LoadFlameModal(props: LoadFlameModalProps) {
         'LoadFlameModal: drop carried no file; types:',
         Array.from(e.dataTransfer?.types ?? []),
       )
+      // Here the picker is one click away, so the toast can just offer it.
+      showToast(EMPTY_DROP_MESSAGE, 10000, [
+        { label: 'Browse files', onClick: () => void loadFromFile() },
+      ])
       return
     }
     await processImportFiles(files)

--- a/packages/app/src/utils/dataTransferFiles.ts
+++ b/packages/app/src/utils/dataTransferFiles.ts
@@ -7,6 +7,18 @@
  * or image dragged from another window carries no file at all. Callers get an
  * empty array in that case instead of a crash or a silently ignored drop.
  */
+/**
+ * What to tell someone whose drop arrived with nothing in it.
+ *
+ * `types: []` is not a rejected file — the browser was handed an empty drag
+ * and the file never reached the page at all, so nothing about the file is at
+ * fault. A file manager on Wayland or X11 that loses the payload mid-drag is
+ * the usual cause, and the picker does not go through drag at all, so it is
+ * the way out rather than a workaround.
+ */
+export const EMPTY_DROP_MESSAGE =
+  'That drop arrived empty — no file came with it. The file is probably fine: open Load Flame and pick it instead.'
+
 export function filesFromDataTransfer(
   dt: DataTransfer | null | undefined,
 ): File[] {


### PR DESCRIPTION
## The failure

Four drops, four console warnings nobody sees, and the file took the blame for a drag that never carried it.

`types: []` is not a rejected file. It means the browser was handed an **empty drag** and the bytes never reached the page — so nothing about the file is wrong. Every other failure on this path already speaks up: too large, no flame chunk, unreadable, no valid session. This one was the silent hole.

## What it does now

The zone says what happened, that the file is probably fine, and where to go instead:

> That drop arrived empty — no file came with it. The file is probably fine: open Load Flame and pick it instead.

Inside the Load Flame modal, where the picker is one click away, the toast carries a **Browse files** button. That is not a consolation prize — the picker does not go through drag at all, which is exactly why it works when the drag does not.

The `console.warn` stays. `types` is what tells you a payload arrived empty rather than malformed, and it is the first thing worth reading when this happens again.

## Tests

+1 test asserting the message reaches the screen, mutation-checked:

| Mutation | Caught |
| --- | --- |
| back to console-only | yes |
| message stops naming the way out | yes |

The existing `Dropzone` tests gained a `ToastProvider` + `ToastHost` around the subject, since the zone now needs the host.

2277 unit tests pass, typecheck and lint clean.

## Note on the e2e suite

`tests/load-flame-dropzone.spec.ts` and `documentation.spec.ts` pass (7/7) against this branch.

The **full** e2e suite is currently failing broadly on my machine — but it fails identically on `68352d6`, before either of today's merged PRs, so it is not a regression from them or from this change. The cause is local: swiftshader's WebGPU has degraded after several hours of parallel runs (`WebGPU device was lost` appears in the console captures). Worth knowing separately: CI only runs `tests/smoke.spec.ts` (`test:e2e:ci`), so a genuine broad e2e regression would not be caught there.