### PR TITLE
fix(arcade): what Cinema was hiding from the agent, and from the viewer

### DIFF
--- a/packages/app/src/arcade/animatablePaths.test.ts
+++ b/packages/app/src/arcade/animatablePaths.test.ts
@@ -238,6 +238,34 @@ describe('animatable catalog', () => {
     })
   })
 
+  /** The agent that met this refusal on a preset's 90-frame orbit guessed the
+   *  keyframes were malformed and spent a step clearing the timeline. All
+   *  three ways out are in the sentence now, including the one it took. */
+  it('names every way past a preset animation it would cut', () => {
+    const built = buildTimelineSnapshot(
+      {
+        durationFrames: 30,
+        mode: 'add',
+        tracks: [{ path: 't2.v2', keyframes: [{ frame: 0, value: 0.7 }] }],
+      },
+      catalog,
+      [
+        {
+          parameterPath: 'exposure',
+          keyframes: [
+            { frame: 0, value: 0.25 },
+            { frame: 90, value: 0.5 },
+          ],
+        },
+      ] satisfies TimelineTrack[],
+    )
+    expect(built.ok).toBe(false)
+    if (built.ok) return
+    expect(built.error).toContain('durationFrames 90 or more')
+    expect(built.error).toContain('mode "replace"')
+    expect(built.error).toContain('timeline.clearTracks')
+  })
+
   it('rejects unknown paths, frames past the end, wrong value types and duplicates', () => {
     const base = { durationFrames: 60 }
     expect(

--- a/packages/app/src/arcade/animatablePaths.ts
+++ b/packages/app/src/arcade/animatablePaths.ts
@@ -328,7 +328,7 @@ export function buildTimelineSnapshot(
     if (last !== undefined && last.frame > input.durationFrames) {
       return {
         ok: false,
-        error: `durationFrames ${input.durationFrames} would cut the existing track "${track.parameterPath}", which runs to frame ${last.frame}. Keep the same duration or send mode "replace".`,
+        error: `durationFrames ${input.durationFrames} would cut the existing track "${track.parameterPath}", which runs to frame ${last.frame}. This flame arrived with its own animation: use durationFrames ${last.frame} or more to build on it, send mode "replace" to drop it, or empty the timeline first with execute_command timeline.clearTracks.`,
       }
     }
   }

--- a/packages/app/src/components/Timeline/TimelineSection.tsx
+++ b/packages/app/src/components/Timeline/TimelineSection.tsx
@@ -91,7 +91,7 @@ export function TimelineSection(props: TimelineSectionProps) {
             >
               −
             </button>
-            <span class={ui.zoomLabel}>
+            <span class={ui.zoomLabel} data-testid="timeline-zoom">
               {Math.round((viewApi()?.zoomLevel() ?? 1) * 100)}%
             </span>
             <button

--- a/packages/app/src/components/Timeline/hooks/useZoomGestures.ts
+++ b/packages/app/src/components/Timeline/hooks/useZoomGestures.ts
@@ -1,4 +1,5 @@
-import { createEffect, createMemo, createSignal, onCleanup } from 'solid-js'
+import { createEffect, createMemo, createSignal, onCleanup, untrack, } from 'solid-js'
+import { agentDriving } from '@/arcade/pilot'
 import { createPinchHandler } from '@/utils/createPinchHandler'
 import type { Accessor } from 'solid-js'
 
@@ -145,6 +146,32 @@ export function useZoomGestures(
     ro.observe(ruler)
     onCleanup(() => {
       ro.disconnect()
+    })
+  })
+
+  // Fit is a button, and an agent has no pointer to press it with.
+  //
+  // A Cinema take replaces the whole timeline, usually with a longer duration
+  // than whatever was on it — a nine-second take over a preset's ninety frames
+  // is three times the span. The dope sheet kept the zoom it had, so the frames
+  // the agent had just written ran off the right edge of the panel the lock
+  // overlay is pointing at, and the viewer watched a step land somewhere they
+  // could not see. Re-fit whenever the span changes while the agent drives.
+  //
+  // Only while it drives: a zoom a person set by hand is theirs, and the
+  // workspace is locked for the whole time this can fire.
+  let previousTotalFrames: number | undefined
+  createEffect(() => {
+    const frames = totalFrames()
+    const driving = agentDriving()
+    const changed =
+      previousTotalFrames !== undefined && previousTotalFrames !== frames
+    previousTotalFrames = frames
+    if (!changed || !driving) return
+    // Untracked: autoFitZoom reads containerHeight, and this effect must depend
+    // on the frame span alone or a panel resize would re-run it.
+    untrack(() => {
+      autoFitZoom()
     })
   })
 

--- a/packages/app/src/webmcp/tools/arcadeCinema.test.ts
+++ b/packages/app/src/webmcp/tools/arcadeCinema.test.ts
@@ -6,6 +6,7 @@ import { cancelSessionRecording, startSessionRecording, stopSessionRecording, un
 import { clearWebMcpContext, setWebMcpContext } from '@/webmcp/contextBridge'
 import { createMockCommandContext, createTestFlame } from '@/webmcp/testUtils'
 import { arcadeEndCinema, arcadeGetAnimatablePaths, arcadeSetKeyframes, arcadeStartCinema, } from './arcadeCinema'
+import type { FlameDescriptor } from '@/flame/schema/flameSchema'
 
 /** A mock whose recorder hands back a take, the way a real one does. */
 function ctxWithRecorder() {
@@ -238,7 +239,27 @@ describe('Cinema tools', () => {
     }
     expect(paths.transforms).toHaveLength(8)
     expect(paths.transformPaths).toContain('preAffine')
-    expect(JSON.stringify(paths).length).toBeLessThan(1500)
+    // Was 1500 before blendWeight (the one keyable parameter no group named)
+    // joined the result at 24 bytes. Every other addition here has to pay for
+    // itself the same way: measure, then move this, rather than the reverse.
+    expect(JSON.stringify(paths).length).toBeLessThan(1600)
+  })
+
+  /** The same flame opened from a motion row: the preset's own tracks are
+   *  reported too, and that is the case an agent actually meets. */
+  it('stays inside the budget when the flame arrives animated', async () => {
+    const ctx = createMockCommandContext()
+    ctx.timeline.tracks = () =>
+      ['camera3D.theta', 'camera3D.phi', 'camera3D.radius'].map((path) => ({
+        parameterPath: path,
+        keyframes: [
+          { frame: 0, value: 1 },
+          { frame: 90, value: 2 },
+        ],
+      }))
+    setWebMcpContext(ctx)
+    const paths = await arcadeGetAnimatablePaths.execute({}, {})
+    expect(JSON.stringify(paths).length).toBeLessThan(1900)
   })
 
   // The grammar is the agent's only description of what set_keyframes accepts,
@@ -303,5 +324,145 @@ describe('Cinema tools', () => {
     expect(
       await arcadeSetKeyframes.execute({ durationFrames: 30, tracks: [] }, {}),
     ).toHaveProperty('error')
+  })
+})
+
+/**
+ * The listing an agent plans its whole take from.
+ *
+ * A 3D flame reported `camera: []` while `camera3D.theta` was keyable, moved
+ * the picture, and was in the catalog the same call had just built — the
+ * summary named the 2D group and nothing else, so a whole parameter family was
+ * offered to nobody.
+ */
+describe('arcade_get_animatable_paths lists everything the timeline drives', () => {
+  afterEach(() => {
+    resetPilot()
+    cancelSessionRecording()
+    clearWebMcpContext()
+  })
+
+  type Summary = {
+    render: { path: string }[]
+    palette: { path: string }[]
+    color: { path: string }[]
+    camera: { path: string; current?: unknown }[]
+    other: { path: string; current?: unknown }[]
+    transformPaths: string
+    existingTracks?: { count: number; endFrame: number; paths: string[] }
+  }
+
+  const summaryFor = async (flame: FlameDescriptor, ctxPatch = {}) => {
+    const ctx = createMockCommandContext()
+    ctx.flameDescriptor = () => flame
+    Object.assign(ctx, ctxPatch)
+    setWebMcpContext(ctx)
+    return (await arcadeGetAnimatablePaths.execute({}, {})) as Summary
+  }
+
+  /**
+   * Nothing the timeline can drive may be invisible to the agent: every
+   * non-transform catalog path is either listed with its current value or
+   * named by the `transformPaths` grammar. The bug was one whole group going
+   * unnamed; this is the ratchet for the next one.
+   */
+  const assertCoversCatalog = (flame: FlameDescriptor, summary: Summary) => {
+    const listed = new Set(
+      [
+        ...summary.render,
+        ...summary.palette,
+        ...summary.color,
+        ...summary.camera,
+        ...summary.other,
+      ].map((entry) => entry.path),
+    )
+    const namedByGrammar = (path: string) =>
+      path.startsWith('finalTransform.') &&
+      summary.transformPaths.includes('finalTransform.{a-f}')
+    const missing = buildAnimatableCatalog(flame)
+      .filter((entry) => !entry.group.startsWith('Transform '))
+      .map((entry) => entry.path)
+      .filter((path) => !listed.has(path) && !namedByGrammar(path))
+    expect(missing).toEqual([])
+  }
+
+  it('offers the 3D camera family on a 3D flame', async () => {
+    const flame = createTestFlame()
+    flame.renderSettings.dimensions = 3
+    flame.renderSettings.camera3D = {
+      theta: 1.2,
+      phi: 1.5,
+      radius: 2.2,
+      fov: 60,
+    } as never
+    const summary = await summaryFor(flame)
+    expect(summary.camera.map((entry) => entry.path)).toEqual([
+      'camera3D.theta',
+      'camera3D.phi',
+      'camera3D.radius',
+      'camera3D.fov',
+    ])
+    expect(summary.camera[0]).toMatchObject({ current: 1.2 })
+    assertCoversCatalog(flame, summary)
+  })
+
+  it('offers the 2D camera family on a 2D flame', async () => {
+    const flame = createTestFlame()
+    const summary = await summaryFor(flame)
+    expect(summary.camera.map((entry) => entry.path)).toEqual([
+      'camera.x',
+      'camera.y',
+      'camera.zoom',
+      'camera.rotation',
+    ])
+    assertCoversCatalog(flame, summary)
+  })
+
+  it('names the tracks a preset arrived with', async () => {
+    const ctx = createMockCommandContext()
+    ctx.timeline.tracks = () =>
+      [
+        {
+          parameterPath: 'camera3D.theta',
+          keyframes: [
+            { frame: 0, value: 1.2 },
+            { frame: 90, value: 7.5 },
+          ],
+        },
+      ] as never
+    setWebMcpContext(ctx)
+    const summary = (await arcadeGetAnimatablePaths.execute({}, {})) as Summary
+    expect(summary.existingTracks).toMatchObject({
+      count: 1,
+      endFrame: 90,
+      paths: ['camera3D.theta'],
+    })
+  })
+
+  it('tells the pilot at the start what the timeline already holds', async () => {
+    const ctx = ctxWithRecorder()
+    ctx.timeline.tracks = () =>
+      [
+        {
+          parameterPath: 'camera3D.theta',
+          keyframes: [
+            { frame: 0, value: 1.2 },
+            { frame: 90, value: 7.5 },
+          ],
+        },
+      ] as never
+    const started = (await arcadeStartCinema.execute({}, {})) as {
+      existingTracks?: { count: number; endFrame: number }
+      tips: string[]
+    }
+    expect(started.existingTracks).toMatchObject({ count: 1, endFrame: 90 })
+    expect(started.tips[0]).toContain('already holds 1 track(s)')
+    expect(started.tips[0]).toContain('timeline.clearTracks')
+  })
+
+  it('says nothing about existing tracks when the timeline is empty', async () => {
+    setWebMcpContext(createMockCommandContext())
+    const summary = (await arcadeGetAnimatablePaths.execute({}, {})) as Summary
+    expect(summary.existingTracks).toBeUndefined()
   })
 })

--- a/packages/app/src/webmcp/tools/arcadeCinema.ts
+++ b/packages/app/src/webmcp/tools/arcadeCinema.ts
@@ -9,6 +9,7 @@ import { executeCommand, preflightReplayCommand } from '@/commands/registry'
 import { withRecordingSuppressed } from '@/recorder/recorder'
 import { getWebMcpContext } from '@/webmcp/contextBridge'
 import type { CatalogEntry } from '@/arcade/animatablePaths'
+import type { TimelineTrack } from '@/utils/timeline'
 import type { WebMcpTool } from '@/webmcp/types'
 
 const NOT_READY = {
@@ -68,11 +69,18 @@ export const arcadeStartCinema: WebMcpTool = {
     if (ctx.view?.showTimeline?.() !== true) {
       executeCommand('view.setShowTimeline', ctx, true)
     }
+    const existing = summarizeExisting(ctx.timeline.tracks())
     return {
       ok: true,
       stepBudget: CINEMA_STEP_BUDGET,
       allowedCommands: describeAllowedCommands(allowed),
+      existingTracks: existing,
       tips: [
+        ...(existing
+          ? [
+              `The timeline already holds ${existing.count} track(s) running to frame ${existing.endFrame} — this flame arrived with an animation. ${existing.note}`,
+            ]
+          : []),
         'Call arcade_get_animatable_paths first.',
         'Build the animation one idea at a time: arcade_set_keyframes with mode "add" per group of related tracks, keeping the same durationFrames. Each call is a step the viewer watches land and can replay.',
         'Keep it under 10 seconds unless asked; use easeInOut for camera moves.',
@@ -91,9 +99,45 @@ const MAX_LISTED_TRANSFORMS = 8
 const TRANSFORM_PATHS =
   'transform.<id>.{preAffine|postAffine}.{a-f} or .{probability|colorSpeed|color.x|color.y} | finalTransform.{a-f} | <id>.<variationId> = variation weight (no transform. prefix)'
 
+/** Groups `summarize` names explicitly. Everything else lands in `other`. */
+const NAMED_GROUPS = new Set([
+  'Render',
+  'Palette',
+  'Color',
+  'Camera',
+  'Camera3D',
+])
+
+/** How many existing track paths are named before the list is truncated. */
+const MAX_LISTED_EXISTING = 12
+
+/**
+ * What the timeline already holds, so a Cinema call can be built around it.
+ *
+ * A flame opened from a motion row arrives with its own animation on the
+ * timeline. An agent that cannot see it sends `mode: "add"` with a shorter
+ * duration, gets the (correct) refusal naming a track it never placed, and has
+ * to guess what happened — the run this came from blamed the keyframes' missing
+ * `interp`, which is optional and was never the problem.
+ */
+function summarizeExisting(tracks: readonly TimelineTrack[]) {
+  if (tracks.length === 0) return undefined
+  const endFrame = Math.max(
+    ...tracks.map((track) => track.keyframes.at(-1)?.frame ?? 0),
+  )
+  return {
+    count: tracks.length,
+    endFrame,
+    paths: tracks.slice(0, MAX_LISTED_EXISTING).map((t) => t.parameterPath),
+    truncated: tracks.length > MAX_LISTED_EXISTING ? true : undefined,
+    note: `mode "add" keeps these and needs durationFrames >= ${endFrame}; "replace" drops them; timeline.clearTracks empties the timeline.`,
+  }
+}
+
 function summarize(
   catalog: CatalogEntry[],
   config: { fps: number; endFrame: number; loopMode?: string } | undefined,
+  existingTracks: readonly TimelineTrack[] = [],
 ) {
   // `type` is dropped for numbers, which is nearly every path; the tool
   // description says so. It is the single biggest saving in this result.
@@ -117,7 +161,28 @@ function summarize(
     render: simple('Render'),
     palette: simple('Palette'),
     color: simple('Color'),
-    camera: simple('Camera'),
+    // A flame renders through exactly one camera family and the catalog drops
+    // the other, so this key always holds the live one — camera3D.* on a 3D
+    // flame. Naming only the 2D group here is what reported `camera: []` for a
+    // 3D flame whose camera3D paths were keyable all along.
+    camera: [...simple('Camera'), ...simple('Camera3D')],
+    // Everything else the timeline drives, collected by exclusion so a new
+    // parameter group cannot go missing the way Camera3D did. Transforms have
+    // their own block below, and `transformPaths` already gives the
+    // finalTransform grammar — its current values are a get_flame away and
+    // would cost more of the result than they are worth here.
+    other: catalog
+      .filter(
+        (entry) =>
+          !NAMED_GROUPS.has(entry.group) &&
+          entry.group !== 'Final Transform' &&
+          !entry.group.startsWith('Transform '),
+      )
+      .map((entry) => ({
+        path: entry.path,
+        type: entry.type === 'number' ? undefined : entry.type,
+        current: entry.current,
+      })),
     transformPaths: TRANSFORM_PATHS,
     transforms: listed.map((id) => ({
       id,
@@ -149,6 +214,7 @@ function summarize(
           loopMode: config.loopMode ?? 'off',
         }
       : undefined,
+    existingTracks: summarizeExisting(existingTracks),
   }
 }
 
@@ -164,6 +230,7 @@ export const arcadeGetAnimatablePaths: WebMcpTool = {
     return summarize(
       buildAnimatableCatalog(ctx.flameDescriptor()),
       ctx.timeline.edit?.snapshot().config,
+      ctx.timeline.tracks(),
     )
   },
 }

--- a/tests/arcade.spec.ts
+++ b/tests/arcade.spec.ts
@@ -80,7 +80,9 @@ test.describe('Lumen Arcade', () => {
       topic: 'variations',
     })
     expect(brief).toMatchObject({ ok: true, topic: 'variations' })
-    const lock = page.getByRole('dialog', { name: 'AI is driving the editor' })
+    const lock = page.getByRole('dialog', {
+      name: 'The agent is driving the editor',
+    })
     await expect(lock).toBeVisible()
     await expect(lock).toContainText('Teaching: Variations')
 
@@ -144,13 +146,66 @@ test.describe('Lumen Arcade', () => {
   test('Stop ends the lesson and keeps the recording', async ({ page }) => {
     await openEditor(page)
     await callTool(page, 'arcade_start_lesson', { topic: 'color' })
-    await page.getByRole('button', { name: /Stop the AI/ }).click()
+    await page.getByRole('button', { name: /Stop the agent/ }).click()
     await expect(
       page.getByRole('dialog', { name: /Stopped by you/ }),
     ).toBeVisible()
     expect(
       await callTool(page, 'arcade_narrate', { text: 'too late' }),
     ).toHaveProperty('error')
+  })
+
+  /**
+   * Fit is a button, and the agent has no pointer.
+   *
+   * A take is usually longer than whatever span the dope sheet was showing, so
+   * the frames the agent just wrote ran off the right edge of the panel the
+   * lock overlay points at. Only a real layout can answer this: jsdom gives
+   * every element a zero width, and autoFitZoom returns early on one.
+   */
+  test('Cinema fits the dope sheet to the take it just wrote', async ({
+    page,
+  }) => {
+    await openEditor(page)
+    expect(await callTool(page, 'arcade_start_cinema', {})).toMatchObject({
+      ok: true,
+    })
+    const zoom = page.getByTestId('timeline-zoom')
+    await expect(zoom).toBeVisible({ timeout: 20_000 })
+    const before = await zoom.textContent()
+
+    // A nine-second take at 30fps, three times the span the editor opens with.
+    expect(
+      await callTool(page, 'arcade_set_keyframes', {
+        fps: 30,
+        durationFrames: 270,
+        play: false,
+        tracks: [
+          {
+            path: 'camera.zoom',
+            keyframes: [
+              { frame: 0, value: 1 },
+              { frame: 270, value: 1.6 },
+            ],
+          },
+        ],
+      }),
+    ).toMatchObject({ ok: true })
+    await expect(zoom).not.toHaveText(before ?? '', { timeout: 10_000 })
+
+    // The invariant, independent of how far the zoom range actually reaches:
+    // the take is already fitted, so pressing Fit changes nothing. Fit has to
+    // wait for the session to end — the pilot shield intercepts every pointer
+    // event over the workspace, which is exactly why the agent cannot press it
+    // and the dope sheet has to fit itself.
+    const fitted = await zoom.textContent()
+    await callTool(page, 'arcade_end_cinema', { title: 'Fit check' })
+    const endCard = page.getByRole('dialog', { name: /Fit check: Finished/ })
+    await expect(endCard).toBeVisible()
+    await page.keyboard.press('Escape')
+    await expect(endCard).toBeHidden()
+    await page.getByRole('button', { name: 'Fit' }).click()
+    await expect(zoom).toHaveText(fitted ?? '')
   })
 
   test('Cinema: paths, keyframes, end', async ({ page }) => {


### PR DESCRIPTION
Three findings from a 3D Cinema run, all reproduced against the real `geode-orbit` gallery row before fixing.

## The paths listing dropped whole parameter groups

`arcade_get_animatable_paths` summarised the catalog by naming four groups. `Camera3D`, `Final Transform` and `Blend` were not among them, so a 3D flame reported **`camera: []`** while `camera3D.theta` sat in the very catalog that call had just built, was accepted by `arcade_set_keyframes`, and visibly moved the picture. The agent had to guess the names.

- `camera` now holds whichever family the flame actually renders through (the other is already filtered out of the catalog, so exactly one is ever present).
- A new `other` key collects anything no group names — `blendWeight` today, and whatever a later `TIMELINE_PARAMETERS` group adds. `finalTransform.a-f` stays described by the `transformPaths` grammar rather than listed, which is where it already was.
- A test walks the catalog and fails if any non-transform path is neither listed nor named by the grammar.

## The timeline the flame arrived with was invisible

A flame opened from a motion row carries its own animation. `mode: "add"` with a shorter `durationFrames` is then correctly refused, naming a track the agent never placed. The run this came from concluded the preset's keyframes were malformed because they had no `interp` — `interp` is optional in the snapshot schema and was never the problem.

- `arcade_start_cinema` and `arcade_get_animatable_paths` now report what the timeline holds: how many tracks, how far they run, and their paths.
- The refusal names all three ways past it, including the `timeline.clearTracks` the agent reached for on its own.

## Fit is a button, and an agent has no pointer

A take is usually longer than the span the dope sheet was showing (a nine-second take over a preset's ninety frames is three times as wide), so the frames the agent had just written ran off the right edge of the panel the pilot lock is pointing at. The dope sheet re-fits itself whenever the frame span changes **while the agent drives**; a zoom a person set by hand is never touched.

## Test plan

- [x] `vitest` — 497 passing across webmcp/arcade/timeline/recorder, including the new catalog-coverage ratchet, the existing-tracks reports and the refusal wording
- [x] `tests/arcade.spec.ts` in a real browser (build + preview): **6/6**, including a new test that the dope sheet is already fitted after a 270-frame take — pressing Fit afterwards changes nothing. jsdom cannot test this: every element there has zero width and `autoFitZoom` returns early.
- [x] The same run repaired two selectors left stale by the agent/AI copy rename (`The agent is driving the editor`, `Stop the agent`); both tests pass again.
- [x] `tsc --noEmit`, `eslint` clean