### PR TITLE
docs(changelog): 0.9.9 sections, and headed capture browsers on the agents workspace

### DIFF
--- a/packages/app/CHANGELOG.md
+++ b/packages/app/CHANGELOG.md
@@ -3,27 +3,37 @@
 What's new in Lumen Apeiron. Concise highlights for each release; the full
 developer history lives in `dev.changelog.md`.
 
-## [Unreleased]
+## [0.9.9] - 2026-09-04
 
 ### Added
 
+- **Lumen Arcade.** Open `/arcade` and hand the editor to an AI agent that
+  speaks WebMCP (Chrome 149+ with the WebMCP flag, or an agent extension such
+  as Claude in Chrome). The app exposes 33 tools, and the hub gives you a
+  prompt card to paste for each mode. **Teach** runs a lesson on the flame you
+  have open, seven topics from variations to sonification, narrated step by
+  step. **Cinema** turns a sentence into motion: the agent authors keyframes
+  for the flame and plays them back, with three presets to start from.
+  **Duel** splits the screen: you and the agent edit the same flame against
+  a clock, in 2D or 3D, and the winner's flame becomes a shareable card that
+  loads straight back into the app. While the agent drives, the workspace is
+  locked behind a Stop button, a ring follows every edit, and the steps list
+  as they happen. Every session is recorded, so you can replay it, save it,
+  or export it as a video. Beats, Arena and Director are on the hub as
+  previews.
+- **Step recorder.** Record what you do as named steps, then replay it with a
+  camera that lands on each control as it changes. Give steps captions and
+  hold times, keep a library of recordings, download any of them as
+  `.steps.json`, or export the replay as a video of up to five minutes.
+  Exported PNGs carry their steps, so dropping one back in brings the
+  recording with it.
 - **Fractal Classics.** Open eight exact affine constructions—including the
   Sierpiński triangle and carpet, Koch curve, Barnsley fern, Heighway dragon,
   Cantor dust, Sierpiński tetrahedron, and Menger sponge—as editable 2D or 3D
   flames from the Gallery.
-
-### Changed
-
-- **Home has a keyboard exit.** Press Escape anywhere in the Home gallery to
-  return to the editor; an open dialog still closes first.
-- **Gallery previews stay lightweight while scrolling.** Tiles wait for the
-  gallery itself to settle, keep a static snapshot, and release their live GPU
-  canvas; animated tiles only return to a live render while hovered.
-
-## [0.9.9] - 2026-08-02
-
-### Added
-
+- **Community showcase.** Sharing to Discord gains an opt-in, off by default,
+  to let Lumen Apeiron feature your flame on Home. Submissions are reviewed
+  before they appear.
 - **Benchmark Studio.** Open the Lab from the bottom toolbar or visit
   `/benchmarks` to compare the real WebGPU flame pipeline with repeatable,
   paired A/B runs. Choose example, recent, uploaded, or freshly generated
@@ -40,8 +50,8 @@ developer history lives in `dev.changelog.md`.
   welcome screen, and reload straight back into it — Home has its own address.
   The Explore cards demonstrate what they describe rather than sitting still:
   the randomizer rolls a flame and steers it, and breeding crosses two flames
-  and plays through their children, one for each crossover mode.
-
+  and plays through their children, one for each crossover mode. Escape
+  returns you to the editor, and tiles stay lightweight while you scroll.
 - **Audio presets that do something.** The wiring presets now drive the
   settings that visibly change the picture, and three of them are built from
   the flame you have loaded — re-weighting its own transforms, variation
@@ -50,8 +60,25 @@ developer history lives in `dev.changelog.md`.
 - **Ancestry as a family tree.** A Pedigree view puts a flame's parents above
   it and its children below, alongside the existing generations view.
 
+### Changed
+
+- **A new mark.** The infinity ribbon gives way to the "Deep C": a heavy arc
+  gathering out of scattered ember marks, drawn to stay legible at favicon
+  size.
+- **Load Flame drop zone.** It now shows when a drag will be accepted, no
+  longer flickers as the pointer moves, lists its formats as pills, and tells
+  you when a drop arrived with nothing in it instead of failing silently.
+
 ### Fixed
 
+- **Audio modulation can no longer corrupt a flame.** Values are held to what
+  the flame accepts; a wide mapping used to leave a flame that would collapse
+  mid-track and then refuse to breed or export.
+- **Importing `.flame` files.** The `sinusoidal` variation was imported as the
+  complex sine and rendered a different shape. Re-import affected files.
+- **Load Flame with a full Recent list** no longer stalls each time it opens,
+  and saving or deleting a recent flame no longer silently drops entries the
+  app could not read.
 - **The microphone works on the site.** Live mic input for audio-reactive
   flames and sonification was blocked outright on lumenapeiron.com — the
   browser never even asked for permission. It worked locally, which is why it

