### PR TITLE
fix(camera): the framing commands drive the 3D orbit, and point at its control

### DIFF
--- a/packages/app/src/arcade/duelPromptCard3D.test.ts
+++ b/packages/app/src/arcade/duelPromptCard3D.test.ts
@@ -3,17 +3,25 @@ import { duelPromptCard } from './topics'
 
 describe('duelPromptCard in three dimensions', () => {
   it('explains the orbit whenever the duel is 3D, however it got there', () => {
+    // Start from the flame the viewer has open and the dimension is that
+    // flame's, which only the panel knows — the card has to be told.
     const current3D = duelPromptCard(120, 'current', 3)
     expect(current3D).toContain('camera3D.theta')
-    // The one camera command that now works in 3D, named as such.
-    // Every camera command drives the orbit now, so the brief says so
-    // rather than sending the agent to the render-setting path for all of it.
-    expect(current3D).toContain('every camera.* command drives it')
-    expect(current3D).toContain('camera3D.theta')
-    expect(current3D).not.toContain('do nothing in 3D')
-
     expect(duelPromptCard(120, 'random-3d')).toContain('camera3D.theta')
     expect(duelPromptCard(120, 'current')).not.toContain('camera3D')
     expect(duelPromptCard(120, 'random-2d', 2)).not.toContain('camera3D')
+  })
+
+  it('describes a camera that works, and says what centre takes with it', () => {
+    const card = duelPromptCard(120, 'random-3d')
+
+    // Every camera.* command drives the orbit now, so the brief no longer
+    // sends the agent to the render-setting path for all of it.
+    expect(card).toContain('every camera.* command drives it')
+    expect(card).not.toContain('do nothing in 3D')
+    // Centre resets the angle too, which the next sentence tells it to set.
+    expect(card).toContain('including the angle you are viewing from')
+    // Pan moves x and y only; the depth is reachable, and named.
+    expect(card).toContain('camera3D.target')
   })
 })

