### PR TITLE
feat(webmcp): list the variation registry, and stop two silent writes

### DIFF
--- a/docs/webmcp.md
+++ b/docs/webmcp.md
@@ -31,7 +31,7 @@ git log --format='%h %ad %s' --date=iso --since=2026-08-25 \
 
 ## Tool catalog
 
-33 tools are registered (`packages/app/src/webmcp/tools/index.ts`). Every
+34 tools are registered (`packages/app/src/webmcp/tools/index.ts`). Every
 description is at most 500 characters and every result is kept under about
 1.5 KB of JSON. The table below lists 32: `arcade_end_duel` is registered
 but does nothing except refuse, so it is described where that refusal is
@@ -41,6 +41,7 @@ explained rather than offered here as a capability.
 | --------------------------------------------------------------------------------------------------------- | ----- | --------------------------------------------------------------------------------- |
 | `get_flame`, `get_flame_detail`                                                                           | read  | Compact and paginated views of the active flame                                   |
 | `list_commands`                                                                                           | read  | Command ids, labels, descriptions, prefix index                                   |
+| `list_variations`                                                                                         | read  | Registered variation names, with the parameters of parametric ones                |
 | `get_undo_state`, `diff_flames`                                                                           | read  | History depth; structural diff between two flames                                 |
 | `execute_command`                                                                                         | write | Run any registered command (validated, guarded while the Arcade drives, recorded) |
 | `set_flame`, `randomize_flame`, `mutate_flame`, `undo`, `redo`, `create_share_link`, `load_share_link`    | mixed | Document-level tools                                                              |

--- a/packages/app/src/commands/builtins/flame.security.test.ts
+++ b/packages/app/src/commands/builtins/flame.security.test.ts
@@ -180,6 +180,68 @@ describe('bounded flame entity commands', () => {
     ).toHaveLength(MAX_VARIATIONS_PER_TRANSFORM)
   })
 