--- a/packages/app/dev.changelog.md
+++ b/packages/app/dev.changelog.md
@@ -7,7 +7,14 @@ changelog surfaced in the About panel lives in `CHANGELOG.md`.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.9.9] - 2026-08-02
+## [0.9.9] - 2026-09-04
+
+The release that hands the editor to an agent. WebMCP tools expose the command
+registry and the flame to any agent in the browser; Lumen Arcade builds three
+modes on them — Teach, Cinema and the split-screen Duel — over a session
+recorder that captures every authored change as a replayable, exportable step.
+Underneath: seats (a reusable editing unit, so two can share one screen), the
+curation and community pipeline behind Home, and the Fractal Classics.
 
 A Home tab backed by a D1 content database — live WebGPU flames rather than
 screenshots, bounded by the existing visibility/compute gating — plus the
@@ -151,6 +158,76 @@ implementations.
   else catches this class of bug — the app builds, deploys and renders
   perfectly, and the only symptom is a prompt that never appears.
 
+- **WebMCP tools** (`src/webmcp/`, `docs/webmcp.md`): 33 tools registered on
+  `document.modelContext`; a `window.webmcp` mock stands in for dev builds and
+  Playwright. Foundation: `get_flame`, `set_flame`, `list_commands`,
+  `get_undo_state`, `execute_command`; `score_flame` and `breed_flames`; the
+  Arcade family (`arcade_status`, `arcade_start_lesson`, `arcade_narrate`,
+  `arcade_end_lesson`, `arcade_start_cinema`, `arcade_set_keyframes`,
+  `arcade_get_animatable_paths`, `arcade_start_duel`, `arcade_end_duel`); and
+  the Flame Clash arena, Evolutionary Art Director and custom-WGSL tools behind
+  the greyed hub cards. `execute_command` dispatches through the recorded live
+  path: `preflightLiveCommand` normalizes the args first and applies the replay
+  policy to what will actually be recorded, so `flame.mutate` and
+  `sonification.setEnabled` are reachable, and a budget error names the path
+  (`arguments[0].tracks[0].keyframes[1].value is undefined`). `arcade/guard.ts`
+  refuses `export.*`, `history.*` and point count / dimensions / quality while
+  an agent drives.
+- **Lumen Arcade** (`src/arcade/`, `components/Arcade/`): `#arcade` tab, a
+  Worker 308 from `/arcade`, a hub with mode cards (Teach, Cinema and Duel
+  live; Beats, Arena and Director greyed), prompt cards and a WebMCP status
+  pill. A pilot state machine owns the lock overlay (Stop, live step list, an
+  end card that replays or saves the take) and the spotlight ring
+  (`PilotSpotlight`: measures the focus hint of each executed command, 700 ms
+  dwell, off during a duel). `topics.ts` carries the seven lessons and their
+  step budgets (variations and affine 45, colour 40, camera and genetics 32,
+  sonification and render 28), held to the video cap by
+  `stepBudgetFitsVideo.test.ts`. Cinema validates keyframe tracks against the
+  animatable catalog, which drops the camera family the flame does not render
+  with (`camera.*` on 3D, `camera3D.*` on 2D) and says so, in radians. The
+  camera gained `panTo`, `panBy`, `zoomBy` and `frame`, clamped to the schema.
+- **Seats and Duel** (`createSeat`, `components/Duel/`): a seat is the reusable
+  editing unit — flame store, history, camera, lock scope — so two mount side
+  by side; the recorder keeps one stream per seat behind a handle, the WebMCP
+  context bridge is keyed by seat, and a command's recording routes by its
+  seat. `DuelStage` mounts over the parked workspace: a clock dial on the seam,
+  a per-seat lock, the whole variation catalogue on the human side, a judge
+  seam with a v0 score sheet, and the clock — not the agent — ends the duel.
+  The result card sits over both flames and exports the winner as a PNG duel
+  card carrying its `FlameJson`. 2D and 3D (`affine3DView`, `startFrom:
+"random-3d"`; orbit keys are disabled while a duel covers the canvas).
+- **Session recorder** (`src/recorder/`, `components/SessionRecorder/`):
+  versioned `.steps.json` (valibot; the initial flame goes through
+  migrate-on-parse). `executeCommand` logs top-level commands while recording
+  and opens a scope per execution so history writes are attributed;
+  `createStoreHistory.onEntryPushed` counts any write that bypassed the
+  registry as an unnamed write — the coverage ratchet in
+  `docs/recorder-coverage.md`. Deterministic replay with a follow-cam driven by
+  focus hints (`recorder/focus.ts`), captions and hold per step, a recordings
+  library, and a `FlameSteps` zTXt chunk in exported PNGs. Video export
+  (`replayVideo.ts`): full-interface capture through WebCodecs into
+  `mp4-muxer`, reading-speed pacing with lead-in and tail, and a 300 s cap —
+  the MP4 is muxed into RAM at the encoder's 8 Mbps floor, so five minutes is
+  about 300 MB.
+- **Community showcase** (`migrations/0006`, `DiscordShareModal`,
+  `worker/index.ts`): the Discord share carries an opt-in consent, off by
+  default, that stages the flame as a `submission_source = 'discord'`,
+  `moderation_status = 'pending'` row; public reads only ever return approved
+  submissions; `gallery-admin approve` and `reject` move the queue.
+- **Gallery curation foundations** (`migrations/0005`,
+  `scripts/seed-gallery.mjs`): provenance columns (`collection`,
+  `provenance_kind`, `source_url`, `license`, `license_url`, `attribution`,
+  `changes`, `original_id`) and one publication gate shared by `publish` and
+  `audit`. `seed-gallery` holds the curated 18-row set — hero, six classics,
+  three gallery pieces, three motion rows, five capability cards — and emits
+  an upsert for any environment.
+- **Fractal Classics and curated examples** (`flame/examples/`): eight exact
+  affine constructions as 2D or 3D flames, and the showcase flames Neon Julian
+  Cosmos, Golden Apollonian Gasket and Cybernetic Swirl.
+- **`@typegpu/noise` RNG** (`shaders/random.ts`, TypeGPU 0.12): the renderer's
+  random sequence comes from TypeGPU's noise primitives, and Benchmark Studio
+  can compare renderer RNG implementations.
+
 ### Changed
 
 - **Home art direction** (`HomeTab.module.css`): Home now carries its own
