### PR TITLE
fix(duel): give the variation tile's weight readout its row back

### DIFF
--- a/packages/app/src/components/Duel/DuelChips.module.css
+++ b/packages/app/src/components/Duel/DuelChips.module.css
@@ -414,6 +414,14 @@
 }
 
 .fieldInput,
+/* The slider takes the tile's whole 64px width, so its readout goes under it,
+   centred like the name above — beside it there is no room for either. */
+.tileWeightRow {
+  display: grid;
+  gap: 2px;
+  justify-items: center;
+}
+
 .tileWeight {
   width: 100%;
   accent-color: var(--duel-warm-core, #fde7ac);

--- a/packages/app/src/components/Duel/duelChipsCss.test.ts
+++ b/packages/app/src/components/Duel/duelChipsCss.test.ts
@@ -20,6 +20,20 @@ describe('DuelChips stylesheet', () => {
     expect(more).toBeGreaterThan(css.lastIndexOf('.swatch {'))
   })
 
+  it('defines every class the panel asks for', () => {
+    // A CSS-module import under vitest answers every key, and a missing rule
+    // renders as class={undefined} rather than as an error — which is how the
+    // weight row under a variation tile shipped with no layout at all.
+    const tsx = readFileSync(join(import.meta.dirname, 'DuelChips.tsx'), 'utf8')
+    const used = new Set(
+      [...tsx.matchAll(/\bui\.([A-Za-z0-9_]+)/g)].map((m) => m[1]!),
+    )
+    const defined = new Set(
+      [...css.matchAll(/\.([A-Za-z][A-Za-z0-9_-]*)/g)].map((m) => m[1]!),
+    )
+    expect([...used].filter((name) => !defined.has(name))).toEqual([])
+  })
+
   it('keeps the Shape grid to one explicit row, so 2D pays no hint gap', () => {
     const start = css.indexOf('.shape {')
     const shape = css.slice(start, css.indexOf('}', start))


### PR DESCRIPTION
A patch on top of the tagged release. One real visual defect, found while reviewing what [#168](https://github.com/chaos-matters/chaos-master/pull/168) and [#169](https://github.com/chaos-matters/chaos-master/pull/169) shipped, plus a guard so it cannot recur.

## The defect

The label wrapping a variation tile's weight slider asks for a class the stylesheet never defined. It rendered as `class={undefined}` — no layout at all — so on a 64px tile the readout sat hard against the left edge under a full-width slider. It is pre-existing, not from either of those PRs.

The slider spans the whole tile, so the readout belongs under it, centred like the name above; a row cannot fit both.

## Why no test caught it

A CSS-module import under vitest is a proxy that answers every key, so a missing rule is `undefined`, not an error. The stylesheet test now asserts that every class the panel asks for is defined. It currently holds for all of them, and nothing in the stylesheet is unused.

## What was verified in the browser

Measured against the dev build on the tagged main — computed styles and box geometry, not screenshots. Eleven checks, all passing:

- the More swatch is a dashed grid box, the same 148x53 as a palette swatch, its count centred both ways
- the 2D Shape panel keeps one grid row, renders no hint, and puts its fields to the right of the grid
- the Start-from select has a dark scheme and a foreground distinct from its background, with dark options
- the duel setup renders as three pills
- the weight readout is a centred grid under its slider
- `camera.zoomBy` still zooms a 2D flame, the duel has a Centre button, and pressing it returns the zoom control to 100%

`pnpm typecheck`, `pnpm lint` (0 errors), `pnpm test` pass.

## Known, not fixed here

On a **2D** flame `camera.center` pushes two history entries, because `setPosition` and `setZoom` dispatch separately — so Ctrl+0 then Ctrl+Z restores the zoom but leaves the position at the origin. Pre-existing, and fixing it changes the 2D command path, which is more than a patch should carry.