+  /**
+   * The agent's report, in a test.
+   *
+   * `{ type: "sphericalVar" }` reached execute, failed flame validation there,
+   * warned to the console and returned — so `execute_command` answered
+   * `success: true` for a variation that never changed, and the run worked
+   * around it with an add and a delete it did not have the steps for.
+   */
+  it('refuses a variation descriptor that is missing its weight', () => {
+    const world = makeContext(deepClone(examples.initExample))
+    const transformId = Object.keys(world.flame().transforms)[0]! as TransformId
+    const variationId = Object.keys(
+      world.flame().transforms[transformId]!.variations,
+    )[0]! as VariationId
+    const setVariation = command('flame.setVariation')
+
+    const refusal = setVariation.validateReplayArgs?.([
+      transformId,
+      variationId,
+      { type: 'sphericalVar' },
+    ])
+    expect(refusal).toContain('incomplete')
+    expect(refusal).toContain('weight')
+    // The whole descriptor still goes through, so the UI paths are untouched.
+    expect(
+      setVariation.validateReplayArgs?.([
+        transformId,
+        variationId,
+        { type: 'sphericalVar', weight: 1 },
+      ]),
+    ).toBeUndefined()
+  })
+
+  /** `__nope__: 1` sat inside a saved pdj variation because nothing checked
+   *  the name against the variation that owns the params. */
+  it('never writes a parameter the variation does not have', () => {
+    const world = makeContext(deepClone(examples.initExample))
+    const transformId = Object.keys(world.flame().transforms)[0]! as TransformId
+    const variationId = Object.keys(
+      world.flame().transforms[transformId]!.variations,
+    )[0]! as VariationId
+    command('flame.setVariation').execute(world.ctx, transformId, variationId, {
+      type: 'pdjVar',
+      weight: 1,
+      params: { a: 1, b: 2, c: 3, d: 4 },
+    })
+    const setParams = command('flame.setVariationParams')
+
+    setParams.execute(world.ctx, transformId, variationId, '__nope__', 1)
+    const params = world.flame().transforms[transformId]!.variations[
+      variationId
+    ]! as unknown as { params: Record<string, number> }
+    expect(Object.hasOwn(params.params, '__nope__')).toBe(false)
+    expect(Object.keys(params.params).sort()).toEqual(['a', 'b', 'c', 'd'])
+
+    setParams.execute(world.ctx, transformId, variationId, 'a', -2.4)
+    const after = world.flame().transforms[transformId]!.variations[
+      variationId
+    ]! as unknown as { params: Record<string, number> }
+    expect(after.params.a).toBe(-2.4)
+  })
+
   it('validates whole-variation replacements before they reach state', () => {
     const world = makeContext(deepClone(examples.initExample))
     const transformId = Object.keys(world.flame().transforms)[0]! as TransformId

--- a/packages/app/src/commands/builtins/flame.ts
+++ b/packages/app/src/commands/builtins/flame.ts
@@ -4,10 +4,12 @@ import { newDefaultTransform } from '@/flame/newTransform'
 import { isFlameGraphWithinLimits, isSafeFlameEntityId, tryValidateFlame, } from '@/flame/schema/flameSchema'
 import { generateTransformId, generateVariationId, } from '@/flame/transformFunction'
 import { defaultLinearType, isVariationTypeFor, } from '@/flame/variationRegistry'
+import { TransformVariationDescriptor } from '@/flame/variations'
 import { getVariationDefault } from '@/flame/variations/utils'
 import { tryValidateTransformColorSnapshot } from '@/recorder/schema'
 import { snapshotOriginForCommand, snapshotOriginLabel, tryValidateSnapshotOrigin, } from '@/recorder/snapshotOrigin'
 import { deepClone } from '@/utils/clone'
+import * as v from '@/valibot'
 import { registerCommand } from '../registry'
 import { num, str } from './describeArgs'
 import type { CommandContext } from '../types'
@@ -934,7 +936,19 @@ registerCommand({
       const vKey = resolveVariationKey(transform.variations, variationRef)
       const variation = vKey ? transform.variations[vKey] : undefined
       if (variation && 'params' in variation) {
-        ;(variation.params as Record<string, number>)[name] = value
+        const params = variation.params as Record<string, number>
+        // Only a name this variation actually has. Every parametric variation
+        // arrives with its full set of defaults, so a real name is always
+        // present — and an unknown one used to be written straight in, which is
+        // how `__nope__: 1` ended up saved inside a pdj variation, inert but
+        // carried by the descriptor and every export of it from then on.
+        if (!Object.hasOwn(params, name)) {
+          console.warn(
+            `[cmd] flame.setVariationParams: "${name}" is not a parameter of ${String((variation as { type?: unknown }).type)} (has ${Object.keys(params).join(', ')})`,
+          )
+          return
+        }
+        params[name] = value
       }
     })
   },
@@ -1005,8 +1019,17 @@ registerCommand({
     }
     if (!isSafeFlameEntityId(args[0])) return 'transform id is unsafe'
     if (!isSafeFlameEntityId(args[1])) return 'variation id is unsafe'
-    if (!isKnownVariationType(variationDescriptorType(args[2]))) {
+    const descriptorType = variationDescriptorType(args[2])
+    if (!isKnownVariationType(descriptorType)) {
       return 'variation descriptor type is not registered'
+    }
+    // A WHOLE descriptor, not just a registered type. `{ type: "sphericalVar" }`
+    // used to pass here and then fail validation inside execute, which warns to
+    // the console and returns — so the caller was told the step succeeded while
+    // the variation never changed. An agent watched exactly that happen and
+    // spent two more steps working around it with add + delete.
+    if (!v.safeParse(TransformVariationDescriptor, args[2]).success) {
+      return `variation descriptor for "${descriptorType}" is incomplete: send the whole descriptor, including weight (and params for a parametric variation). Read the current one with get_flame_detail.`
     }
     if (
       args.length === 4 &&

--- a/packages/app/src/webmcp/tools/arcadeTeach.test.ts
+++ b/packages/app/src/webmcp/tools/arcadeTeach.test.ts
@@ -5,7 +5,7 @@ import { LESSON_TOPICS, TOPIC_IDS } from '@/arcade/topics'
 import { cancelSessionRecording } from '@/recorder/recorder'
 import { clearWebMcpContext, setWebMcpContext } from '@/webmcp/contextBridge'
 import { wrapTool } from '@/webmcp/registerWebMcp'
-import { createMockCommandContext } from '@/webmcp/testUtils'
+import { createMockCommandContext, createTestFlame, } from '@/webmcp/testUtils'
 import { arcadeEndLesson, arcadeNarrate, arcadeStartLesson, arcadeStatus, } from './arcadeTeach'
 import { executeCommandTool } from './executeCommand'
 import { setFlame } from './setFlame'
@@ -167,5 +167,47 @@ describe('Teach tools', () => {
       isError?: boolean
     }
     expect(result.isError).toBe(true)
+  })
+})
+
+/**
+ * The brief used to carry a short sample list, which read as the whole
+ * registry: one run treated it as a starting point and probed for more names
+ * with add-then-delete pairs, spending 26 of its 45 steps before teaching
+ * anything. What replaced it has to name the convention of the registry the
+ * flame actually renders in — the two do not share one.
+ */
+describe('the variations brief points at the registry it renders in', () => {
+  afterEach(() => {
+    resetPilot()
+    cancelSessionRecording()
+    clearWebMcpContext()
+  })
+
+  const briefFor = async (dimensions: 2 | 3) => {
+    const ctx = createMockCommandContext()
+    const flame = createTestFlame()
+    flame.renderSettings.dimensions = dimensions
+    ctx.flameDescriptor = () => flame
+    setWebMcpContext(ctx)
+    return (await arcadeStartLesson.execute({ topic: 'variations' }, {})) as {
+      tips: string[]
+      stepBudget: number
+    }
+  }
+
+  it('names a 2D example and the tool that lists the rest', async () => {
+    const brief = await briefFor(2)
+    const tip = brief.tips.join(' ')
+    expect(tip).toContain('sphericalVar')
+    expect(tip).toContain('list_variations')
+    expect(tip).toContain('add-then-delete')
+  })
+
+  it('names a 3D example on a 3D flame', async () => {
+    const brief = await briefFor(3)
+    const tip = brief.tips.join(' ')
+    expect(tip).toContain('spherical3D')
+    expect(tip).not.toContain('sphericalVar')
   })
 })

--- a/packages/app/src/webmcp/tools/arcadeTeach.ts
+++ b/packages/app/src/webmcp/tools/arcadeTeach.ts
@@ -6,8 +6,11 @@ import { agentDriving, drivingState, notePilotStep, pilot, pilotElapsedMs, pilot
 import { budgetExhaustedMessage, finishPilot } from '@/arcade/pilotActions'
 import { ALWAYS_ALLOWED, BLANK_CANVAS_STEPS, isTopicId, LESSON_TOPICS, TOPIC_IDS, } from '@/arcade/topics'
 import { executeCommand, preflightReplayCommand } from '@/commands/registry'
+import { variationTypes as registeredVariationTypes } from '@/flame/variations'
+import { variationTypes3D } from '@/flame/variations3D'
 import { anySessionRecording } from '@/recorder/recorder'
 import { getWebMcpContext } from '@/webmcp/contextBridge'
+import type { CommandContext } from '@/commands/types'
 import type { WebMcpTool } from '@/webmcp/types'
 
 const NOT_READY = {
@@ -61,6 +64,26 @@ export const arcadeStatus: WebMcpTool = {
           : undefined,
     }
   },
+}
+
+/**
+ * One example of the naming, from the registry the flame actually renders in.
+ *
+ * The two registries do not share a convention — 2D names end in `Var` and 3D
+ * ones in `3D` — so a single hardcoded example is wrong half the time, which
+ * is what a sample list here was for. `list_variations` carries the rest and
+ * defaults to the same registry.
+ */
+function variationSample(ctx: CommandContext): string {
+  return renders3D(ctx) ? SAMPLE_VARIATION_TYPES_3D[1] : SAMPLE_VARIATION_TYPES[1]
+}
+
+function variationCount(ctx: CommandContext): number {
+  return renders3D(ctx) ? variationTypes3D.length : registeredVariationTypes.length
+}
+
+function renders3D(ctx: CommandContext): boolean {
+  return (ctx.flameDescriptor().renderSettings.dimensions ?? 2) === 3
 }
 
 export const arcadeStartLesson: WebMcpTool = {
@@ -140,13 +163,19 @@ export const arcadeStartLesson: WebMcpTool = {
       goal: topic.goal,
       startFrom,
       allowedCommands: describeAllowedCommands(allowed),
-      variationTypes: usesVariationTypes
-        ? (ctx.flameDescriptor().renderSettings.dimensions ?? 2) === 3
-          ? SAMPLE_VARIATION_TYPES_3D
-          : SAMPLE_VARIATION_TYPES
-        : undefined,
       stepBudget: topic.stepBudget,
       tips: [
+        // A short sample list used to sit here, and it read as the whole
+        // registry: one run took it as a starting point and probed for more
+        // names with add-then-delete pairs, spending 26 of its 45 steps before
+        // the lesson began. One example of the naming, and the tool that lists
+        // the rest, is smaller than the list AND covers both registries —
+        // list_variations defaults to the one the flame renders in.
+        ...(usesVariationTypes
+          ? [
+              `Variation names look like ${variationSample(ctx)}, and ${variationCount(ctx)} are registered: call list_variations, which is free. Never probe a name with add-then-delete.`,
+            ]
+          : []),
         'Narrate before each group; args must match the shapes exactly.',
         'Check with get_flame; finish with arcade_end_lesson.',
       ],

--- a/packages/app/src/webmcp/tools/index.ts
+++ b/packages/app/src/webmcp/tools/index.ts
@@ -19,6 +19,7 @@ import { getFlame } from './getFlame'
 import { getFlameDetail } from './getFlameDetail'
 import { getUndoState } from './getUndoState'
 import { listCommands } from './listCommands'
+import { listVariations } from './listVariations'
 import { mutateFlame } from './mutateFlame'
 import { openArena } from './openArena'
 import { openArtDirector } from './openArtDirector'
@@ -38,6 +39,7 @@ export {
   getFlameDetail,
   getUndoState,
   listCommands,
+  listVariations,
   diffFlamesTool,
   createShareLink,
   setFlame,
@@ -75,6 +77,7 @@ export const allTools: readonly WebMcpTool[] = [
   getFlame,
   getFlameDetail,
   listCommands,
+  listVariations,
   getUndoState,
   arcadeStatus,
   arcadeGetAnimatablePaths,

--- a/packages/app/src/webmcp/tools/listVariations.test.ts
+++ b/packages/app/src/webmcp/tools/listVariations.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest'
+import { variationTypes } from '@/flame/variations'
+import { clearWebMcpContext, setWebMcpContext } from '@/webmcp/contextBridge'
+import { createMockCommandContext, createTestFlame } from '@/webmcp/testUtils'
+import { listVariations } from './listVariations'
+
+type Listing = {
+  dimensions: number
+  total: number
+  offset: number
+  returned: number
+  variations: (string | { name: string; params: string[] })[]
+  truncated?: boolean
+  next?: string
+}
+
+const call = async (input: unknown) =>
+  (await listVariations.execute(input, {})) as Listing
+
+const names = (listing: Listing) =>
+  listing.variations.map((entry) =>
+    typeof entry === 'string' ? entry : entry.name,
+  )
+
+describe('list_variations', () => {
+  it('answers without a workspace, and pages the 2D registry', async () => {
+    clearWebMcpContext()
+    const first = await call({})
+    expect(first.dimensions).toBe(2)
+    expect(first.total).toBe(variationTypes.length)
+    expect(first.returned).toBe(80)
+    expect(first.truncated).toBe(true)
+    expect(first.next).toContain('offset 80')
+    const second = await call({ offset: 80 })
+    expect(names(second)[0]).toBe(variationTypes[80])
+  })
+
+  /** The names an agent has to guess today. `linear` is not one of them. */
+  it('names variations the way addTransform expects them', async () => {
+    clearWebMcpContext()
+    const starters = await call({ starters: true })
+    expect(names(starters)).toContain('sphericalVar')
+    expect(names(starters)).toContain('pdjVar')
+    expect(names(starters)).not.toContain('spherical')
+    expect(starters.truncated).toBeUndefined()
+  })
+
+  it('carries the parameter names of a parametric variation', async () => {
+    clearWebMcpContext()
+    const found = await call({ search: 'pdj', parametricOnly: true })
+    expect(found.variations).toContainEqual({
+      name: 'pdjVar',
+      params: ['a', 'b', 'c', 'd'],
+    })
+  })
+
+  it('lists the 3D registry for a 3D flame', async () => {
+    const ctx = createMockCommandContext()
+    const flame = createTestFlame()
+    flame.renderSettings.dimensions = 3
+    ctx.flameDescriptor = () => flame
+    setWebMcpContext(ctx)
+    const listing = await call({})
+    expect(listing.dimensions).toBe(3)
+    // The 3D registry does not use the `Var` suffix, which is the other half
+    // of why guessing a name was hopeless.
+    expect(names(listing).some((name) => name.endsWith('3D'))).toBe(true)
+    expect(listing.total).toBeLessThan(variationTypes.length)
+    clearWebMcpContext()
+  })
+
+  it('caps a caller that asks for everything at once', async () => {
+    clearWebMcpContext()
+    const listing = await call({ limit: 10_000 })
+    expect(listing.returned).toBe(200)
+  })
+})

--- a/packages/app/src/webmcp/tools/listVariations.ts
+++ b/packages/app/src/webmcp/tools/listVariations.ts
@@ -1,0 +1,147 @@
+import { SAMPLE_VARIATION_TYPES } from '@/arcade/commandHints'
+import { isParametricVariationType, transformVariations, variationTypes, } from '@/flame/variations'
+import { isParametricVariationType3D, transformVariations3D, variationTypes3D, } from '@/flame/variations3D'
+import { getWebMcpContext } from '@/webmcp/contextBridge'
+import type { WebMcpTool } from '@/webmcp/types'
+
+/**
+ * The registry is 446 names long and was reachable only by guessing.
+ *
+ * An agent asked to teach variations had no way to learn one name: nothing
+ * enumerated the registry, `linear` is rejected because the registered name is
+ * `linearVar`, and a failed guess is free while a successful one costs an add
+ * and a delete. One session spent 26 of its 45 steps probing 13 names before
+ * the lesson could start. This tool is the listing that makes that unnecessary,
+ * and it is free: read-only, no step, no lock.
+ */
+
+/** Names per page. The full 2D registry is ~14 KB of JSON; a page is ~2 KB. */
+const DEFAULT_LIMIT = 80
+const MAX_LIMIT = 200
+
+/**
+ * Enough of each family to start a lesson without a single probe.
+ *
+ * The eight the lesson brief already sends, plus the parametric and angular
+ * ones a teacher reaches for next — the run that prompted this tool probed
+ * exactly these six on top of the brief's list.
+ */
+const STARTERS: readonly string[] = [
+  ...SAMPLE_VARIATION_TYPES,
+  'handkerchiefVar',
+  'bubbleVar',
+  'crossVar',
+  'curlVar',
+  'pdjVar',
+  'juliaNVar',
+]
+
+function paramNames(type: string, in3D: boolean): string[] | undefined {
+  const variation = in3D
+    ? transformVariations3D[type as never]
+    : transformVariations[type]
+  const schema = (
+    variation as
+      | { DescriptorSchema?: { entries?: Record<string, unknown> } }
+      | undefined
+  )?.DescriptorSchema?.entries?.params
+  // `params` is an object schema, or that schema wrapped in `v.optional` when
+  // the variation ships defaults. Both carry the names on `entries`.
+  const entries = schema as
+    | {
+        entries?: Record<string, unknown>
+        wrapped?: { entries?: Record<string, unknown> }
+      }
+    | undefined
+  const names = Object.keys(entries?.wrapped?.entries ?? entries?.entries ?? {})
+  return names.length > 0 ? names : undefined
+}
+
+export const listVariations: WebMcpTool = {
+  name: 'list_variations',
+  description:
+    'List the variation type names this build registers, for flame.addTransform, flame.addVariation and flame.setVariation. Names end in "Var" for 2D flames ("sphericalVar", not "spherical"); the 3D registry uses its own names ("spiral3D"). Defaults to the family the current flame renders in. Pass search to filter, parametricOnly for the ones that take params (their parameter names come back with them), and starters:true for a short list to teach from. Read-only: it costs no step.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      search: {
+        type: 'string',
+        description: 'Case-insensitive substring, e.g. "julia" or "blur"',
+      },
+      dimensions: {
+        type: 'integer',
+        enum: [2, 3],
+        description: "Which registry to list (default: the current flame's)",
+      },
+      parametricOnly: {
+        type: 'boolean',
+        description:
+          'Only variations that take parameters, listed with their parameter names',
+      },
+      starters: {
+        type: 'boolean',
+        description:
+          'A short cross-section of the classic families, enough to teach from',
+      },
+      limit: {
+        type: 'integer',
+        description: `Names per page, 1-${MAX_LIMIT} (default ${DEFAULT_LIMIT})`,
+      },
+      offset: { type: 'integer', description: 'Skip this many names' },
+    },
+  },
+  annotations: { readOnlyHint: true },
+  execute: (input: unknown) => {
+    const raw = (input ?? {}) as Record<string, unknown>
+    const ctx = getWebMcpContext()
+    const flameDimensions = ctx?.flameDescriptor().renderSettings.dimensions
+    const in3D =
+      raw.dimensions === 3 || (raw.dimensions !== 2 && flameDimensions === 3)
+    const all = in3D ? variationTypes3D : variationTypes
+    const isParametric = in3D
+      ? isParametricVariationType3D
+      : isParametricVariationType
+
+    let names = [...all]
+    if (raw.starters === true) {
+      names = names.filter((name) => STARTERS.includes(name))
+    }
+    if (typeof raw.search === 'string' && raw.search.trim() !== '') {
+      const needle = raw.search.trim().toLowerCase()
+      names = names.filter((name) => name.toLowerCase().includes(needle))
+    }
+    if (raw.parametricOnly === true) {
+      names = names.filter((name) => isParametric(name as never))
+    }
+
+    const total = names.length
+    const offset =
+      typeof raw.offset === 'number' && raw.offset > 0
+        ? Math.floor(raw.offset)
+        : 0
+    const limit =
+      typeof raw.limit === 'number' && raw.limit > 0
+        ? Math.min(Math.floor(raw.limit), MAX_LIMIT)
+        : DEFAULT_LIMIT
+    const page = names.slice(offset, offset + limit)
+
+    return {
+      dimensions: in3D ? 3 : 2,
+      total,
+      offset,
+      returned: page.length,
+      // Parameter names come with the parametric ones: the alternative is an
+      // agent writing `__nope__` into a descriptor because nothing said what
+      // pdj takes. Plain names stay plain strings, which is most of them.
+      variations: page.map((name) => {
+        const params = isParametric(name) ? paramNames(name, in3D) : undefined
+        return params === undefined ? name : { name, params }
+      }),
+      truncated: offset + page.length < total ? true : undefined,
+      next:
+        offset + page.length < total
+          ? `Call again with offset ${offset + page.length}, or narrow it with search.`
+          : undefined,
+    }
+  },
+}

--- a/tests/arcade.spec.ts
+++ b/tests/arcade.spec.ts
@@ -208,6 +208,79 @@ test.describe('Lumen Arcade', () => {
     await expect(zoom).toHaveText(fitted ?? '')
   })
 
+  /**
+   * The registry, without probing it.
+   *
+   * A lesson spent 26 of its 45 steps adding and deleting transforms to find
+   * out which names exist, because nothing listed them and `linear` is
+   * rejected in favour of `linearVar`. This asserts the listing is there, is
+   * free, and answers with names the same session can hand to addTransform.
+   */
+  test('list_variations answers without costing the lesson a step', async ({
+    page,
+  }) => {
+    await openEditor(page)
+    const brief = await callTool(page, 'arcade_start_lesson', {
+      topic: 'variations',
+    })
+    expect(brief).toMatchObject({ ok: true, stepBudget: 45 })
+    expect(JSON.stringify(brief.tips)).toContain('list_variations')
+
+    const listing = (await callTool(page, 'list_variations', {
+      starters: true,
+    })) as { variations: (string | { name: string })[]; total: number }
+    const names = listing.variations.map((entry) =>
+      typeof entry === 'string' ? entry : entry.name,
+    )
+    expect(names).toContain('sphericalVar')
+    // `total` counts what the filter matched, so the whole registry needs its
+    // own call — which is the paging contract the tool advertises.
+    expect(listing.total).toBe(names.length)
+    const whole = (await callTool(page, 'list_variations', {})) as {
+      total: number
+      truncated?: boolean
+    }
+    expect(whole.total).toBeGreaterThan(300)
+    expect(whole.truncated).toBe(true)
+
+    // A name straight from the listing, and the step count is untouched by
+    // the listing call itself: this is the first step of the lesson.
+    expect(
+      await callTool(page, 'execute_command', {
+        commandId: 'flame.addTransform',
+        args: ['sphericalVar', 'tListed', 'vListed'],
+      }),
+    ).toMatchObject({ success: true, steps: 1 })
+
+    // The junk key that outlived a session: pdj has a, b, c and d, and
+    // nothing else reaches the descriptor.
+    await callTool(page, 'execute_command', {
+      commandId: 'flame.addTransform',
+      args: ['pdjVar', 'tPdj', 'vPdj'],
+    })
+    await callTool(page, 'execute_command', {
+      commandId: 'flame.setVariationParams',
+      args: ['tPdj', 'vPdj', '__nope__', 1],
+    })
+    const flame = (await callTool(page, 'get_flame_detail', {
+      section: 'transform',
+      transformId: 'tPdj',
+    })) as {
+      transform?: { variations?: Record<string, { params?: object }> }
+    }
+    const params = flame.transform?.variations?.vPdj?.params ?? {}
+    expect(Object.keys(params).sort()).toEqual(['a', 'b', 'c', 'd'])
+
+    // And a half-written descriptor is refused rather than reported as done.
+    const refused = await callTool(page, 'execute_command', {
+      commandId: 'flame.setVariation',
+      args: ['tListed', 'vListed', { type: 'swirlVar' }],
+    })
+    expect(String(refused.error)).toContain('incomplete')
+
+    await callTool(page, 'arcade_end_lesson', { title: 'Listing check' })
+  })
+
   test('Cinema: paths, keyframes, end', async ({ page }) => {
     await openEditor(page)
     expect(await callTool(page, 'arcade_start_cinema', {})).toMatchObject({


### PR DESCRIPTION
Stacked on #170 (same worktree, same area — merge that first). Three findings from a Teach run on variations, each verified against the recorded session before fixing.

## The registry was reachable only by guessing

Nothing listed the 446 registered variations. The lesson brief carried eight sample names, which read as the whole set, and `linear` is rejected because the registered name is `linearVar` (the 3D registry does not use the suffix at all: `spiral3D`). A failed guess is free, but a successful one costs an add and a delete — so the run spent **26 of its 45 steps** probing 13 names before the lesson could start. The recorded steps show it plainly: 14 `addTransform`/`deleteTransform` pairs named `probe_<name>`, all in one burst.

`list_variations` is the listing. Read-only, so it costs no step and no lock:

- paged (80 per call, 200 max) with `offset`/`next`
- `search` substring, `parametricOnly`, and `starters` for a short cross-section of the classic families
- parametric variations come back with their parameter names, so `pdjVar` arrives as `{ name, params: ['a','b','c','d'] }`
- defaults to the registry the current flame renders in (2D or 3D)

The Teach brief drops its sample list and points at the tool instead, naming the `Var` convention and the registry size.

## `flame.setVariation` reported success for a write that never happened

`['t1','v1',{type:'sphericalVar'}]` passed `validateReplayArgs` (the type is registered), then failed whole-flame validation inside `execute`, which warns to the console and returns. `execute_command` answered `success: true`, the step was spent, and the variation was unchanged. The run worked around it with an `addVariation` + `deleteVariation` pair it could not afford.

An incomplete descriptor is now refused at preflight, saying what is missing and where to read the current one.

## `flame.setVariationParams` wrote whatever name it was handed

Probing the argument shape with `['t3','v3','__nope__',1]` succeeded and left `__nope__: 1` inside a pdj variation — inert to the render, but carried by the descriptor and every export of it afterwards. Only a parameter the variation actually has is written now. Deliberately tolerant rather than throwing: an already-saved recording carrying a junk name replays as a no-op instead of failing.

## Test plan

- [x] `vitest` **2306 passing** (full suite), including 5 new tests for the listing tool and 2 for the command fixes
- [x] `tests/arcade.spec.ts` in a real browser: **7/7**, with a new test that walks the whole path — brief points at the tool, listing answers, a listed name reaches `addTransform` as step 1, `__nope__` never lands in the descriptor, and the half-written descriptor comes back refused
- [x] `docs/webmcp.md` count and table updated (its ratchet test enforces both)
- [x] `tsc --noEmit`, `eslint` clean