@@ -161,6 +238,19 @@ implementations.
   one palette keeps the full-bleed hero framed identically regardless of a
   theme setting nobody chose for this page. The nine `[data-theme='dark']`
   overrides are gone with it.
+
+- **Deep C mark** (`assets/favicon.svg`): two flat inks, a 249-degree band
+  open to the west with three ember marks in its mouth; 16 px legibility
+  (greyscale standard deviation of the downsampled mark) 0.245 to 0.325.
+- **Load Flame drop zone** (`Dropzone`, `LoadFlameModal`,
+  `createFileDragState()`, `utils/dataTransferFiles.ts`): one shared drag
+  state with dragenter/dragleave depth counting and `dropEffect = 'copy'`; the
+  drag rule that had never existed (`ui.uploadZoneDragging` was undefined, so
+  the element carried a literal `undefined` class) is an inset ring that
+  cannot overflow the modal; formats as pills with an info affordance for the
+  multi-file rule; an empty drop (`types: []`) raises a toast that names the
+  cause and offers the picker.
+- **Copy**: the product says "agent", not "AI", throughout the Arcade.
 
 ### Fixed
 
@@ -292,6 +382,33 @@ implementations.
   nonce it finds in the CSP header onto the tag it injects (its documented
   mechanism). `'unsafe-inline'` stays out and the app's own `<script src>`
   tags remain allowed by `'self'`.
+
+- **flam3 alias shadowed an exact variation** (flame import):
+  `sinusoidal` resolved to `sinVar` (the complex sine) instead of the
+  registry's exact `sinusoidalVar`. The alias is gone so the registry resolves
+  it, and the historical `sinusodial` misspelling points at `sinusoidalVar`.
+- **Recents** (`LoadFlameModal`, recent-flames store): validating 150 stored
+  flames cost ~90 ms on every open; the validated list is now memoized on the
+  raw payload (cold 104.7 ms, warm 0). `saveRecentFlame` and
+  `deleteRecentFlame` did a read-modify-write on the validated list and
+  silently dropped every entry the schema rejected.
+- **Console panel pinned every logged object** (console store): entries carry
+  a bounded serialization taken at log time (depth, items, keys, string and
+  total length; cycles resolved; DOM and GPU handles named; own enumerable
+  keys only), and the ring buffer is a store so a push wakes only readers of
+  the new index.
+- **Audio mappings clamped** (`applyAudioMappingsToFlame`,
+  `scripts/validate-gallery.mjs`): every mapping funnels through one clamp
+  against the schema — `palettePhase` is 0–1, not radians; `skipIters`
+  rounds; NaN becomes finite; a transform's probability stays above zero,
+  since zero is the collapse itself. `validate-gallery` runs `validateFlame`
+  over every stored row and sequence entry.
+- **Arcade and replay, before release**: Cinema no longer records a
+  `timeline.setAnimationEnabled` no-op ahead of the keyframes; the pause a
+  step earns is paid to that step, and the closing step is held before a take
+  is called finished; captions are whole sentences at reading speed; the
+  Teach and Cinema overlay is readable over the flame; the arena archetypes
+  name variations that exist (all 44 were bare Apophysis names).
 
 ## [0.9.8] - 2026-07-24
 