--- a/packages/app/src/arcade/duelPromptCard3D.test.ts
+++ b/packages/app/src/arcade/duelPromptCard3D.test.ts
@@ -6,8 +6,11 @@ describe('duelPromptCard in three dimensions', () => {
     const current3D = duelPromptCard(120, 'current', 3)
     expect(current3D).toContain('camera3D.theta')
     // The one camera command that now works in 3D, named as such.
-    expect(current3D).toContain('camera.center recentres the orbit')
-    expect(current3D).not.toContain('does nothing useful')
+    // Every camera command drives the orbit now, so the brief says so
+    // rather than sending the agent to the render-setting path for all of it.
+    expect(current3D).toContain('every camera.* command drives it')
+    expect(current3D).toContain('camera3D.theta')
+    expect(current3D).not.toContain('do nothing in 3D')
 
     expect(duelPromptCard(120, 'random-3d')).toContain('camera3D.theta')
     expect(duelPromptCard(120, 'current')).not.toContain('camera3D')

--- a/packages/app/src/arcade/topics.ts
+++ b/packages/app/src/arcade/topics.ts
@@ -278,11 +278,12 @@ export function duelPromptCard(
 ): string {
   const minutes = Math.round((seconds / 60) * 10) / 10
   const clock = minutes === 1 ? '1 minute' : `${minutes} minutes`
-  // The 3D camera has no commands of its own; it is reached through the
-  // generic render-setting path, which the agent has no way to guess.
+  // The camera commands read as 2D verbs, and how they land on an orbit is
+  // not something an agent can guess; the angles have no 2D counterpart at
+  // all, so those are named as the render-setting paths they are.
   const camera3D =
     dimensions === 3
-      ? ' In 3D the camera is orbit, not pan and zoom: read it from get_flame under renderSettings.camera3D and move it with execute_command flame.setRenderSetting on the paths camera3D.theta, camera3D.phi, camera3D.radius, camera3D.target, camera3D.fov and camera3D.roll. camera.center recentres the orbit; the other camera.* commands do nothing in 3D.'
+      ? ' In 3D the camera is an orbit around a point, and every camera.* command drives it: zoom is how close the orbit sits, pan moves the point it looks at, camera.center puts both back. To swing around the flame, and for the lens, read renderSettings.camera3D from get_flame and set camera3D.theta, camera3D.phi, camera3D.fov or camera3D.roll with execute_command flame.setRenderSetting.'
       : ''
   return `Duel me in Lumen Apeiron. Call arcade_start_duel to begin: we each get ${clock} and our own flame, side by side, and I am editing mine while you edit yours.${START_FROM_PHRASE[startFrom]} Read your flame with get_flame and change it with execute_command — only flame.* and camera.* are allowed, and you have ${DUEL_STEP_BUDGET} steps.${camera3D} Say what you are going for with arcade_narrate as you work. Aim for something striking rather than merely complicated. You cannot end the duel — the clock does, and I can call it early — so when you are happy call arcade_duel_ready with a short title and keep polishing until time runs out.
 

--- a/packages/app/src/arcade/topics.ts
+++ b/packages/app/src/arcade/topics.ts
@@ -283,7 +283,7 @@ export function duelPromptCard(
   // all, so those are named as the render-setting paths they are.
   const camera3D =
     dimensions === 3
-      ? ' In 3D the camera is an orbit around a point, and every camera.* command drives it: zoom is how close the orbit sits, pan moves the point it looks at, camera.center puts both back. To swing around the flame, and for the lens, read renderSettings.camera3D from get_flame and set camera3D.theta, camera3D.phi, camera3D.fov or camera3D.roll with execute_command flame.setRenderSetting.'
+      ? ' In 3D the camera is an orbit around a point, and every camera.* command drives it: zoom is how close the orbit sits, pan moves the point it looks at in x and y, and camera.center resets the whole orbit including the angle you are viewing from. For the angle itself, the depth of that point, and the lens, read renderSettings.camera3D from get_flame and set camera3D.theta, camera3D.phi, camera3D.target, camera3D.fov or camera3D.roll with execute_command flame.setRenderSetting.'
       : ''
   return `Duel me in Lumen Apeiron. Call arcade_start_duel to begin: we each get ${clock} and our own flame, side by side, and I am editing mine while you edit yours.${START_FROM_PHRASE[startFrom]} Read your flame with get_flame and change it with execute_command — only flame.* and camera.* are allowed, and you have ${DUEL_STEP_BUDGET} steps.${camera3D} Say what you are going for with arcade_narrate as you work. Aim for something striking rather than merely complicated. You cannot end the duel — the clock does, and I can call it early — so when you are happy call arcade_duel_ready with a short title and keep polishing until time runs out.
 

--- a/packages/app/src/commands/builtins/camera.ts
+++ b/packages/app/src/commands/builtins/camera.ts
@@ -1,5 +1,5 @@
 import { vec2f } from 'typegpu/data'
-import { camera3DDefault, MAX_CAMERA_ZOOM_VALUE, MIN_CAMERA_ZOOM_VALUE, } from '@/flame/schema/flameSchema'
+import { camera3DDefault, MAX_CAMERA_ZOOM_VALUE, MAX_ORBIT_RADIUS, MIN_CAMERA_ZOOM_VALUE, MIN_ORBIT_RADIUS, } from '@/flame/schema/flameSchema'
 import { executeCommand, registerCommand } from '../registry'
 import { num } from './describeArgs'
 import type { CommandContext } from '../types'
@@ -21,11 +21,6 @@ import type { Camera3DObj } from '@/flame/schema/flameSchema'
  *  malformed session file cannot send the viewport to infinity. */
 const MAX_CAMERA_OFFSET = 10_000
 
-/** The range the orbit's own R control offers. The schema leaves radius
- *  unbounded, and a radius of zero puts the eye inside the flame. */
-const MIN_CAMERA_RADIUS = 0.1
-const MAX_CAMERA_RADIUS = 100
-
 function clampZoom(value: number): number {
   return Math.min(MAX_CAMERA_ZOOM_VALUE, Math.max(MIN_CAMERA_ZOOM_VALUE, value))
 }
@@ -38,8 +33,10 @@ function finite(value: unknown, fallback: number): number {
   return typeof value === 'number' && Number.isFinite(value) ? value : fallback
 }
 
+/** The same range the wheel clamps to, so a command and a scroll cannot
+ *  disagree about how close the orbit may sit. */
 function clampRadius(value: number): number {
-  return Math.min(MAX_CAMERA_RADIUS, Math.max(MIN_CAMERA_RADIUS, value))
+  return Math.min(MAX_ORBIT_RADIUS, Math.max(MIN_ORBIT_RADIUS, value))
 }
 
 /**
@@ -74,6 +71,11 @@ function zoomForRadius(radius: number): number {
 
 /** The orbit as the commands need it, with anything malformed replaced.
  *
+ *  The radius is read as it is stored, NOT clamped: clamping the reading and
+ *  then dividing it inverts a relative zoom — from a radius below the floor,
+ *  "twice as close" would compute from the floor and move the camera away.
+ *  Only what is written back is clamped.
+ *
  *  Defensively, because a descriptor can say `dimensions: 3` and carry no
  *  orbit at all: `flame.setRenderSetting dimensions 3` writes the number
  *  straight into the store, and the schema only fills the default in on a
@@ -87,7 +89,7 @@ function orbitOf(ctx: CommandContext): {
   const camera = stored ?? camera3DDefault
   const [x, y, z] = camera.target
   return {
-    radius: clampRadius(finite(camera.radius, camera3DDefault.radius)),
+    radius: finite(camera.radius, camera3DDefault.radius),
     target: [finite(x, 0), finite(y, 0), finite(z, 0)],
   }
 }

--- a/packages/app/src/commands/builtins/camera.ts
+++ b/packages/app/src/commands/builtins/camera.ts
@@ -2,6 +2,8 @@ import { vec2f } from 'typegpu/data'
 import { camera3DDefault, MAX_CAMERA_ZOOM_VALUE, MIN_CAMERA_ZOOM_VALUE, } from '@/flame/schema/flameSchema'
 import { executeCommand, registerCommand } from '../registry'
 import { num } from './describeArgs'
+import type { CommandContext } from '../types'
+import type { Camera3DObj } from '@/flame/schema/flameSchema'
 
 /**
  * Framing as commands, so both a person and an agent reach the camera the
@@ -19,6 +21,11 @@ import { num } from './describeArgs'
  *  malformed session file cannot send the viewport to infinity. */
 const MAX_CAMERA_OFFSET = 10_000
 
+/** The range the orbit's own R control offers. The schema leaves radius
+ *  unbounded, and a radius of zero puts the eye inside the flame. */
+const MIN_CAMERA_RADIUS = 0.1
+const MAX_CAMERA_RADIUS = 100
+
 function clampZoom(value: number): number {
   return Math.min(MAX_CAMERA_ZOOM_VALUE, Math.max(MIN_CAMERA_ZOOM_VALUE, value))
 }
@@ -29,6 +36,69 @@ function clampOffset(value: number): number {
 
 function finite(value: unknown, fallback: number): number {
   return typeof value === 'number' && Number.isFinite(value) ? value : fallback
+}
+
+function clampRadius(value: number): number {
+  return Math.min(MAX_CAMERA_RADIUS, Math.max(MIN_CAMERA_RADIUS, value))
+}
+
+/**
+ * 2 unless the flame says otherwise.
+ *
+ * Read defensively: a context assembled for the camera alone carries no
+ * descriptor, and a viewport with no flame behind it is 2D by definition.
+ */
+function dimensionsOf(ctx: CommandContext): 2 | 3 {
+  const read = ctx.flameDescriptor as
+    | CommandContext['flameDescriptor']
+    | undefined
+  return read?.().renderSettings.dimensions === 3 ? 3 : 2
+}
+
+/**
+ * Zoom, in three dimensions, is how close the orbit sits.
+ *
+ * The default radius of 5 is zoom 1, and twice the zoom is half the radius —
+ * so the same five commands drive both viewports and an agent that has
+ * learned `camera.zoomBy 2` does not need a second verb for a 3D flame.
+ * Orbit angle is the one thing with no 2D counterpart, so it stays on
+ * `flame.setRenderSetting camera3D.theta` / `camera3D.phi`.
+ */
+function radiusForZoom(zoom: number): number {
+  return clampRadius(camera3DDefault.radius / clampZoom(zoom))
+}
+
+function zoomForRadius(radius: number): number {
+  return camera3DDefault.radius / radius
+}
+
+/** The orbit as the commands need it, with anything malformed replaced.
+ *
+ *  Defensively, because a descriptor can say `dimensions: 3` and carry no
+ *  orbit at all: `flame.setRenderSetting dimensions 3` writes the number
+ *  straight into the store, and the schema only fills the default in on a
+ *  parse. */
+function orbitOf(ctx: CommandContext): {
+  radius: number
+  target: [number, number, number]
+} {
+  const stored: Camera3DObj | undefined =
+    ctx.flameDescriptor().renderSettings.camera3D
+  const camera = stored ?? camera3DDefault
+  const [x, y, z] = camera.target
+  return {
+    radius: clampRadius(finite(camera.radius, camera3DDefault.radius)),
+    target: [finite(x, 0), finite(y, 0), finite(z, 0)],
+  }
+}
+
+/**
+ * Through the render-setting path, exactly as the 2D setters go: it merges
+ * the container, releases a held timeline frame, and — being nested inside a
+ * command that is already recording — adds no step of its own.
+ */
+function setOrbit(ctx: CommandContext, patch: Partial<Camera3DObj>): void {
+  executeCommand('flame.setRenderSetting', ctx, 'camera3D', patch)
 }
 
 registerCommand({
@@ -43,14 +113,9 @@ registerCommand({
     // was a no-op there. The orbit only: fov and roll are the lens, and Centre
     // leaves the 2D rotation alone for the same reason. Through the same
     // render-setting path as the 2D setters, so a held timeline frame lets go.
-    if ((ctx.flameDescriptor().renderSettings.dimensions ?? 2) === 3) {
+    if (dimensionsOf(ctx) === 3) {
       const { theta, phi, radius } = camera3DDefault
-      executeCommand('flame.setRenderSetting', ctx, 'camera3D', {
-        theta,
-        phi,
-        radius,
-        target: [0, 0, 0],
-      })
+      setOrbit(ctx, { theta, phi, radius, target: [0, 0, 0] })
       return
     }
     ctx.setPosition(vec2f(0, 0))
@@ -65,9 +130,15 @@ registerCommand({
     return z === undefined ? 'Zoom the camera' : `Zoom to ${z}`
   },
   label: 'Zoom To',
-  description: 'Set camera zoom to a specific level',
+  description:
+    'Set camera zoom to a specific level. In 3D that is how close the orbit sits: zoom 1 is the default distance, zoom 2 is twice as close.',
   execute(ctx, zoom?: unknown) {
-    ctx.setZoom(clampZoom(finite(zoom, 1)))
+    const zoomValue = clampZoom(finite(zoom, 1))
+    if (dimensionsOf(ctx) === 3) {
+      setOrbit(ctx, { radius: radiusForZoom(zoomValue) })
+      return
+    }
+    ctx.setZoom(zoomValue)
   },
 })
 
@@ -78,12 +149,17 @@ registerCommand({
     return f === undefined ? 'Zoom the camera' : `Zoom by ${f}x`
   },
   label: 'Zoom By',
-  description: 'Multiply the current zoom by a factor (2 = twice as close)',
+  description:
+    'Multiply the current zoom by a factor (2 = twice as close). In 3D it halves or doubles the orbit distance.',
   execute(ctx, factor?: unknown) {
     const f = finite(factor, 1)
     // A zero or negative factor is not a zoom, and would leave the viewport
     // in a state the schema rejects. Treat it as "no change".
     if (f <= 0) return
+    if (dimensionsOf(ctx) === 3) {
+      setOrbit(ctx, { radius: clampRadius(orbitOf(ctx).radius / f) })
+      return
+    }
     ctx.setZoom(clampZoom(ctx.zoom() * f))
   },
 })
@@ -98,8 +174,16 @@ registerCommand({
       : `Pan to ${px}, ${py}`
   },
   label: 'Pan To',
-  description: 'Move the camera centre to a world position',
+  description:
+    'Move the camera centre to a world position. In 3D that is the point the orbit looks at, moved in x and y; its depth is left where it is.',
   execute(ctx, x?: unknown, y?: unknown) {
+    if (dimensionsOf(ctx) === 3) {
+      const [tx, ty, tz] = orbitOf(ctx).target
+      setOrbit(ctx, {
+        target: [clampOffset(finite(x, tx)), clampOffset(finite(y, ty)), tz],
+      })
+      return
+    }
     const current = ctx.position()
     ctx.setPosition(
       vec2f(
@@ -120,8 +204,20 @@ registerCommand({
       : `Pan by ${px}, ${py}`
   },
   label: 'Pan By',
-  description: 'Move the camera centre by a world-space offset',
+  description:
+    'Move the camera centre by a world-space offset. In 3D it slides the point the orbit looks at along x and y.',
   execute(ctx, dx?: unknown, dy?: unknown) {
+    if (dimensionsOf(ctx) === 3) {
+      const [tx, ty, tz] = orbitOf(ctx).target
+      setOrbit(ctx, {
+        target: [
+          clampOffset(tx + finite(dx, 0)),
+          clampOffset(ty + finite(dy, 0)),
+          tz,
+        ],
+      })
+      return
+    }
     const current = ctx.position()
     ctx.setPosition(
       vec2f(
@@ -148,8 +244,17 @@ registerCommand({
   // what the command was for. An agent reading this reached for an empty call
   // expecting auto-framing and got "expected exactly 3 arguments".
   description:
-    'Pan and zoom in one step, so the move reads as one beat. Takes exactly three arguments: [x, y, zoom] — the world position to centre on and the zoom to land at. Does not auto-frame; use camera.center for a known starting point.',
+    'Pan and zoom in one step, so the move reads as one beat. Takes exactly three arguments: [x, y, zoom] — the world position to centre on and the zoom to land at. Works in 3D too, where it moves the orbit target and its distance. Does not auto-frame; use camera.center for a known starting point.',
   execute(ctx, x?: unknown, y?: unknown, zoom?: unknown) {
+    if (dimensionsOf(ctx) === 3) {
+      const orbit = orbitOf(ctx)
+      const [tx, ty, tz] = orbit.target
+      setOrbit(ctx, {
+        target: [clampOffset(finite(x, tx)), clampOffset(finite(y, ty)), tz],
+        radius: radiusForZoom(finite(zoom, zoomForRadius(orbit.radius))),
+      })
+      return
+    }
     const current = ctx.position()
     ctx.setPosition(
       vec2f(

--- a/packages/app/src/commands/builtins/camera3D.test.ts
+++ b/packages/app/src/commands/builtins/camera3D.test.ts
@@ -3,36 +3,140 @@ import { describe, expect, it, vi } from 'vitest'
 import { camera3DDefault } from '@/flame/schema/flameSchema'
 import { createMockCommandContext } from '@/webmcp/testUtils'
 import { executeCommand } from '../registry'
+import type { CommandContext } from '../types'
 
-describe('camera.center', () => {
-  it('resets the orbit of a 3D flame and keeps the lens', () => {
-    const ctx = createMockCommandContext()
-    ctx.setFlameDescriptor((draft) => {
-      draft.renderSettings.dimensions = 3
-      draft.renderSettings.camera3D = {
-        ...camera3DDefault,
-        theta: 1.2,
-        phi: 0.4,
-        radius: 9,
-        target: [1, 2, 3],
-        fov: 25,
-        roll: 0.6,
-      }
-    }, 'test')
-    const setPreviewHeld = vi.fn()
-    Object.assign(ctx.timeline, { setPreviewHeld })
+/** A 3D flame with an orbit that is nowhere near its default. */
+function orbiting(): CommandContext {
+  const ctx = createMockCommandContext()
+  ctx.setFlameDescriptor((draft) => {
+    draft.renderSettings.dimensions = 3
+    draft.renderSettings.camera3D = {
+      ...camera3DDefault,
+      theta: 1.2,
+      phi: 0.4,
+      radius: 8,
+      target: [1, 2, 3],
+      fov: 25,
+      roll: 0.6,
+    }
+  }, 'test')
+  return ctx
+}
+
+const orbit = (ctx: CommandContext) =>
+  ctx.flameDescriptor().renderSettings.camera3D
+
+describe('the framing commands in three dimensions', () => {
+  it('centres by resetting the orbit, and keeps the lens', () => {
+    const ctx = orbiting()
 
     executeCommand('camera.center', ctx)
 
-    expect(ctx.flameDescriptor().renderSettings.camera3D).toEqual({
-      ...camera3DDefault,
-      fov: 25,
-      roll: 0.6,
-    })
-    // Through the render-setting path, so a held timeline frame lets go of
-    // the camera the way it does for a 2D pan.
-    expect(setPreviewHeld).toHaveBeenCalledWith(false)
+    expect(orbit(ctx)).toEqual({ ...camera3DDefault, fov: 25, roll: 0.6 })
     expect(ctx.setPosition).not.toHaveBeenCalled()
+    expect(ctx.setZoom).not.toHaveBeenCalled()
+  })
+
+  it('zooms by moving the orbit closer, the default distance being zoom 1', () => {
+    const ctx = orbiting()
+
+    executeCommand('camera.zoomTo', ctx, 1)
+    expect(orbit(ctx).radius).toBeCloseTo(camera3DDefault.radius, 6)
+
+    executeCommand('camera.zoomTo', ctx, 2)
+    expect(orbit(ctx).radius).toBeCloseTo(camera3DDefault.radius / 2, 6)
+
+    // The angles are the one thing zoom must not touch.
+    expect(orbit(ctx).theta).toBeCloseTo(1.2, 6)
+    expect(orbit(ctx).phi).toBeCloseTo(0.4, 6)
+  })
+
+  it('halves the distance for a factor of two, and ignores a non-zoom', () => {
+    const ctx = orbiting()
+
+    executeCommand('camera.zoomBy', ctx, 2)
+    expect(orbit(ctx).radius).toBeCloseTo(4, 6)
+
+    executeCommand('camera.zoomBy', ctx, 0)
+    executeCommand('camera.zoomBy', ctx, -4)
+    expect(orbit(ctx).radius).toBeCloseTo(4, 6)
+  })
+
+  it('keeps the orbit at a distance the R control could reach', () => {
+    const ctx = orbiting()
+
+    executeCommand('camera.zoomTo', ctx, 1e9)
+    expect(orbit(ctx).radius).toBe(0.1)
+
+    executeCommand('camera.zoomTo', ctx, 0.000_001)
+    expect(orbit(ctx).radius).toBe(100)
+  })
+
+  it('pans the point the orbit looks at, leaving its depth alone', () => {
+    const ctx = orbiting()
+
+    executeCommand('camera.panTo', ctx, -1.5, 2)
+    expect(orbit(ctx).target).toEqual([-1.5, 2, 3])
+
+    executeCommand('camera.panBy', ctx, 0.5, -1)
+    expect(orbit(ctx).target).toEqual([-1, 1, 3])
+  })
+
+  it('frames the target and the distance as one step', () => {
+    const ctx = orbiting()
+
+    executeCommand('camera.frame', ctx, 1, -1, 4)
+
+    expect(orbit(ctx).target).toEqual([1, -1, 3])
+    expect(orbit(ctx).radius).toBeCloseTo(camera3DDefault.radius / 4, 6)
+  })
+
+  it('takes the camera from a held timeline frame, as a 2D pan does', () => {
+    // Without this the reset lands in the document while the canvas keeps
+    // rendering the held frame — the no-op the viewer reported.
+    for (const [id, ...args] of [
+      ['camera.center'],
+      ['camera.zoomTo', 2],
+      ['camera.zoomBy', 2],
+      ['camera.panTo', 1, 1],
+      ['camera.panBy', 1, 1],
+      ['camera.frame', 1, 1, 2],
+    ] as const) {
+      const ctx = orbiting()
+      const setPreviewHeld = vi.fn()
+      Object.assign(ctx.timeline, { setPreviewHeld })
+
+      executeCommand(id, ctx, ...args)
+
+      expect(setPreviewHeld, id).toHaveBeenCalledWith(false)
+    }
+  })
+
+  it('leaves the orbit alone on a 2D flame', () => {
+    const ctx = createMockCommandContext()
+    const before = ctx.flameDescriptor().renderSettings.camera3D
+
+    executeCommand('camera.zoomTo', ctx, 3)
+    executeCommand('camera.panTo', ctx, 1, 2)
+
+    expect(ctx.setZoom).toHaveBeenCalledWith(3)
+    expect(ctx.setPosition).toHaveBeenCalledWith(
+      expect.objectContaining({ x: 1, y: 2 }),
+    )
+    expect(ctx.flameDescriptor().renderSettings.camera3D).toEqual(before)
+  })
+
+  it('copes with a 3D flame that carries no orbit yet', () => {
+    // `flame.setRenderSetting dimensions 3` writes the number and nothing
+    // else, so the first camera command can be the one that meets a
+    // descriptor with no camera3D on it.
+    const ctx = createMockCommandContext()
+    executeCommand('flame.setRenderSetting', ctx, 'dimensions', 3)
+    expect(ctx.flameDescriptor().renderSettings.camera3D).toBeUndefined()
+
+    executeCommand('camera.zoomBy', ctx, 2)
+
+    expect(orbit(ctx).radius).toBeCloseTo(camera3DDefault.radius / 2, 6)
     expect(ctx.setZoom).not.toHaveBeenCalled()
   })
 

--- a/packages/app/src/commands/builtins/camera3D.test.ts
+++ b/packages/app/src/commands/builtins/camera3D.test.ts
@@ -1,8 +1,8 @@
 import '@/commands/builtins'
 import { describe, expect, it, vi } from 'vitest'
-import { camera3DDefault } from '@/flame/schema/flameSchema'
+import { camera3DDefault, MAX_ORBIT_RADIUS, MIN_ORBIT_RADIUS, } from '@/flame/schema/flameSchema'
 import { createMockCommandContext } from '@/webmcp/testUtils'
-import { executeCommand } from '../registry'
+import { executeCommand, executeReplayCommand } from '../registry'
 import type { CommandContext } from '../types'
 
 /** A 3D flame with an orbit that is nowhere near its default. */
@@ -62,14 +62,37 @@ describe('the framing commands in three dimensions', () => {
     expect(orbit(ctx).radius).toBeCloseTo(4, 6)
   })
 
-  it('keeps the orbit at a distance the R control could reach', () => {
+  it('keeps the orbit inside the range the wheel itself allows', () => {
     const ctx = orbiting()
 
     executeCommand('camera.zoomTo', ctx, 1e9)
-    expect(orbit(ctx).radius).toBe(0.1)
+    expect(orbit(ctx).radius).toBe(MIN_ORBIT_RADIUS)
 
     executeCommand('camera.zoomTo', ctx, 0.000_001)
-    expect(orbit(ctx).radius).toBe(100)
+    expect(orbit(ctx).radius).toBe(MAX_ORBIT_RADIUS)
+  })
+
+  it('never backs away from a zoom-in, however close the orbit already is', () => {
+    // Reading the radius through the clamp and then dividing inverts the
+    // move: from the floor, "twice as close" computed from 0.1 and pushed
+    // the camera out to 0.05. The wheel can leave the orbit right here.
+    const ctx = orbiting()
+    executeCommand('flame.setRenderSetting', ctx, 'camera3D', {
+      radius: MIN_ORBIT_RADIUS,
+    })
+
+    executeCommand('camera.zoomBy', ctx, 2)
+
+    expect(orbit(ctx).radius).toBe(MIN_ORBIT_RADIUS)
+  })
+
+  it('zooms in from a radius the R control cannot type', () => {
+    const ctx = orbiting()
+    executeCommand('flame.setRenderSetting', ctx, 'camera3D', { radius: 0.04 })
+
+    executeCommand('camera.zoomBy', ctx, 2)
+
+    expect(orbit(ctx).radius).toBeCloseTo(0.02, 6)
   })
 
   it('pans the point the orbit looks at, leaving its depth alone', () => {
@@ -112,8 +135,12 @@ describe('the framing commands in three dimensions', () => {
     }
   })
 
-  it('leaves the orbit alone on a 2D flame', () => {
+  it('leaves the orbit alone on a 2D flame that has one', () => {
+    // A parsed flame always carries a camera3D, whatever its dimensions.
     const ctx = createMockCommandContext()
+    ctx.setFlameDescriptor((draft) => {
+      draft.renderSettings.camera3D = { ...camera3DDefault, radius: 8 }
+    }, 'test')
     const before = ctx.flameDescriptor().renderSettings.camera3D
 
     executeCommand('camera.zoomTo', ctx, 3)
@@ -138,6 +165,23 @@ describe('the framing commands in three dimensions', () => {
 
     expect(orbit(ctx).radius).toBeCloseTo(camera3DDefault.radius / 2, 6)
     expect(ctx.setZoom).not.toHaveBeenCalled()
+  })
+
+  it('replays as itself, without the nested write becoming a step', () => {
+    // The 3D branches dispatch flame.setRenderSetting; a replayed camera step
+    // must still land the same orbit and be accepted by the replay guard.
+    const ctx = orbiting()
+
+    expect(executeReplayCommand('camera.zoomTo', ctx, 2)).toBe(true)
+    expect(orbit(ctx).radius).toBeCloseTo(camera3DDefault.radius / 2, 6)
+
+    expect(executeReplayCommand('camera.panTo', ctx, 1, 2)).toBe(true)
+    expect(orbit(ctx).target).toEqual([1, 2, 3])
+
+    // The same malformed calls the 2D suite rejects are still rejected.
+    expect(executeReplayCommand('camera.panTo', ctx, 'left', 2)).toBe(false)
+    expect(executeReplayCommand('camera.panTo', ctx, 1)).toBe(false)
+    expect(orbit(ctx).target).toEqual([1, 2, 3])
   })
 
   it('still resets position and zoom for a 2D flame', () => {

--- a/packages/app/src/flame/schema/flameSchema.ts
+++ b/packages/app/src/flame/schema/flameSchema.ts
@@ -17,6 +17,13 @@ export const backgroundColorDefault: [number, number, number] = [0, 0, 0]
 export const backgroundColorDefaultWhite: [number, number, number] = [1, 1, 1]
 export const MIN_CAMERA_ZOOM_VALUE: number = 0.01
 export const MAX_CAMERA_ZOOM_VALUE: number = 500
+// Orbit-zoom radius clamp. The lower bound keeps the 3D brightness/quality
+// normalization out of its blow-out regime at extreme magnification — use fly
+// mode (which translates the rig instead of shrinking the radius) to get
+// visually closer than this. Here rather than in the camera component because
+// the framing commands clamp to the same range the wheel does.
+export const MIN_ORBIT_RADIUS: number = 0.02
+export const MAX_ORBIT_RADIUS: number = 100
 const cameraDefault: {
   zoom: number
   position: [number, number]

--- a/packages/app/src/lib/WheelZoomCamera3D.tsx
+++ b/packages/app/src/lib/WheelZoomCamera3D.tsx
@@ -1,6 +1,7 @@
 import { batch, createEffect, createMemo, createSignal, onCleanup, } from 'solid-js'
 import { vec3 } from 'wgpu-matrix'
 import { useChangeHistory } from '@/contexts/ChangeHistoryContext'
+import { MAX_ORBIT_RADIUS, MIN_ORBIT_RADIUS } from '@/flame/schema/flameSchema'
 import { Camera3D } from '@/lib/Camera3D'
 import { useCamera3D } from '@/lib/Camera3DContext'
 import { cameraBasis, rollAdjustLookDelta } from '@/lib/cameraMath'
@@ -24,12 +25,6 @@ const FLY_SPEED_RANGE: [number, number] = [0.05, 20]
 // the radius is clamped to this range first so panning is never absurdly fast
 // when far out or painfully slow when zoomed in close.
 const PAN_RADIUS_RANGE: [number, number] = [1, 12]
-// Orbit-zoom radius clamp. The lower bound keeps the 3D brightness/quality
-// normalization out of its blow-out regime at extreme magnification — use fly
-// mode (which translates the rig instead of shrinking the radius) to get
-// visually closer than this.
-const MIN_ORBIT_RADIUS = 0.02
-const MAX_ORBIT_RADIUS = 100
 // Movement keys (always camera-controlled in 3D) and fly-only keys.
 const MOVE_KEYS = new Set([
   'w',

--- a/packages/app/src/recorder/focus.ts
+++ b/packages/app/src/recorder/focus.ts
@@ -37,10 +37,10 @@ import type { FlameCommand } from '@/commands/types'
  * selectors is what lets every caller stay dimension-blind — ViewControls
  * mounts the 2D group or the 3D one and never both, so at most one can match.
  */
-const CAMERA_3D_COUNTERPART: Record<string, string | undefined> = {
-  'camera.zoom': 'camera3D.radius',
-  'camera.position': 'camera3D',
-}
+const CAMERA_3D_COUNTERPART = new Map([
+  ['camera.zoom', 'camera3D.radius'],
+  ['camera.position', 'camera3D'],
+])
 
 function paramSelectors(value: string): string[] {
   const quoted = cssQuote(value)
@@ -66,7 +66,10 @@ export function focusSelectors(hint: string): string[] {
   const quoted = cssQuote(value)
   switch (kind) {
     case 'param': {
-      const counterpart = CAMERA_3D_COUNTERPART[value]
+      // A Map, not an object literal: hints come out of session files, and
+      // `param:constructor` against a literal answers with a function, which
+      // `cssQuote` would then throw on rather than resolve to no element.
+      const counterpart = CAMERA_3D_COUNTERPART.get(value)
       return counterpart === undefined
         ? paramSelectors(value)
         : [...paramSelectors(value), ...paramSelectors(counterpart)]

--- a/packages/app/src/recorder/focus.ts
+++ b/packages/app/src/recorder/focus.ts
@@ -28,6 +28,34 @@ import { affineFocusId, affineRandomizeFocusId, affineResetFocusId, colorFocusId
 import { snapshotOriginFocus, snapshotOriginForCommand } from './snapshotOrigin'
 import type { FlameCommand } from '@/commands/types'
 
+/**
+ * The 3D control that stands in for a 2D camera parameter.
+ *
+ * One verb, two viewports: `camera.zoom` and `camera3D.radius` are the same
+ * knob under different names, and the orbit target has no control of its own,
+ * so a pan points at the orbit group as a whole. Offering both sets of
+ * selectors is what lets every caller stay dimension-blind — ViewControls
+ * mounts the 2D group or the 3D one and never both, so at most one can match.
+ */
+const CAMERA_3D_COUNTERPART: Record<string, string | undefined> = {
+  'camera.zoom': 'camera3D.radius',
+  'camera.position': 'camera3D',
+}
+
+function paramSelectors(value: string): string[] {
+  const quoted = cssQuote(value)
+  return [
+    `[data-parameter-path=${quoted}]`,
+    // The tour anchors name the control by role, and which suffix a given
+    // parameter uses is not derivable — try the ones in use.
+    `[data-tour-target=${cssQuote(`${value}-slider`)}]`,
+    `[data-tour-target=${cssQuote(`${value}-select`)}]`,
+    `[data-tour-target=${cssQuote(`${value}-picker`)}]`,
+    `[data-tour-target=${cssQuote(`${value}-buttons`)}]`,
+    `[data-tour-target=${cssQuote(`${value}-controls`)}]`,
+  ]
+}
+
 /** Elements the follow-cam can be asked to look at, most specific first. */
 export function focusSelectors(hint: string): string[] {
   const separator = hint.indexOf(':')
@@ -37,17 +65,12 @@ export function focusSelectors(hint: string): string[] {
   if (value === '') return []
   const quoted = cssQuote(value)
   switch (kind) {
-    case 'param':
-      return [
-        `[data-parameter-path=${quoted}]`,
-        // The tour anchors name the control by role, and which suffix a given
-        // parameter uses is not derivable — try the ones in use.
-        `[data-tour-target=${cssQuote(`${value}-slider`)}]`,
-        `[data-tour-target=${cssQuote(`${value}-select`)}]`,
-        `[data-tour-target=${cssQuote(`${value}-picker`)}]`,
-        `[data-tour-target=${cssQuote(`${value}-buttons`)}]`,
-        `[data-tour-target=${cssQuote(`${value}-controls`)}]`,
-      ]
+    case 'param': {
+      const counterpart = CAMERA_3D_COUNTERPART[value]
+      return counterpart === undefined
+        ? paramSelectors(value)
+        : [...paramSelectors(value), ...paramSelectors(counterpart)]
+    }
     case 'ui':
       return [`[data-tour-target=${quoted}]`]
     case 'focus': {

--- a/packages/app/src/recorder/focusCamera3D.test.ts
+++ b/packages/app/src/recorder/focusCamera3D.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import { focusHintFor, focusSelectors, resolveFocusElement } from './focus'
+
+/**
+ * A camera step points at the control that moved. There are two such controls
+ * — the 2D zoom field and the orbit's R — and the hint cannot know which flame
+ * is loaded, so it offers both. Only one is ever mounted.
+ */
+describe('camera focus across dimensions', () => {
+  it('offers the orbit control after the 2D one, never instead of it', () => {
+    const zoom = focusSelectors(focusHintFor('camera.zoomBy', [2])!)
+    expect(zoom[0]).toBe('[data-parameter-path="camera.zoom"]')
+    expect(zoom).toContain('[data-parameter-path="camera3D.radius"]')
+
+    // The orbit target has no field of its own, so a pan points at the group.
+    const pan = focusSelectors(focusHintFor('camera.panTo', [1, 2])!)
+    expect(pan[0]).toBe('[data-parameter-path="camera.position"]')
+    expect(pan).toContain('[data-tour-target="camera3D-controls"]')
+  })
+
+  it('finds the orbit control when a 3D flame is what is on screen', () => {
+    document.body.innerHTML = `
+      <div data-tour-target="camera3D-controls">
+        <input data-parameter-path="camera3D.radius" />
+      </div>
+    `
+    const radius = document.querySelector<HTMLElement>(
+      '[data-parameter-path="camera3D.radius"]',
+    )!
+    radius.getBoundingClientRect = () =>
+      ({ left: 10, top: 20, width: 100, height: 30 }) as DOMRect
+
+    // The 2D controls are unmounted in 3D, so the first four selectors miss
+    // and the step lands on the orbit's own field instead of nothing.
+    expect(resolveFocusElement('param:camera.zoom')).toBe(radius)
+
+    document.body.innerHTML = ''
+  })
+
+  it('leaves every other parameter with the selectors it always had', () => {
+    expect(focusSelectors('param:gamma')).toEqual([
+      '[data-parameter-path="gamma"]',
+      '[data-tour-target="gamma-slider"]',
+      '[data-tour-target="gamma-select"]',
+      '[data-tour-target="gamma-picker"]',
+      '[data-tour-target="gamma-buttons"]',
+      '[data-tour-target="gamma-controls"]',
+    ])
+  })
+})

--- a/packages/app/src/recorder/focusCamera3D.test.ts
+++ b/packages/app/src/recorder/focusCamera3D.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
 import { focusHintFor, focusSelectors, resolveFocusElement } from './focus'
 
 /**
@@ -7,6 +7,10 @@ import { focusHintFor, focusSelectors, resolveFocusElement } from './focus'
  * is loaded, so it offers both. Only one is ever mounted.
  */
 describe('camera focus across dimensions', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
   it('offers the orbit control after the 2D one, never instead of it', () => {
     const zoom = focusSelectors(focusHintFor('camera.zoomBy', [2])!)
     expect(zoom[0]).toBe('[data-parameter-path="camera.zoom"]')
@@ -33,8 +37,19 @@ describe('camera focus across dimensions', () => {
     // The 2D controls are unmounted in 3D, so the first four selectors miss
     // and the step lands on the orbit's own field instead of nothing.
     expect(resolveFocusElement('param:camera.zoom')).toBe(radius)
+  })
 
-    document.body.innerHTML = ''
+  it('answers nothing for a hint that names an inherited property', () => {
+    // Hints come out of session files. Looked up in an object literal,
+    // `constructor` answers with a function and the selector builder throws
+    // inside a replay's animation frame instead of resolving to no element.
+    expect(() => focusSelectors('param:constructor')).not.toThrow()
+    expect(focusSelectors('param:constructor')).toEqual(
+      focusSelectors('param:gamma').map((selector) =>
+        selector.replace(/gamma/g, 'constructor'),
+      ),
+    )
+    expect(resolveFocusElement('param:__proto__')).toBeNull()
   })
 
   it('leaves every other parameter with the selectors it always had', () => {


### PR DESCRIPTION
Follow-up to [#168](https://github.com/chaos-matters/chaos-master/pull/168), which made `camera.center` 3D-aware and left the other five commands as 2D-only no-ops. In a 3D duel `camera.*` is allowed and the agent's brief hands it out, so a `camera.zoomBy` did nothing and cost a step.

## What the commands mean in 3D

| Command | 3D behaviour |
| --- | --- |
| `camera.zoomTo z` | Orbit radius: the default 5 is zoom 1, so radius is `5 / z`, clamped to the 0.1 to 100 the R control offers |
| `camera.zoomBy f` | Halves the distance for `f = 2`; a factor of zero or less is still "no change" |
| `camera.panTo x y` | Moves the point the orbit looks at, in x and y; its depth is left where it is |
| `camera.panBy dx dy` | The same, relative |
| `camera.frame x y z` | Target and distance in one step |
| `camera.center` | Unchanged from #168: orbit back to default, lens untouched |

Orbit angle has no 2D counterpart, so `camera3D.theta` and `camera3D.phi` stay on `flame.setRenderSetting`. The duel brief says that now, instead of "camera.* does nothing in 3D".

Every 3D write goes through `flame.setRenderSetting` on the `camera3D` container, exactly as the 2D setters do: it merges, it releases a held timeline frame, and nested inside a command that is already recording it adds no step of its own. The orbit is read defensively, because a descriptor can say `dimensions: 3` and carry no `camera3D` — `flame.setRenderSetting dimensions 3` writes the number straight into the store and only a schema parse fills the default in. A test pins that case.

## Focus anchors

A camera step points at the control that moved, and there are two such controls. Plumbing the dimension through would have meant teaching both the recorder (which stores the hint) and the replay preparation (which recomputes and overrides it) to agree.

Instead a camera hint now offers the orbit's selectors after the 2D ones: `param:camera.zoom` also tries `camera3D.radius`, and `param:camera.position` also tries the `camera3D-controls` group, since the orbit target has no field of its own. ViewControls mounts the 2D group or the 3D one and never both, so at most one can match and every caller stays dimension-blind. Before this, a 3D replay of a camera step spotlighted nothing at all.

## Tests

`commands/builtins/camera3D.test.ts` covers all six commands on an orbit that is nowhere near its default, the clamped ends, the missing-orbit descriptor, that a 2D flame's orbit is untouched, and that every one of the six releases a held timeline frame. `recorder/focusCamera3D.test.ts` covers the selector order, that a mounted orbit control resolves from a 2D hint, and that every other parameter's selectors are unchanged.

`pnpm typecheck`, `pnpm lint` (0 errors), `pnpm test` (200 files, 2315 tests) pass.

## Review round (second commit)

Four focused reviewers; everything confirmed is fixed except one pre-existing item.

- **The clamped read inverted a relative zoom.** `orbitOf` clamped the stored radius before dividing it, so from a radius the wheel can reach but the R field cannot type (its floor is 0.02, the command used 0.1), `camera.zoomBy 2` computed from 0.1 and pushed the camera *away*. The reading is raw now; only the write is clamped, and to the wheel's own range, which moved into the schema beside the other camera bounds so a command and a scroll cannot disagree.
- **The counterpart lookup was an object literal**, so a hint of `param:constructor` answered with a function and `cssQuote` threw inside the spotlight's animation frame — where a malformed hint from a session file is supposed to resolve to no element. It is a `Map`.
- **The 3D brief was wrong about centre**: it resets the angle too, which the next sentence tells the agent to set. It says so now, and names `camera3D.target`, the one part of the orbit point that pan does not reach.
- **Tests**: a replayed 3D camera step (including the malformed calls the frozen 2D suite rejects), both floor cases, a 2D flame that actually carries an orbit, an inherited-property hint, DOM cleanup in `afterEach`, and the brief's claims asserted once each rather than five assertions that passed before the change.

Not fixed, pre-existing and untouched here: on a **2D** flame `camera.center` pushes two history entries (`setPosition` and `setZoom` dispatch separately), so Ctrl+0 then Ctrl+Z restores the zoom but leaves the position at the origin. The 3D path is one entry.

`pnpm typecheck`, `pnpm lint` (0 errors), `pnpm test` (200 files, 2320 tests) pass.