--- a/packages/app/playwright.resilience.config.ts
+++ b/packages/app/playwright.resilience.config.ts
@@ -45,6 +45,8 @@ export default defineConfig({
             '--enable-unsafe-webgpu',
             '--enable-features=Vulkan',
             '--ignore-gpu-blocklist',
+            // Hidden agent workspace: the headed window never covers the user's screen.
+            '--class=agent-browser',
           ],
         },
       },

--- a/packages/app/scripts/capture-gallery-posters.mjs
+++ b/packages/app/scripts/capture-gallery-posters.mjs
@@ -329,6 +329,9 @@ async function main() {
       '--enable-unsafe-webgpu',
       '--enable-features=Vulkan',
       '--ignore-gpu-blocklist',
+      // The window manager files agent-owned windows by this class on a hidden
+      // workspace, so a capture never lands on top of whatever the user is doing.
+      '--class=agent-browser',
     ],
   })
   // ignoreHTTPSErrors: the dev server runs over HTTPS with a self-signed cert

--- a/packages/app/scripts/capture-readme-screenshots.mjs
+++ b/packages/app/scripts/capture-readme-screenshots.mjs
@@ -739,6 +739,8 @@ try {
       '--enable-unsafe-webgpu',
       '--enable-features=Vulkan',
       '--ignore-gpu-blocklist',
+      // Same reason as capture-gallery-posters: a hidden workspace for agent windows.
+      '--class=agent-browser',
     ],
   })
 

--- a/packages/app/scripts/render-flames.mjs
+++ b/packages/app/scripts/render-flames.mjs
@@ -55,6 +55,8 @@ export async function renderFlames({
       '--enable-unsafe-webgpu',
       '--enable-features=Vulkan',
       '--ignore-gpu-blocklist',
+      // Same reason as capture-gallery-posters: a hidden workspace for agent windows.
+      '--class=agent-browser',
     ],
   })
   try {

--- a/packages/landing/scripts/capture-posters.mjs
+++ b/packages/landing/scripts/capture-posters.mjs
@@ -64,7 +64,13 @@ mkdirSync(resolve(OUT_DIR, 'earth-variants'), { recursive: true })
 
 const browser = await chromium.launch({
   headless: false,
-  args: ['--enable-unsafe-webgpu', '--enable-features=Vulkan'],
+  // --class: the window manager files agent-owned windows by this class on a
+  // hidden workspace, so the capture window never covers the user's screen.
+  args: [
+    '--enable-unsafe-webgpu',
+    '--enable-features=Vulkan',
+    '--class=agent-browser',
+  ],
 })
 // ignoreHTTPSErrors: the dev server runs over HTTPS (basic-ssl) with a
 // self-signed cert; without this Playwright refuses to load the capture page.


### PR DESCRIPTION
## Summary

Two things for the release:

**Changelogs for 0.9.9.** `CHANGELOG.md` folds `[Unreleased]` into `[0.9.9]`, re-dated 2026-09-04, and adds what the section was missing: Lumen Arcade (Teach, Cinema, Duel over WebMCP), the step recorder and its video export, the community showcase, the Deep C mark, the Load Flame drop zone, and the fixes users can meet (audio clamp, `.flame` `sinusoidal` import, Recent list). Fixes to code that never shipped stay out of the user-facing file. `dev.changelog.md` gets the detailed entries: WebMCP tools, Arcade internals, seats and Duel, the recorder, migrations 0005/0006, the classics, the RNG, and the pre-release Arcade/replay fix-ups as one line. No version bump: `package.json` is already 0.9.9. No tag in this PR.

**`--class=agent-browser`** on all five headed Chromium launches (gallery posters, README shots, `render-flames`, the landing posters, the `chromium-gpu` Playwright project), so a capture run never opens a window on top of what the user is doing.

## Test plan

- [x] `gallery-admin capture --all-missing --env dev` ran with the patched launcher (19 posters on the real GPU)
- [x] Changelog headings match the About panel parser (`## [x.y.z] - date`, `### Added/Changed/Fixed`)
- [x] pre-commit prettier + eslint